### PR TITLE
[Feat] #9 - Map Domain Layer 설계 (Entities 및 Repository Interface 정의)

### DIFF
--- a/Neki-iOS.xcodeproj/project.pbxproj
+++ b/Neki-iOS.xcodeproj/project.pbxproj
@@ -42,7 +42,6 @@
 				Features/Archive/Sources/Presentation/Sources/Feature/.gitkeep,
 				Features/Archive/Sources/Presentation/Sources/View/.gitkeep,
 				Features/Map/Sources/Data/Sources/.gitkeep,
-				Features/Map/Sources/Domain/Sources/.gitkeep,
 				Features/Map/Sources/Presentation/Sources/Feature/.gitkeep,
 				Features/Map/Sources/Presentation/Sources/View/.gitkeep,
 				Info.plist,

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/GeographicBoundingBox.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/GeographicBoundingBox.swift
@@ -1,0 +1,22 @@
+//
+//  GeographicBoundingBox.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 12/29/25.
+//
+
+import Foundation
+
+struct GeographicBoundingBox: Equatable {
+    let minLatitude: Double
+    let minLongitude: Double
+    let maxLatitude: Double
+    let maxLongitude: Double
+    
+    init(minLatitude: Double, minLongitude: Double, maxLatitude: Double, maxLongitude: Double) {
+        self.minLatitude = minLatitude
+        self.minLongitude = minLongitude
+        self.maxLatitude = maxLatitude
+        self.maxLongitude = maxLongitude
+    }
+}

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/GeographicBoundingBox.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/GeographicBoundingBox.swift
@@ -7,13 +7,20 @@
 
 import Foundation
 
-struct GeographicBoundingBox: Equatable {
+public struct GeographicBoundingBox: Equatable {
     let minLatitude: Double
     let minLongitude: Double
     let maxLatitude: Double
     let maxLongitude: Double
     
     init(minLatitude: Double, minLongitude: Double, maxLatitude: Double, maxLongitude: Double) {
+        precondition(GeographicLimit.isValidLatitude(minLatitude), "최소 위도\(minLatitude)는 유효하지 않습니다.")
+        precondition(GeographicLimit.isValidLatitude(maxLatitude), "최대 위도\(maxLatitude)는 유효하지 않습니다.")
+        precondition(GeographicLimit.isValidLongitude(minLongitude), "최소 경도\(minLongitude)는 유효하지 않습니다.")
+        precondition(GeographicLimit.isValidLongitude(maxLongitude), "최대 경도\(maxLongitude)는 유효하지 않습니다.")
+        precondition(minLatitude <= maxLatitude, "최소 위도는 최대 위도보다 작거나 같아야 합니다.")
+        precondition(minLongitude <= maxLongitude, "최소 경도는 최대 경도보다 작거나 같아야 합니다.")
+        
         self.minLatitude = minLatitude
         self.minLongitude = minLongitude
         self.maxLatitude = maxLatitude

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/GeographicCoordinate.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/GeographicCoordinate.swift
@@ -1,0 +1,20 @@
+//
+//  GeographicCoordinate.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 12/29/25.
+//
+
+import Foundation
+
+public struct GeographicCoordinate: Hashable {
+    /// 위도 (가로선)
+    public let latitude: Double
+    /// 경도 (세로선)
+    public let longitude: Double
+    
+    public init(latitude: Double, longitude: Double) {
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+}

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/GeographicCoordinate.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/GeographicCoordinate.swift
@@ -14,6 +14,9 @@ public struct GeographicCoordinate: Hashable {
     public let longitude: Double
     
     public init(latitude: Double, longitude: Double) {
+        precondition(GeographicLimit.isValidLatitude(latitude), "위도 값 \(latitude)이 유효한 범위를 벗어났습니다. 유효 범위: \(GeographicLimit.latitudeRange)")
+        precondition(GeographicLimit.isValidLongitude(longitude), "경도 값 \(longitude)이 유효한 범위를 벗어났습니다. 유효 범위 :\(GeographicLimit.longitudeRange)")
+        
         self.latitude = latitude
         self.longitude = longitude
     }

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/GeographicLimit.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/GeographicLimit.swift
@@ -1,0 +1,17 @@
+//
+//  GeographicLimit.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 12/30/25.
+//
+
+import Foundation
+
+/// 지리 좌표 시스템의 유효 범위를 정의합니다.
+enum GeographicLimit {
+    static let latitudeRange: ClosedRange<Double> = -90.0...90.0
+    static let longitudeRange: ClosedRange<Double> = -180.0...180.0
+    
+    static func isValidLatitude(_ latitude: Double) -> Bool { latitudeRange.contains(latitude) }
+    static func isValidLongitude(_ longitude: Double) -> Bool { longitudeRange.contains(longitude) }
+}

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/PhotoBooth.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/PhotoBooth.swift
@@ -1,0 +1,34 @@
+//
+//  PhotoBooth.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 12/29/25.
+//
+
+import Foundation
+
+/// 포토부스 지점 정보
+public struct PhotoBooth: Identifiable {
+    public let id: UUID
+    public let brand: PhotoBoothBrand
+    public let name: String
+    public let coordinate: GeographicCoordinate
+    public let address: String
+    public let detailInformationURL: URL?
+    
+    public init(
+        id: UUID,
+        brand: PhotoBoothBrand,
+        name: String,
+        coordinate: GeographicCoordinate,
+        address: String,
+        detailInformationURL: URL? = nil
+    ) {
+        self.id = id
+        self.brand = brand
+        self.name = name
+        self.coordinate = coordinate
+        self.address = address
+        self.detailInformationURL = detailInformationURL
+    }
+}

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/PhotoBoothBrand.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/PhotoBoothBrand.swift
@@ -1,0 +1,33 @@
+//
+//  PhotoBoothBrand.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 12/29/25.
+//
+
+import Foundation
+
+/// 포토부스 브랜드의 종류입니다.
+public enum PhotoBoothBrand: CaseIterable {
+    case life4cut
+    case photoism
+    case photogray
+    case photosignature
+    case planBStudio
+    case monomansion
+    case theFilm
+    case insphoto
+    
+    public var displayName: String {
+        switch self {
+        case .life4cut: "인생네컷"
+        case .photoism: "포토이즘"
+        case .photogray: "포토 그레이"
+        case .photosignature: "포토 시그니처"
+        case .planBStudio: "플랜 비 스튜디오"
+        case .monomansion: "모노맨션"
+        case .theFilm: "더필름"
+        case .insphoto: "인스포토"
+        }
+    }
+}

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Interfaces/PhotoBoothRepository.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Interfaces/PhotoBoothRepository.swift
@@ -1,0 +1,15 @@
+//
+//  PhotoBoothRepository.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 12/29/25.
+//
+
+import Foundation
+
+protocol PhotoBoothRepository {
+    /// 특정 지도 영역 내의 포토부스 목록을 가져옵니다.
+    /// - Parameter bounds: 조회 시점의 지리적 영역
+    /// - Returns: 해당 영역 내의 포토부스 배열
+    func readPhotoBooths(in bounds: GeographicBoundingBox) async throws -> [PhotoBooth]
+}


### PR DESCRIPTION
## 🌴 작업한 브랜치
- `feat/#9-map-domain`


## ✅ 작업한 내용

### 요약
지도 SDK(Kakao/Naver) 종류와 관계없이 비즈니스 로직을 수행할 수 있도록 **Map Feature의 Domain Layer**를 우선 구현했습니다.
외부 프레임워크에 의존하지 않는 상위 Layer이기에 순수한 Swift만을 사용하려는 의도를 담았습니다.

### 주요 변경 사항
* **경로**: `/Features/Map/Sources/Domain` 경로에서 작업하였습니다.
* **Entities**:
    * `GeographicCoordinate`: 좌표를 표현한 타입입니다.
    * `GeographicBoundingBox`: 지도 내 영역(Viewport)을 표현하고 DB 쿼리에도 쓸 수 있도록 만든 타입입니다.
    * `PhotoBooth` 포토부스 지점의 정보를 담는 타입입니다.
    * `PhotoBoothBrand`: 브랜드 구분 및 필터링 등에 쓰일 타입입니다.
* **Interfaces**
    * `PhotoBoothRepository`: 포토부스 목록으로의 접근을 제공하는 인터페이스입니다. 추후 Data Layer에서 이를 채택해 구현합니다.


## ❗️PR Point
1. 선언된 타입들이 전반적으로 네이밍 컨벤션 및 팀 린트 규칙에 부합하는지 확인 부탁드려요.
2. 지도 도메인에서의 더 풍성한 데이터 표현을 위하여 더 많은 자료구조 또는 타입들이 필요할 수 있어요! 그러나 기능 명세와 디자인 시안이 아직 다듬어지고 있는 중이므로, 우선은 여기까지만 작성해보았습니다. 이 부분에 있어서 논의해도 좋아요!


## 📟 관련 이슈
- Resolved: #9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 지도에서 사진관을 표시하기 위한 데이터 모델 추가
  * 좌표와 경계 정보를 검증하는 지리적 유효성 검사 추가
  * 사진관 브랜드별 표시명(로컬라이즈드 이름) 지원 추가
  * 특정 지리적 범위 내에서 사진관을 조회하는 인터페이스 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->