### PR TITLE
[Feat] #12 - Map Business Logic 구현 (PhotoBoothClient 및 Mock Data)

### DIFF
--- a/Neki-iOS.xcodeproj/project.pbxproj
+++ b/Neki-iOS.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		592F2C5E2F0508FE00802BB7 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 592F2C5D2F0508FE00802BB7 /* ComposableArchitecture */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		6C4998EB2EF7EF64006BE1DB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -66,6 +70,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				592F2C5E2F0508FE00802BB7 /* ComposableArchitecture in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -124,6 +129,7 @@
 			);
 			name = "Neki-iOS";
 			packageProductDependencies = (
+				592F2C5D2F0508FE00802BB7 /* ComposableArchitecture */,
 			);
 			productName = "Neki-iOS";
 			productReference = 6C4998DD2EF7EF62006BE1DB /* Neki-iOS.app */;
@@ -184,6 +190,7 @@
 					};
 					6C4998E92EF7EF64006BE1DB = {
 						CreatedOnToolsVersion = 26.2;
+						LastSwiftMigration = 2600;
 						TestTargetID = 6C4998DC2EF7EF62006BE1DB;
 					};
 					6C4998F32EF7EF64006BE1DB = {
@@ -201,6 +208,9 @@
 			);
 			mainGroup = 6C4998D42EF7EF62006BE1DB;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				592F2C5C2F0508FE00802BB7 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 6C4998DE2EF7EF62006BE1DB /* Products */;
 			projectDirPath = "";
@@ -476,6 +486,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 586LZSS32L;
@@ -487,6 +498,7 @@
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -498,6 +510,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 586LZSS32L;
@@ -598,6 +611,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		592F2C5C2F0508FE00802BB7 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pointfreeco/swift-composable-architecture";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.23.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		592F2C5D2F0508FE00802BB7 /* ComposableArchitecture */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 592F2C5C2F0508FE00802BB7 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */;
+			productName = ComposableArchitecture;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 6C4998D52EF7EF62006BE1DB /* Project object */;
 }

--- a/Neki-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Neki-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,132 @@
+{
+  "originHash" : "e7024a9cd3fa1c40fa4003b3b2b186c00ba720c787de8ba274caf8fc530677e8",
+  "pins" : [
+    {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "fd16d76fd8b9a976d88bfb6cacc05ca8d19c91b6",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "6989976265be3f8d2b5802c722f9ba168e227c71",
+        "version" : "1.7.2"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-composable-architecture",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-composable-architecture",
+      "state" : {
+        "revision" : "5b0890fabfd68a2d375d68502bc3f54a8548c494",
+        "version" : "1.23.1"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "swift-dependencies",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-dependencies",
+      "state" : {
+        "revision" : "a10f9feeb214bc72b5337b6ef6d5a029360db4cc",
+        "version" : "1.10.0"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "state" : {
+        "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-navigation",
+      "state" : {
+        "revision" : "bf498690e1f6b4af790260f542e8428a4ba10d78",
+        "version" : "2.6.0"
+      }
+    },
+    {
+      "identity" : "swift-perception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-perception",
+      "state" : {
+        "revision" : "4f47ebafed5f0b0172cf5c661454fa8e28fb2ac4",
+        "version" : "2.0.9"
+      }
+    },
+    {
+      "identity" : "swift-sharing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-sharing",
+      "state" : {
+        "revision" : "3bfc408cc2d0bee2287c174da6b1c76768377818",
+        "version" : "2.7.4"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "31073495cae9caf243c440eac94b3ab067e3d7bc",
+        "version" : "1.8.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Clients/PhotoBoothClient.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Clients/PhotoBoothClient.swift
@@ -1,0 +1,85 @@
+//
+//  PhotoBoothClient.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 12/31/25.
+//
+
+import Foundation
+import ComposableArchitecture
+
+@DependencyClient
+public struct PhotoBoothClient {
+    /// 지도 영역(bounds) 내의 포토부스 데이터를 가져옵니다.
+    public var fetchPhotoBooths: @Sendable (_ bounds: GeographicBoundingBox) async throws -> [PhotoBooth]
+}
+
+
+// MARK: - PhotoBoothClient + Logic Implementation
+
+extension PhotoBoothClient {
+    static func liveImplementation(bounds: GeographicBoundingBox) async throws -> [PhotoBooth] {
+        // TODO: 추후 Repository 및 서버 연결하여 실질 코드로 변경해야 합니다.
+        // 1. 네트워크 지연 시나리오를 모방함 (0.5 ~ 1.5초)
+        try await Task.sleep(nanoseconds: UInt64(Double.random(in: 0.5...1.5) * 1_000_000_000))
+        
+        // 2. 랜덤 데이터 생성 설정
+        let count = Int.random(in: 20...50) // 20~50개 가짜 POI 생성
+        var mockData: [PhotoBooth] = []
+        
+        // 3. 요청된 범위(Bounds) 내에서 랜덤 좌표 생성
+        for i in 0..<count {
+            let randomLatitude = Double.random(in: bounds.minLatitude...bounds.maxLatitude)
+            let randomLongitude = Double.random(in: bounds.minLongitude...bounds.maxLongitude)
+            
+            // 랜덤 브랜드 선택
+            let randomBrand = PhotoBoothBrand.allCases.randomElement() ?? .unknown
+            
+            let booth = PhotoBooth(
+                id: UUID(),
+                brand: randomBrand,
+                name: "\(randomBrand.displayName) 강남 \(i)호점",
+                coordinate: GeographicCoordinate(latitude: randomLatitude, longitude: randomLongitude),
+                address: "서울특별시 강남구 테헤란로 \(Int.random(in: 100...999))",
+                detailInformationURL: URL(string: "https://map.kakao.com")
+            )
+            
+            mockData.append(booth)
+        }
+        
+        return mockData
+    }
+    
+    static func previewImplementation(bounds: GeographicBoundingBox) async throws -> [PhotoBooth] {
+        [
+            PhotoBooth(
+                id: UUID(),
+                brand: .photogray,
+                name: "강남 1호점",
+                coordinate: .init(latitude: 37.498095, longitude: 127.027610),
+                address: "서울특별시 강남구 역삼동 821-1"
+            )
+        ]
+    }
+}
+
+
+// MARK: - PhotoBoothClient + DependencyKey
+
+extension PhotoBoothClient: DependencyKey {
+    public static let liveValue = Self(fetchPhotoBooths: liveImplementation)
+    
+    public static let testValue = Self()
+    
+    public static let previewValue = Self(fetchPhotoBooths: previewImplementation)
+}
+
+
+// MARK: - PhotoBoothClient + Dependency Accessor
+
+public extension DependencyValues {
+    var photoBoothClient: PhotoBoothClient {
+        get { self[PhotoBoothClient.self] }
+        set { self[PhotoBoothClient.self] = newValue }
+    }
+}

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/GeographicBoundingBox.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/GeographicBoundingBox.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct GeographicBoundingBox: Equatable {
+public struct GeographicBoundingBox: Equatable, Sendable {
     let minLatitude: Double
     let minLongitude: Double
     let maxLatitude: Double

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/GeographicCoordinate.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/GeographicCoordinate.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct GeographicCoordinate: Hashable {
+public struct GeographicCoordinate: Hashable, Sendable {
     /// 위도 (가로선)
     public let latitude: Double
     /// 경도 (세로선)

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/PhotoBooth.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/PhotoBooth.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// 포토부스 지점 정보
-public struct PhotoBooth: Identifiable {
+public struct PhotoBooth: Identifiable, Sendable {
     public let id: UUID
     public let brand: PhotoBoothBrand
     public let name: String

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/PhotoBoothBrand.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/PhotoBoothBrand.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// 포토부스 브랜드의 종류입니다.
-public enum PhotoBoothBrand: CaseIterable {
+public enum PhotoBoothBrand: CaseIterable, Sendable {
     case life4cut
     case photoism
     case photogray
@@ -17,6 +17,7 @@ public enum PhotoBoothBrand: CaseIterable {
     case monomansion
     case theFilm
     case insphoto
+    case unknown
     
     public var displayName: String {
         switch self {
@@ -28,6 +29,7 @@ public enum PhotoBoothBrand: CaseIterable {
         case .monomansion: "모노맨션"
         case .theFilm: "더필름"
         case .insphoto: "인스포토"
+        case .unknown: "비지원 브랜드"
         }
     }
 }


### PR DESCRIPTION
## 🌴 작업한 브랜치
- `feat/#12-map-business`


## ✅ 작업한 내용

### 요약
Map Feature의 비즈니스 로직을 담당하는 `PhotoBoothClient`를 구현했습니다.
TCA의 `DependencyClient` 패턴을 적용하였으며, 아직 백엔드 API가 없는 상태이므로 임시 Mock Data 생성 로직을 포함합니다.

**주요 변경점**
* **PhotoBoothClient:** TCA 의존성 주입을 위한 Client 인터페이스 정의 및 구현.
    * `fetchPhotoBooths`: 특정 영역(BoundingBox) 내의 데이터를 비동기로 가져오는 인터페이스.
* **Mock Implementation:**
    * `liveImplementation`: 서울 강남역 인근 좌표를 기준으로 랜덤한 포토부스 데이터를 생성하는 로직 구현.
* **Concurrency Safety:**
    * `PhotoBooth`, `GeographicBoundingBox` 등 주요 엔티티에 `Sendable` 프로토콜 채택.
    * `@Sendable` 클로저 사용을 위한 타입 안전성 확보.

---
## ❗️PR Point

### 1. Client 성격의 타입 선언 방식
코드를 정리하는데 있어서 다음의 순서를 적용했습니다.
1. Client 타입 선언 본문 (e.g: `PhotoBoothClient`)
2. 로직 구현부 (e.g: 구현 메서드들 -> `liveImplementation`, `previewImplementation`)
3. DependencyKey 등록 (`extension PhotoBoothClient: DependencyKey`
4. 의존성 접근자 등록 (`DependencyValues`)

이게 하나의 컨벤션이 될 수도 있을 것 같아서....
보다 코드를 쉽고 빠르게 읽기 좋게 하기 위해 다른 아이디어가 있다면 공유해주세요, 적극 반영하겠습니다!

---

### 2. TCA-Client 개념 이해
MVVM 아키텍처에서는 ViewModel이 UseCase에 의존하고, UseCase는 비즈니스 로직을 구현하는 방식으로 설계됩니다.
대부분의 경우, UseCase의 프로토콜을 만들어서, 이를 채택한 실제 구현체나 가짜 구현체의 타입을 찍어내듯이 만듭니다.
또한 `execute(_:)` 같은 메서드를 요구하도록 한 뒤, 하나의 메서드를 위해 하나의 타입을 만들도록 강제하는 경우도 있습니다.

이를 TCA 아키텍처에서는 Client라는 개념으로 대체합니다.
제가 이해한 주요 차이점은 다음과 같습니다.
1. Client에는 핵심 로직을 구현하되, 타입의 인스턴스 생성이 불필요하다. (`static`으로 선언되고 정적 디스패칭 됩니다.)
2. Client에는 비즈니스 로직이 복수 개가 존재할 수 있다.
    * 기존 UseCase는 타입 하나 당 `execute`메서드 하나로 1:1 대응되어 보일러 플레이트 느낌의 타입이 많아집니다.
    * 대신, Client는 대표되는 관심사(예: 포토부스 관련)를 내세우고, 그것과 관련된 비즈니스 로직들을 여러 개 관리하는 1:N 관계로 구성합니다.
3. `@Dependency` 매크로를 통해 각 요소간의 의존성 접근이 가능하도록 합니다.
    * Reducer는 Client을 의존합니다.
    * Client는 Repository를 의존합니다.
    * 이 경우에 `DependencyKey`, `DependencyValues` 등을 사용해서 의존성 등록을 하는데, 이게 '어느 영역까지 등록을 해야하는가?'에 대한 고민이 듭니다.
    > 정리하면, DependencyValues로의 접근으로 의존성을 주입하는 것과 생성자를 통해 주입하는 방법이 있는데, 어느 영역, 어느 수준까지 혼용을 할 수 있는건지? 아니면 한가지 방식을 선택하고 그걸로만 해야하는건지? 와 같은 호기심이 들고, 더 나아가서 TCA 철학에서 무엇이 권장되는지? 입니다.
4. Client는 메서드가 아니라 클로저 프로퍼티로 구성된다.
    * 'Pointree는 개발자에게 있어서 live, test, preview 등, 로직의 목적에 따라 타입을 다시 만들고 메서드를 정의하는게 아니라 클로저에 바로 개념적인 로직을 넣는 문화를 전파 하려고? 이렇게 만들었다'라는 추측...인데, 어떤 근본적인 이유가 숨어있는 것 같은 느낌이 듭니다. (`static`으로 선언된 이유와도 연관있을 것 같고..)

위에 작성한 대로, TCA-Client 개념에 대해서 올바르게 이해한 것인지 검토 부탁드리며, 의논해보면 좋을 것 같습니다!


## 📟 관련 이슈
- Resolved: #12
