### PR TITLE
[Feat] 디자인 시스템: Neki 컬러 팔레트 구조화

### DIFF
--- a/Neki-iOS/Shared/DesignSystem/Sources/Color/NekiColor.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Color/NekiColor.swift
@@ -7,13 +7,13 @@
 
 import SwiftUI
 
-public typealias Hex = UInt
+public typealias ColorHexCode = UInt
 
 
 // MARK: - Color + Hex
 
 extension Color {
-    init(hex: Hex, opacity: Double = 1.0) {
+    init(hex: ColorHexCode, opacity: Double = 1.0) {
         self.init(
             .sRGB,
             red: Double((hex >> 16) & 0xff) / 255,
@@ -28,7 +28,7 @@ extension Color {
 // MARK: - UIColor + Hex
 
 extension UIColor {
-    convenience init(hex: Hex, alpha: CGFloat = 1.0) {
+    convenience init(hex: ColorHexCode, alpha: CGFloat = 1.0) {
         self.init(
             red: CGFloat((hex >> 16) & 0xff) / 255,
             green: CGFloat((hex >> 08) & 0xff) / 255,
@@ -39,7 +39,7 @@ extension UIColor {
 }
 
 /// Neki 컬러 팔레트
-public enum NekiColor: Hex {
+public enum NekiColor: ColorHexCode {
     // MARK: Grayscale
     /// Gray 25
     /// - Hex: 0xF9FAFA
@@ -171,5 +171,5 @@ public extension ShapeStyle where Self == Color {
     // MARK: - Utils
     /// 동적으로 색상을 선택해야 하거나 Hex 코드를 써야 할 때만 함수 사용
     static func neki(_ type: NekiColor) -> Color { type.color }
-    static func hex(_ code: Hex) -> Color { Color(hex: code) }
+    static func hex(_ code: ColorHexCode) -> Color { Color(hex: code) }
 }

--- a/Neki-iOS/Shared/DesignSystem/Sources/Color/NekiColor.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Color/NekiColor.swift
@@ -138,3 +138,38 @@ public enum NekiColor: Hex {
 }
 
 
+// MARK: - Color + NekiColor
+
+public extension ShapeStyle where Self == Color {
+    // MARK: - Grayscale
+    static var nekiGray25: Color { NekiColor.gray25.color }
+    static var nekiGray50: Color { NekiColor.gray50.color }
+    static var nekiGray75: Color { NekiColor.gray75.color }
+    static var nekiGray100: Color { NekiColor.gray100.color }
+    static var nekiGray200: Color { NekiColor.gray200.color }
+    static var nekiGray300: Color { NekiColor.gray300.color }
+    static var nekiGray400: Color { NekiColor.gray400.color }
+    static var nekiGray500: Color { NekiColor.gray500.color }
+    static var nekiGray600: Color { NekiColor.gray600.color }
+    static var nekiGray700: Color { NekiColor.gray700.color }
+    static var nekiGray800: Color { NekiColor.gray800.color }
+    static var nekiGray900: Color { NekiColor.gray900.color }
+    
+    // MARK: - Primary
+    static var nekiPrimary25: Color { NekiColor.primary25.color }
+    static var nekiPrimary50: Color { NekiColor.primary50.color }
+    static var nekiPrimary100: Color { NekiColor.primary100.color }
+    static var nekiPrimary200: Color { NekiColor.primary200.color }
+    static var nekiPrimary300: Color { NekiColor.primary300.color }
+    static var nekiPrimary400: Color { NekiColor.primary400.color }
+    static var nekiPrimary500: Color { NekiColor.primary500.color }
+    static var nekiPrimary600: Color { NekiColor.primary600.color }
+    static var nekiPrimary700: Color { NekiColor.primary700.color }
+    static var nekiPrimary800: Color { NekiColor.primary800.color }
+    static var nekiPrimary900: Color { NekiColor.primary900.color }
+    
+    // MARK: - Utils
+    /// 동적으로 색상을 선택해야 하거나 Hex 코드를 써야 할 때만 함수 사용
+    static func neki(_ type: NekiColor) -> Color { type.color }
+    static func hex(_ code: Hex) -> Color { Color(hex: code) }
+}

--- a/Neki-iOS/Shared/DesignSystem/Sources/Color/NekiColor.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Color/NekiColor.swift
@@ -134,7 +134,7 @@ public enum NekiColor: ColorHexCode {
     /// - Hex: 0x7A0A00
     case primary900 = 0x7A0A00
     
-    var color: Color { Color(hex: rawValue) }
+    public var color: Color { Color(hex: rawValue) }
 }
 
 

--- a/Neki-iOS/Shared/DesignSystem/Sources/Color/NekiColor.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Color/NekiColor.swift
@@ -38,3 +38,103 @@ extension UIColor {
     }
 }
 
+/// Neki 컬러 팔레트
+public enum NekiColor: Hex {
+    // MARK: Grayscale
+    /// Gray 25
+    /// - Hex: 0xF9FAFA
+    case gray25 = 0xF9FAFA
+    
+    /// Gray 50
+    /// - Hex: 0xEEF1F1
+    case gray50 = 0xEEF1F1
+    
+    /// Gray 75
+    /// - Hex: 0xE3E4E8
+    case gray75 = 0xE3E4E8
+    
+    /// Gray 100
+    /// - Hex: 0xCDCED5
+    case gray100 = 0xCDCED5
+    
+    /// Gray 200
+    /// - Hex: 0xB7B9C3
+    case gray200 = 0xB7B9C3
+    
+    /// Gray 300
+    /// - Hex: 0xA0A3B0
+    case gray300 = 0xA0A3B0
+    
+    /// Gray 400
+    /// - Hex: 0x8A8E9E
+    case gray400 = 0x8A8E9E
+    
+    /// Gray 500
+    /// - Hex: 0x74788B
+    case gray500 = 0x74788B
+    
+    /// Gray 600
+    /// - Hex: 0x616575
+    case gray600 = 0x616575
+    
+    /// Gray 700
+    /// - Hex: 0x4F525F
+    case gray700 = 0x4F525F
+    
+    /// Gray 800
+    /// - Hex: 0x3C3E48
+    case gray800 = 0x3C3E48
+    
+    /// Gray 900
+    /// - Hex: 0x202227
+    case gray900 = 0x202227
+    
+    // MARK: Primary
+    /// Primary 25
+    /// - Hex: 0xFFECEB
+    case primary25 = 0xFFECEB
+    
+    /// Primary 50
+    /// - Hex: 0xFFDAD6
+    case primary50 = 0xFFDAD6
+    
+    /// Primary 100
+    /// - Hex: 0xFFC7C2
+    case primary100 = 0xFFC7C2
+    
+    /// Primary 200
+    /// - Hex: 0xFFA299
+    case primary200 = 0xFFA299
+    
+    /// Primary 300
+    /// - Hex: 0xFF786B
+    case primary300 = 0xFF786B
+    
+    /// Primary 400
+    /// - Hex: 0xFF5647
+    case primary400 = 0xFF5647
+    
+    /// Primary 500
+    /// - Hex: 0xFF311F
+    case primary500 = 0xFF311F
+    
+    /// Primary 600
+    /// - Hex: 0xF51500
+    case primary600 = 0xF51500
+    
+    /// Primary 700
+    /// - Hex: 0xCC1100
+    case primary700 = 0xCC1100
+    
+    /// Primary 800
+    /// - Hex: 0xA30E00
+    case primary800 = 0xA30E00
+    
+    /// Primary 900
+    /// - Hex: 0x7A0A00
+    case primary900 = 0x7A0A00
+    
+    var color: Color { Color(hex: rawValue) }
+}
+
+

--- a/Neki-iOS/Shared/DesignSystem/Sources/Color/NekiColor.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Color/NekiColor.swift
@@ -1,0 +1,40 @@
+//
+//  NekiColor.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/1/26.
+//
+
+import SwiftUI
+
+public typealias Hex = UInt
+
+
+// MARK: - Color + Hex
+
+extension Color {
+    init(hex: Hex, opacity: Double = 1.0) {
+        self.init(
+            .sRGB,
+            red: Double((hex >> 16) & 0xff) / 255,
+            green: Double((hex >> 08) & 0xff) / 255,
+            blue: Double((hex >> 00) & 0xff) / 255,
+            opacity: opacity
+        )
+    }
+}
+
+
+// MARK: - UIColor + Hex
+
+extension UIColor {
+    convenience init(hex: Hex, alpha: CGFloat = 1.0) {
+        self.init(
+            red: CGFloat((hex >> 16) & 0xff) / 255,
+            green: CGFloat((hex >> 08) & 0xff) / 255,
+            blue: CGFloat((hex >> 00) & 0xff) / 255,
+            alpha: alpha
+        )
+    }
+}
+

--- a/Neki-iOS/Shared/DesignSystem/Sources/Color/NekiColor.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Color/NekiColor.swift
@@ -142,31 +142,31 @@ public enum NekiColor: ColorHexCode {
 
 public extension ShapeStyle where Self == Color {
     // MARK: - Grayscale
-    static var nekiGray25: Color { NekiColor.gray25.color }
-    static var nekiGray50: Color { NekiColor.gray50.color }
-    static var nekiGray75: Color { NekiColor.gray75.color }
-    static var nekiGray100: Color { NekiColor.gray100.color }
-    static var nekiGray200: Color { NekiColor.gray200.color }
-    static var nekiGray300: Color { NekiColor.gray300.color }
-    static var nekiGray400: Color { NekiColor.gray400.color }
-    static var nekiGray500: Color { NekiColor.gray500.color }
-    static var nekiGray600: Color { NekiColor.gray600.color }
-    static var nekiGray700: Color { NekiColor.gray700.color }
-    static var nekiGray800: Color { NekiColor.gray800.color }
-    static var nekiGray900: Color { NekiColor.gray900.color }
+    static var gray25: Color { NekiColor.gray25.color }
+    static var gray50: Color { NekiColor.gray50.color }
+    static var gray75: Color { NekiColor.gray75.color }
+    static var gray100: Color { NekiColor.gray100.color }
+    static var gray200: Color { NekiColor.gray200.color }
+    static var gray300: Color { NekiColor.gray300.color }
+    static var gray400: Color { NekiColor.gray400.color }
+    static var gray500: Color { NekiColor.gray500.color }
+    static var gray600: Color { NekiColor.gray600.color }
+    static var gray700: Color { NekiColor.gray700.color }
+    static var gray800: Color { NekiColor.gray800.color }
+    static var gray900: Color { NekiColor.gray900.color }
     
     // MARK: - Primary
-    static var nekiPrimary25: Color { NekiColor.primary25.color }
-    static var nekiPrimary50: Color { NekiColor.primary50.color }
-    static var nekiPrimary100: Color { NekiColor.primary100.color }
-    static var nekiPrimary200: Color { NekiColor.primary200.color }
-    static var nekiPrimary300: Color { NekiColor.primary300.color }
-    static var nekiPrimary400: Color { NekiColor.primary400.color }
-    static var nekiPrimary500: Color { NekiColor.primary500.color }
-    static var nekiPrimary600: Color { NekiColor.primary600.color }
-    static var nekiPrimary700: Color { NekiColor.primary700.color }
-    static var nekiPrimary800: Color { NekiColor.primary800.color }
-    static var nekiPrimary900: Color { NekiColor.primary900.color }
+    static var primary25: Color { NekiColor.primary25.color }
+    static var primary50: Color { NekiColor.primary50.color }
+    static var primary100: Color { NekiColor.primary100.color }
+    static var primary200: Color { NekiColor.primary200.color }
+    static var primary300: Color { NekiColor.primary300.color }
+    static var primary400: Color { NekiColor.primary400.color }
+    static var primary500: Color { NekiColor.primary500.color }
+    static var primary600: Color { NekiColor.primary600.color }
+    static var primary700: Color { NekiColor.primary700.color }
+    static var primary800: Color { NekiColor.primary800.color }
+    static var primary900: Color { NekiColor.primary900.color }
     
     // MARK: - Utils
     /// 동적으로 색상을 선택해야 하거나 Hex 코드를 써야 할 때만 함수 사용


### PR DESCRIPTION
## 🌴 작업한 브랜치
- `feat/#15-color`


## ✅ 작업한 내용

### 개요
Neki 앱 전반에서 일관된 색상을 사용하고 개발 생산성을 높이기 위해 디자인 시스템 하 컬러 팔레트를 구축했습니다.

---

### 주요 변경 사항
* **NekiColor 열거형**: Hex code를 기반으로 한 컬러 팔레트 정의.
* **Extreme Dot Syntax**: `.foregroundStyle(.nekiPrimary600)`과 같이 점 표기법을 사용하는 직관적 접근자 구현.

---

### 기술적 의사결정
1. Static 기반의 접근자
* 결정: `.nekiPrimary500`과 같이 프로퍼티를 직접 나열하는 방식을 채택했습니다.
* 이유: 기존 `neki(_:)` 메서드는 Xcode 자동완성 및 멤버 목록에 즉각 나타나지 않아, 사용하는 쪽에서 불편을 느낄 수 있겠다 싶었습니다.

2. White / Black 색상 제거
* 결정: 팔레트에서 white와 black 케이스를 제거했습니다.
* 이유: SwiftUI 표준인 `.white`, `.black`과 완전히 동일한 hex 값을 가지므로 중복 선언할 필요가 없다고 판단했습니다.

3. 유틸리티 메서드
* 내용: 팔레트와 관련없이 다른 hex code로 직접 색상을 표현하고 싶을 경우를 대비해 추가적인 유틸리티성 메서드를 준비했습니다.
* 안내사항: `.foregroundStyle(_:)`처럼 `ShapeStyle` 프로토콜을 따르는 무언가를 매개변수로 요구하는 곳에서는 즉시 자동완성 목록에 나타나지 않을 수 있습니다. (컴파일은 무사히 됩니다.)

---

### 사용법
```swift
// 1. 권장 방식 (즉시 자동완성)
Text("Hello")
    .foregroundStyle(.nekiGray900)
    .background(.nekiPrimary50)

// 2. 동적 사용 (자동완성 지연 가능성 있음)
Circle()
    .fill(.neki(.primary500))
    .stroke(.hex(0xFF0000))
```


## ❗️PR Point
1. Hex 값들이 디자인 가이드와 일치하는지 더블체크 해주시는 것도 좋습니다!
2. 네이밍 컨벤션(`neki~~`)은 괜찮으신지 검토받고, 혹은 추천도 받습니다!


## 📟 관련 이슈
- Resolved: #15 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * iOS 앱용 통합 컬러 시스템 도입 — 상세한 그레이스케일 및 메인 팔레트 추가로 시각적 통일성 향상.
  * 정적 팔레트 속성으로 간편한 색상 사용 제공 및 런타임에서 색상을 생성·조회하는 헬퍼 추가.
  * 헥스 기반 색상 생성 지원으로 앱 전반의 색상 표현이 일관되고 재사용 가능해짐.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->