### PR TITLE
[Feat] #32 - TCA 기반 계층형 네비게이션 아키텍처 및 Coordinator 패턴 구현

### DIFF
--- a/Neki-iOS.xcodeproj/project.pbxproj
+++ b/Neki-iOS.xcodeproj/project.pbxproj
@@ -41,8 +41,6 @@
 			membershipExceptions = (
 				APP/Sources/Resources/.gitkeep,
 				Core/Sources/Coordinator/Sources/.gitkeep,
-				Features/Archive/Sources/Presentation/Sources/Feature/.gitkeep,
-				Features/Archive/Sources/Presentation/Sources/View/.gitkeep,
 				Features/Map/Sources/Data/Sources/.gitkeep,
 				Info.plist,
 			);

--- a/Neki-iOS/APP/Sources/Application/Neki_iOSApp.swift
+++ b/Neki-iOS/APP/Sources/Application/Neki_iOSApp.swift
@@ -6,12 +6,28 @@
 //
 
 import SwiftUI
+import ComposableArchitecture
 
 @main
 struct Neki_iOSApp: App {
+    let store = Store(initialState: AppCoordinator.State.splash(SplashFeature.State())) {
+        AppCoordinator()
+            ._printChanges()
+    }
+    
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            AppCoordinatorView(store: store)
         }
     }
+}
+
+#Preview("앱 시작 (Splash)") {
+    AppCoordinatorView(
+        store: Store(
+            initialState: AppCoordinator.State.splash(SplashFeature.State())
+        ) {
+            AppCoordinator()
+        }
+    )
 }

--- a/Neki-iOS/APP/Sources/Application/TempSplash+Auth.swift
+++ b/Neki-iOS/APP/Sources/Application/TempSplash+Auth.swift
@@ -1,0 +1,112 @@
+//
+//  TempSplash+Auth.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/15/26.
+//
+
+import Foundation
+import SwiftUI
+import ComposableArchitecture
+
+// MARK: - 1. Splash Feature
+@Reducer
+struct SplashFeature {
+    @ObservableState
+    struct State: Equatable {}
+    
+    enum Action {
+        case didTapGoAuthButton
+        case delegate(Delegate)
+        enum Delegate { case moveToAuth }
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .didTapGoAuthButton:
+                return .send(.delegate(.moveToAuth))
+            default:
+                return .none
+            }
+        }
+    }
+}
+
+struct SplashView: View {
+    let store: StoreOf<SplashFeature>
+    
+    var body: some View {
+        ZStack {
+            Color.blue.opacity(0.2).ignoresSafeArea()
+            VStack(spacing: 20) {
+                Text("Splash View 💦")
+                    .font(.largeTitle)
+                
+                Button("Auth 화면으로 이동") {
+                    store.send(.didTapGoAuthButton)
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+}
+
+// MARK: - 2. Auth Coordinator
+@Reducer
+struct AuthCoordinator {
+    @ObservableState
+    struct State: Equatable {}
+    
+    enum Action {
+        case didTapGoSplashButton
+        case didTapLoginButton
+        
+        case delegate(Delegate)
+        enum Delegate {
+            case moveToSplash
+            case moveToMainTab
+        }
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .didTapGoSplashButton:
+                return .send(.delegate(.moveToSplash))
+                
+            case .didTapLoginButton:
+                return .send(.delegate(.moveToMainTab))
+                
+            default:
+                return .none
+            }
+        }
+    }
+}
+
+struct AuthCoordinatorView: View {
+    let store: StoreOf<AuthCoordinator>
+    
+    var body: some View {
+        ZStack {
+            Color.yellow.opacity(0.2).ignoresSafeArea()
+            VStack(spacing: 20) {
+                Text("Auth View 🔒")
+                    .font(.largeTitle)
+                
+                Button("Splash로 돌아가기") {
+                    store.send(.didTapGoSplashButton)
+                }
+                .tint(.gray)
+                .buttonStyle(.borderedProminent)
+                
+                Button("로그인 완료 (메인으로)") {
+                    store.send(.didTapLoginButton)
+                }
+                .tint(.green)
+                .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+}

--- a/Neki-iOS/APP/Sources/Coordinator/AppCoordinator.swift
+++ b/Neki-iOS/APP/Sources/Coordinator/AppCoordinator.swift
@@ -1,0 +1,58 @@
+//
+//  AppCoordinator.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/15/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+@Reducer
+struct AppCoordinator {
+    
+    @ObservableState
+    enum State {
+        case splash(SplashFeature.State)
+        case auth(AuthCoordinator.State)
+        case mainTab(MainTabCoordinator.State)
+    }
+    
+    enum Action {
+        case splash(SplashFeature.Action)
+        case auth(AuthCoordinator.Action)
+        case mainTab(MainTabCoordinator.Action)
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+                
+            // MARK: - Splash 화면에서의 이동
+            case .splash(.delegate(.moveToAuth)):
+                state = .auth(AuthCoordinator.State())
+                return .none
+                
+            // MARK: - Auth 화면에서의 이동
+            case .auth(.delegate(.moveToSplash)):
+                state = .splash(SplashFeature.State())
+                return .none
+                
+            case .auth(.delegate(.moveToMainTab)):
+                state = .mainTab(MainTabCoordinator.State())
+                return .none
+                
+            // MARK: - MainTab 화면에서의 이동
+            case .mainTab(.delegate(.logout)):
+                state = .auth(AuthCoordinator.State())
+                return .none
+                
+            default:
+                return .none
+            }
+        }
+        .ifCaseLet(\.splash, action: \.splash) { SplashFeature() }
+        .ifCaseLet(\.auth, action: \.auth) { AuthCoordinator() }
+        .ifCaseLet(\.mainTab, action: \.mainTab) { MainTabCoordinator() }
+    }
+}

--- a/Neki-iOS/APP/Sources/Coordinator/AppCoordinatorView.swift
+++ b/Neki-iOS/APP/Sources/Coordinator/AppCoordinatorView.swift
@@ -1,0 +1,31 @@
+//
+//  AppCoordinatorView.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/15/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct AppCoordinatorView: View {
+    @Bindable var store: StoreOf<AppCoordinator>
+    
+    var body: some View {
+        switch store.state {
+        case .splash:
+            if let store = store.scope(state: \.splash, action: \.splash) {
+                SplashView(store: store)
+              }
+        case .auth:
+            if let store = store.scope(state: \.auth, action: \.auth) {
+                AuthCoordinatorView(store: store)
+              }
+            
+        case .mainTab:
+            if let store = store.scope(state: \.mainTab, action: \.mainTab) {
+                MainTabCoordinatorView(store: store)
+              }
+        }
+    }
+}

--- a/Neki-iOS/APP/Sources/Coordinator/MainTabCoordinator.swift
+++ b/Neki-iOS/APP/Sources/Coordinator/MainTabCoordinator.swift
@@ -1,0 +1,72 @@
+//
+//  MainTabCoordinator.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/15/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+// import Pose
+// import Archive
+
+@Reducer
+struct MainTabCoordinator {
+    
+    @ObservableState
+    struct State {
+        var selectedTab: Tab = .pose
+        
+        // 하위 코디네이터들의 State를 보유
+        var pose = PoseCoordinator.State()
+        var archive = ArchiveCoordinator.State()
+    }
+    
+    enum Action {
+        case tabSelected(Tab)
+        
+        case pose(PoseCoordinator.Action)
+        case archive(ArchiveCoordinator.Action)
+        
+        // 상위 코디네이터(AppCoordinator)로 보낼 신호
+        case delegate(Delegate)
+        enum Delegate {
+            case logout
+        }
+    }
+    
+    enum Tab: Hashable {
+        case pose
+        case archive
+    }
+    
+    var body: some ReducerOf<Self> {
+        Scope(state: \.pose, action: \.pose) {
+            PoseCoordinator()
+        }
+        
+        Scope(state: \.archive, action: \.archive) {
+            ArchiveCoordinator()
+        }
+        
+        Reduce { state, action in
+            switch action {
+            case let .tabSelected(tab):
+                state.selectedTab = tab
+                return .none
+                
+                // 아카이브 내부 뷰에서 포즈 내부 뷰로 변경 (피쳐간 이동)
+            case let .archive(.delegate(.requestJumpToPose(item))):
+                state.selectedTab = .pose
+                return .send(.pose(.routeToDetail(item)))
+                
+            case .pose(.delegate(.logout)):
+                return .send(.delegate(.logout))
+                
+            default:
+                return .none
+            }
+        }
+    }
+    
+}

--- a/Neki-iOS/APP/Sources/Coordinator/MainTabCoordinatorView.swift
+++ b/Neki-iOS/APP/Sources/Coordinator/MainTabCoordinatorView.swift
@@ -1,0 +1,38 @@
+//
+//  MainTabCoordinatorView.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/15/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+// import Pose
+// import Archive
+
+struct MainTabCoordinatorView: View {
+    @Bindable var store: StoreOf<MainTabCoordinator>
+    
+    var body: some View {
+        TabView(selection: $store.selectedTab.sending(\.tabSelected)) {
+            
+            // Pose Tab
+            PoseCoordinatorView(store: store.scope(state: \.pose, action: \.pose))
+                .tabItem {
+                    Label("포즈", systemImage: "figure.stand")
+                }
+                .tag(MainTabCoordinator.Tab.pose)
+            
+            // Archive Tab
+            ArchiveCoordinatorView(store: store.scope(state: \.archive, action: \.archive))
+                .tabItem {
+                    Label("보관함", systemImage: "archivebox")
+                }
+                .tag(MainTabCoordinator.Tab.archive)
+            
+            // Map Tab
+            // MyPage Tab
+        }
+        .tint(.black)
+    }
+}

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Coordinator/ArchiveCoordinator.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Coordinator/ArchiveCoordinator.swift
@@ -62,7 +62,9 @@ struct ArchiveCoordinator {
         }
         .forEach(\.path, action: \.path)
     }
-    
+}
+
+extension ArchiveCoordinator {
     @Reducer
     enum Path {
         case detail(ArchiveDetailFeature)

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Coordinator/ArchiveCoordinator.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Coordinator/ArchiveCoordinator.swift
@@ -1,0 +1,71 @@
+//
+//  ArchiveCoordinator.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/14/26.
+//
+
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+struct ArchiveCoordinator {
+    
+    @ObservableState
+    struct State {
+        var root = ArchiveFeature.State()
+        var path = StackState<Path.State>()
+    }
+    
+    enum Action {
+        case root(ArchiveFeature.Action)
+        case path(StackActionOf<Path>)
+        case delegate(Delegate)
+        
+        // 상위 코디네이터(MainTab)로 보낼 신호
+        enum Delegate {
+            case requestJumpToPose(FeedImageItem)
+        }
+    }
+    
+    var body: some ReducerOf<Self> {
+        Scope(state: \.root, action: \.root) {
+            ArchiveFeature()
+        }
+        
+        Reduce { state, action in
+            /// 화면전환과 관련된 액션 case만 사용하고 나머지는 default를 이용해 무시
+            switch action {
+                // 아카이브 피드에서 이미지 클릭해서 상세 보기
+            case let .root(.imageTapped(item)):
+                state.path.append(.detail(ArchiveDetailFeature.State(item: item)))
+                return .none
+                
+                // 아카이브 상세에서 더 자세히 보기 클릭
+            case let .path(.element(id: _, action: .detail(.didTapDeepLinkButton(item)))):
+                state.path.append(.deepDetail(ArchiveDeepDetailFeature.State(item: item)))
+                return .none
+                
+                // [DeepDetail -> Root] 한 번에 이동
+            case .path(.element(id: _, action: .deepDetail(.didTapPopToRoot))):
+                state.path.removeAll()
+                return .none
+                
+                // 아카이브에서 포즈의 특정 사진 디테일 화면으로 이동 (Feature간 이동)
+            case .path(.element(id: _, action: .deepDetail(.didTapJumpToPose))):
+                guard case let .deepDetail(deepState) = state.path.last else { return .none }
+                return .send(.delegate(.requestJumpToPose(deepState.item.toFeedImageItem())))
+                
+            default:
+                return .none
+            }
+        }
+        .forEach(\.path, action: \.path)
+    }
+    
+    @Reducer
+    enum Path {
+        case detail(ArchiveDetailFeature)
+        case deepDetail(ArchiveDeepDetailFeature)
+    }
+}

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Coordinator/ArchiveCoordinatorView.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Coordinator/ArchiveCoordinatorView.swift
@@ -1,0 +1,27 @@
+//
+//  ArchiveCoordinatorView.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/14/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct ArchiveCoordinatorView: View {
+    @Bindable var store: StoreOf<ArchiveCoordinator>
+    
+    var body: some View {
+        NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
+            ArchiveView(store: store.scope(state: \.root, action: \.root))
+                .navigationTitle("아카이빙")
+        } destination: { store in
+            switch store.case {
+            case .detail(let store):
+                ArchiveDetailView(store: store)
+            case .deepDetail(let store):
+                ArchiveDeepDetailView(store: store)
+            }
+        }
+    }
+}

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveDeepDetailFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveDeepDetailFeature.swift
@@ -1,0 +1,35 @@
+//
+//  ArchiveDeepDetailFeature.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/14/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+@Reducer
+struct ArchiveDeepDetailFeature {
+    
+    @ObservableState
+    struct State: Equatable {
+        let item: ArchiveImageItem
+    }
+    
+    enum Action {
+        // Navigation Action
+        case didTapPopToRoot
+        case didTapBackButton
+        case didTapJumpToPose
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            default:
+                return .none
+            }
+        }
+    }
+    
+}

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveDetailFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveDetailFeature.swift
@@ -1,0 +1,33 @@
+//
+//  ArchiveDetailFeature.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/14/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+@Reducer
+struct ArchiveDetailFeature {
+    @ObservableState
+    struct State: Equatable {
+        let item: ArchiveImageItem
+    }
+    
+    enum Action {
+        // Navigation Action
+        case didTapBackButton
+        case didTapDeepLinkButton(ArchiveImageItem)
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            default:
+                return .none
+            }
+        }
+    }
+    
+}

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFeature.swift
@@ -1,5 +1,5 @@
 //
-//  PoseFeedFeature.swift
+//  ArchiveFeedFeature.swift
 //  Neki-iOS
 //
 //  Created by OneTen on 1/7/26.
@@ -9,30 +9,33 @@ import SwiftUI
 import ComposableArchitecture
 
 @Reducer
-struct PoseFeedFeature {
+struct ArchiveFeature {
     
     @ObservableState
     struct State: Equatable {
-        var items: IdentifiedArrayOf<FeedImageItem> = []
+        var items: IdentifiedArrayOf<ArchiveImageItem> = []
     }
     
     enum Action {
+        // View Life Cycle Action
         case onAppear
-        case imageTapped(FeedImageItem)
+        
+        // Navigation Action
+        case imageTapped(ArchiveImageItem)
     }
     
     var body: some ReducerOf<Self> {
         Reduce { state, action in
+            /// 화면전환과 관련된 액션은 default를 이용해 무시하고 나머지 case만 사용
             switch action {
             case .onAppear:
                 if state.items.isEmpty {
-                    let dummyList = FeedImageItem.dummyData()
+                    let dummyList = ArchiveImageItem.dummyData()
                     state.items = IdentifiedArray(uniqueElements: dummyList)
                 }
                 return .none
                 
-            case let .imageTapped(item):
-                print("Tapped item ID: \(item.id)")
+            default:
                 return .none
             }
         }

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Item/ArchiveImageItem.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Item/ArchiveImageItem.swift
@@ -1,0 +1,54 @@
+//
+//  ArchiveImageItem.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/7/26.
+//
+
+import Foundation
+
+struct ArchiveImageItem: Equatable, Identifiable {
+    let id: UUID
+    let imageURL: URL?
+    
+    init(id: UUID, imageURLString: String) {
+        self.id = id
+        self.imageURL = URL(string: imageURLString)
+    }
+    
+    init(id: UUID, imageURL: URL) {
+        self.id = id
+        self.imageURL = imageURL
+    }
+}
+
+extension ArchiveImageItem {
+    static func dummyData() -> [ArchiveImageItem] {
+        return [
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(300)/\(500)?random=\(1)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(200)/\(500)?random=\(2)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(300)/\(300)?random=\(3)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(300)/\(800)?random=\(4)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(500)/\(500)?random=\(5)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(700)/\(500)?random=\(6)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(300)/\(900)?random=\(7)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(300)/\(100)?random=\(8)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(200)/\(500)?random=\(9)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(300)/\(500)?random=\(10)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(300)/\(500)?random=\(11)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(300)/\(500)?random=\(12)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(300)/\(500)?random=\(13)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(300)/\(500)?random=\(14)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(300)/\(500)?random=\(15)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(300)/\(500)?random=\(16)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(300)/\(500)?random=\(17)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(300)/\(500)?random=\(18)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(300)/\(500)?random=\(19)"),
+            ArchiveImageItem(id: UUID(), imageURLString: "https://picsum.photos/\(300)/\(500)?random=\(20)")
+        ]
+    }
+    
+    func toFeedImageItem() -> FeedImageItem {
+        return FeedImageItem(id: id, imageURL: imageURL!)
+    }
+}

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveDeepDetailView.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveDeepDetailView.swift
@@ -1,0 +1,33 @@
+//
+//  ArchiveDeepDetailView.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/14/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct ArchiveDeepDetailView: View {
+    let store: StoreOf<ArchiveDeepDetailFeature>
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("더 깊은 상세 화면")
+                .font(.largeTitle)
+            
+            Button("루트 화면으로 가기 (Pop to Root)") {
+                store.send(.didTapPopToRoot)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.red)
+            
+            Button("포즈 디테일 화면으로 가기 (Navigate to Pose)") {
+                store.send(.didTapJumpToPose)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.red)
+        }
+        .navigationTitle("Archive Deep Detail")
+    }
+}

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveDetailView.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveDetailView.swift
@@ -1,0 +1,36 @@
+//
+//  ArchiveDetailView.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/14/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+import Kingfisher
+
+struct ArchiveDetailView: View {
+    let store: StoreOf<ArchiveDetailFeature>
+    
+    var body: some View {
+        VStack {
+            KFImage(store.item.imageURL)
+                .resizable()
+                .placeholder { ProgressView() }
+                .aspectRatio(contentMode: .fit)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .padding()
+            
+            Text("이미지 ID: \(store.item.id)")
+                .font(.headline)
+            
+            Button("더 자세히 보기 (Next)") {
+                store.send(.didTapDeepLinkButton(store.item))
+            }
+            
+            Spacer()
+        }
+        .navigationTitle("Archive 상세 보기")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveImageView.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveImageView.swift
@@ -1,0 +1,49 @@
+//
+//  ArchiveImageView.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/7/26.
+//
+
+import SwiftUI
+import Kingfisher
+
+struct ArchiveImageView: View {
+    
+    //MARK: - Properties
+
+    let item: ArchiveImageItem
+    
+    //MARK: - Main Body
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            KFImage(item.imageURL)
+                .resizable()
+                .placeholder {
+                    placeholderView
+                }
+                .retry(maxCount: 3, interval: .seconds(5))
+                .onFailure { error in
+                    print("이미지 로드 실패: \(error)")
+                }
+                .aspectRatio(contentMode: .fit)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipped()
+    }
+}
+
+
+//MARK: - Sub View
+
+extension ArchiveImageView {
+    private var placeholderView: some View {
+        RoundedRectangle(cornerRadius: 12)
+            .fill(.gray100)
+            .frame(height: 180)
+            .overlay {
+                ProgressView()
+            }
+    }
+}

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveView.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveView.swift
@@ -1,5 +1,5 @@
 //
-//  PoseView.swift
+//  ArchiveView.swift
 //  Neki-iOS
 //
 //  Created by OneTen on 1/7/26.
@@ -8,9 +8,9 @@
 import SwiftUI
 import ComposableArchitecture
 
-struct PoseView: View {
+struct ArchiveView: View {
     
-    let store: StoreOf<PoseFeature>
+    let store: StoreOf<ArchiveFeature>
     
     var body: some View {
         ScrollView {
@@ -18,7 +18,7 @@ struct PoseView: View {
                 items: Array(store.items),
                 columns: 2
             ) { item in
-                FeedImageView(item: item)
+                ArchiveImageView(item: item)
                     .onTapGesture {
                         store.send(.imageTapped(item))
                     }

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveView.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveView.swift
@@ -27,8 +27,8 @@ struct ArchiveView: View {
             .padding(.bottom, 128)
         }
         .scrollIndicators(.never)
-        .onAppear {
-            store.send(.onAppear)
+        .task {
+            await store.send(.onAppear).finish()
         }
     }
 }

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Coordinator/PoseCoordinator.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Coordinator/PoseCoordinator.swift
@@ -69,7 +69,9 @@ struct PoseCoordinator {
         }
         .forEach(\.path, action: \.path)
     }
-    
+}
+
+extension PoseCoordinator {
     @Reducer
     enum Path {
         case detail(PoseDetailFeature)

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Coordinator/PoseCoordinator.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Coordinator/PoseCoordinator.swift
@@ -1,0 +1,78 @@
+//
+//  PoseCoordinator.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/14/26.
+//
+
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+struct PoseCoordinator {
+    
+    @ObservableState
+    struct State {
+        var root = PoseFeature.State()
+        var path = StackState<Path.State>()
+    }
+    
+    enum Action {
+        case root(PoseFeature.Action)
+        case path(StackActionOf<Path>)
+        
+        case routeToDetail(FeedImageItem)
+        
+        case delegate(Delegate)
+        
+        enum Delegate {
+            case logout
+        }
+    }
+    
+    var body: some ReducerOf<Self> {
+        Scope(state: \.root, action: \.root) {
+            PoseFeature()
+        }
+        
+        Reduce { state, action in
+            /// 화면전환과 관련된 액션 case만 사용하고 나머지는 default를 이용해 무시
+            switch action {
+                // 포즈 피드에서 이미지 클릭해서 상세 보기
+            case let .root(.imageTapped(item)):
+                state.path.append(.detail(PoseDetailFeature.State(item: item)))
+                return .none
+                
+                // 포즈 상세에서 더 자세히 보기 클릭
+            case let .path(.element(id: _, action: .detail(.didTapDeepLinkButton(item)))):
+                state.path.append(.deepDetail(PoseDeepDetailFeature.State(item: item)))
+                return .none
+                
+                // [DeepDetail -> Root] 한 번에 이동
+            case .path(.element(id: _, action: .deepDetail(.didTapPopToRoot))):
+                state.path.removeAll()
+                return .none
+                
+            case let .routeToDetail(item):
+                // 기존 스택을 비우고 싶다면: state.path.removeAll()
+                // 포즈 외부에서 이미지 디테일 뷰로 이동 (Feature간 전환)
+                state.path.append(.detail(PoseDetailFeature.State(item: item)))
+                return .none
+                
+            case .path(.element(id: _, action: .deepDetail(.delegate(.logout)))):
+                // 상위(MainTab)로 토스
+                return .send(.delegate(.logout))
+                
+            default:
+                return .none
+            }
+        }
+        .forEach(\.path, action: \.path)
+    }
+    
+    @Reducer
+    enum Path {
+        case detail(PoseDetailFeature)
+        case deepDetail(PoseDeepDetailFeature)
+    }
+}

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Coordinator/PoseCoordinatorView.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Coordinator/PoseCoordinatorView.swift
@@ -1,0 +1,27 @@
+//
+//  PoseCoordinatorView.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/14/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct PoseCoordinatorView: View {
+    @Bindable var store: StoreOf<PoseCoordinator>
+    
+    var body: some View {
+        NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
+            PoseView(store: store.scope(state: \.root, action: \.root))
+                .navigationTitle("포즈 추천")
+        } destination: { store in
+            switch store.case {
+            case .detail(let store):
+                PoseDetailView(store: store)
+            case .deepDetail(let store):
+                PoseDeepDetailView(store: store)
+            }
+        }
+    }
+}

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Feature/PoseDeepDetailFeature.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Feature/PoseDeepDetailFeature.swift
@@ -1,0 +1,43 @@
+//
+//  PoseDeepDetailFeature.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/14/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+@Reducer
+struct PoseDeepDetailFeature {
+    
+    @ObservableState
+    struct State: Equatable {
+        let item: FeedImageItem
+    }
+    
+    enum Action {
+        // Navigation Action
+        case didTapPopToRoot
+        case didTapBackButton
+        case didTapLogoutButton
+        case delegate(Delegate)
+        
+        enum Delegate {
+            case logout
+        }
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .didTapLogoutButton:
+                return .send(.delegate(.logout))
+                
+            default:
+                return .none
+            }
+        }
+    }
+    
+}

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Feature/PoseDetailFeature.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Feature/PoseDetailFeature.swift
@@ -1,0 +1,33 @@
+//
+//  PoseDetailFeature.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/14/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+@Reducer
+struct PoseDetailFeature {
+    @ObservableState
+    struct State: Equatable {
+        let item: FeedImageItem
+    }
+    
+    enum Action {
+        // Navigation Action
+        case didTapBackButton
+        case didTapDeepLinkButton(FeedImageItem)
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            default:
+                return .none
+            }
+        }
+    }
+    
+}

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Feature/PoseFeature.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Feature/PoseFeature.swift
@@ -1,0 +1,43 @@
+//
+//  PoseFeedFeature.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/7/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+@Reducer
+struct PoseFeature {
+    
+    @ObservableState
+    struct State: Equatable {
+        var items: IdentifiedArrayOf<FeedImageItem> = []
+    }
+    
+    enum Action {
+        // View Life Cycle Action
+        case onAppear
+        
+        // Navigation Action
+        case imageTapped(FeedImageItem)
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            /// 화면전환과 관련된 액션은 default를 이용해 무시하고 나머지 case만 사용
+            switch action {
+            case .onAppear:
+                if state.items.isEmpty {
+                    let dummyList = FeedImageItem.dummyData()
+                    state.items = IdentifiedArray(uniqueElements: dummyList)
+                }
+                return .none
+                
+            default:
+                return .none
+            }
+        }
+    }
+}

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/PoseDeepDetailView.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/PoseDeepDetailView.swift
@@ -1,0 +1,32 @@
+//
+//  PoseDeepDetailView.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/14/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct PoseDeepDetailView: View {
+    let store: StoreOf<PoseDeepDetailFeature>
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("더 깊은 상세 화면")
+                .font(.largeTitle)
+            
+            Button("로그아웃") {
+                store.send(.didTapLogoutButton)
+            }
+            .foregroundStyle(.red)
+            
+            Button("루트 화면으로 가기 (Pop to Root)") {
+                store.send(.didTapPopToRoot)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.red)
+        }
+        .navigationTitle("Deep Detail")
+    }
+}

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/PoseDetailView.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/PoseDetailView.swift
@@ -1,0 +1,36 @@
+//
+//  PoseDetailView.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 1/14/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+import Kingfisher
+
+struct PoseDetailView: View {
+    let store: StoreOf<PoseDetailFeature>
+    
+    var body: some View {
+        VStack {
+            KFImage(store.item.imageURL)
+                .resizable()
+                .placeholder { ProgressView() }
+                .aspectRatio(contentMode: .fit)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .padding()
+            
+            Text("이미지 ID: \(store.item.id)")
+                .font(.headline)
+            
+            Button("더 자세히 보기 (Next)") {
+                store.send(.didTapDeepLinkButton(store.item))
+            }
+            
+            Spacer()
+        }
+        .navigationTitle("상세 보기")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/PoseView.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/PoseView.swift
@@ -27,8 +27,8 @@ struct PoseView: View {
             .padding(.bottom, 128)
         }
         .scrollIndicators(.never)
-        .onAppear {
-            store.send(.onAppear)
+        .task {
+            await store.send(.onAppear).finish()
         }
     }
 }


### PR DESCRIPTION
## 🌴 작업한 브랜치
- `feat#32`


## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
TCA 1.23.1 최신 스펙(StackState, Path Reducer)을 준수하여 앱의 전반적인 네비게이션 흐름을 관리하는 계층형 Coordinator 패턴을 구현했습니다.

앱의 구조를 크게 **Root-Tab-Feature**의 3단계 계층으로 분리하여 모듈 간 의존성을 낮추고 상태 관리를 명확히 했습니다.

```
📱 AppCoordinator (Root / Switching)
│  : 앱의 전체 생명주기 관리 (Enum State)
│
├── 💦 SplashFeature
│      (앱 실행 시 초기 진입)
│
├── 🔒 AuthCoordinator
│      (로그인/회원가입 화면 흐름)
│
└── 📑 MainTabCoordinator (Struct State / Scope)
    │  : 탭바 관리 및 하위 탭 상태 보존
    │
    ├── 🧘 PoseCoordinator (Stack State)
    │   │  : 포즈 탭 내부의 네비게이션 스택 관리
    │   │
    │   ├── [Root] PoseFeature (포즈 피드 홈)
    │   ├── [Push] PoseDetailFeature (상세)
    │   └── [Push] PoseDeepDetailFeature (더 깊은 상세 - 로그아웃 버튼 있음)
    │
    └── 📂 ArchiveCoordinator (Stack State)
        │  : 아카이브 탭 내부의 네비게이션 스택 관리
        │
        ├── [Root] ArchiveFeature (보관함 홈)
        ├── [Push] ArchiveDetailFeature (상세)
        └── [Push] ArchiveDeepDetailFeature (더 깊은 상세 - 포즈 이동 버튼 있음)
```

### AppCoordinator

앱의 최상위 진입점으로, 화면을 쌓는 것이 아니라 상태에 따라 **View를 통째로 교체(Switching)** 합니다.
Splash ↔ Auth ↔ MainTab 간의 전환을 관리합니다.
한 시점에 하나의 화면만 메모리에 존재해야 하므로 Enum State와 ifCaseLet을 사용했습니다.

### MainTabCoordinator

Pose와 Archive, Map, MyPage 탭을 관리합니다.
Feature 모듈 간의 화면 전환(예: 아카이브에서 포즈 상세로 이동)을 중개합니다.

### FeatureCoordinator

각 탭(Pose, Archive) 내부의 깊은 화면 이동(Push/Pop)을 담당합니다.
TCA의 StackState와 Path Reducer 패턴을 사용하여 네비게이션을 구현했습니다.

### Delegate Action 패턴

하위 뷰에서 상위 코디네이터로 이벤트를 전달할 때, 직접 참조하는 대신 Delegate Action을 정의하여 신호를 위로 전달합니다.

**로그아웃 시나리오**: DeepDetail -> PoseCoord -> MainTabCoordinator -> AppCoordinator 순으로 액션이 버블링되어 최종적으로 Auth 화면으로 전환됩니다.

**탭 간 이동 시나리오**: ArchiveDeepDetail -> ArchiveCoordinator -> MainTabCoordinator -> PoseCoordinator 순으로 전달되어 탭 전환 및 뷰 푸시가 이루어집니다.

### CoordinatorView

각 Feature모듈의 네비게이션 흐름을 관리하는  **CoordinatorView**를 구현했습니다.
Coordinator가 쓰이는 실제 사용처 느낌입니다!

모든 화면 전환 로직 `Push`, `Pop`, `PopToRoot`등은 `Coordinator`가 전담합니다.

실제 화면(View)의 전환은 CoordinatorView 내부의 NavigationStack과 destination 클로저를 통해 이루어집니다.

```
// ArchiveCoordinatorView.swift

NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
    ArchiveView(...)
} destination: { store in
    // Coordinator의 State에 따라 실제 뷰를 스위칭
    switch store.case {
    case .detail(let store):
        ArchiveDetailView(store: store)
    case .deepDetail(let store):
        ArchiveDeepDetailView(store: store)
    }
}
```


### Feature Reducer의 역할 축소 (Delegation 패턴)

각 화면 단위의 Reducer(ArchiveFeature)는 자신의 비즈니스 로직(데이터 로드 등)에만 집중합니다.
화면 전환이 필요한 이벤트(imageTapped)는 Action에는 정의하지만, **Reduce 내부에서는 처리하지 않고 무시(default: return .none)** 합니다.

이 액션은 상위 계층인 Coordinator가 감지하여 네비게이션 로직을 수행합니다.

**Feature Reducer(ArchiveFeature)** 
화면 전환 액션(imageTapped)이 발생했을 때, Feature 내부에서는 아무런 상태 변경을 하지 않도록 default 문으로 처리했습니다. 이를 통해 Feature는 네비게이션 로직을 제외한 순수 로직만 관리합니다.

```
// ArchiveFeature.swift
var body: some ReducerOf<Self> {
    Reduce { state, action in
        switch action {
        case .onAppear:
            // 데이터 로드 로직 등은 여기서 처리
            return .none
            
        // ⭐️ 화면 전환 액션(.imageTapped)은 여기서 처리하지 않고 상위로 위임
        default:
            return .none
        }
    }
}
```

**Coordinator Reducer (ArchiveCoordinator)** 
하위 Feature에서 무시된 액션을 Coordinator가 잡아서 실제 스택(path)을 변경합니다.

```
// ArchiveCoordinator.swift
Reduce { state, action in
    switch action {
    // ⭐️ 하위 Feature의 액션을 감지하여 네비게이션 처리
    case let .root(.imageTapped(item)):
        state.path.append(.detail(ArchiveDetailFeature.State(item: item)))
        return .none
    // ...
    }
}
```

<img width="1141" height="642" alt="스크린샷 2026-01-15 오전 3 34 17" src="https://github.com/user-attachments/assets/054b9e73-4f04-44bd-b527-bf4177960b42" />

이건 제미나이가 만들어준 구조 이미지인데 그냥 가져와봤어요 막 정확하지는 않은듯

## ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->
1. 화면전환 로직만을 테스트하기 위해 일단 임시로 Pose와 Archive에 여러 리듀서와 뷰를 만들어뒀습니다. 실제 구현 들어가며 모두 지울 예정입니다! 지금은 화면전환 방식과 방법에 대한 예시로 남겨뒀습니다
2. 위의 항목과 비슷한 맥락으로 TempSplash+Auth 라는 파일이 있습니다. splash와 auth의 상태일 때 리듀서와 뷰를 대충 제미나이 넣고 만든건데 네비게이션 플로우 확인만 하려고 만들었습니다. 실제로 다 구현되면 지워야 할 파일입니다!!
3. Coordinator와 CoordinatorView는 별도의 폴더를 만들어서 관리하게끔 만들었습니다. 다른 feature 리듀서들과 view랑은 성격이 명확히 다르다고 생각해서 분리해뒀는데 뭔가 다른 의견이 있으신지 궁금합니다
4. 가장 고민했던 부분은 사실 MainTabCoordinator과 AppCoordinator를 어느 계층에서 관리하고 있어야 하는가였습니다. 근데 아무리 고민을 해봐도 MainTabCoordinator 는 각 Feature 모듈에 대해 알고 있어야 하고 AppCoordinator 는 앱의 전반적인 흐름과 관련된 것들을 알고 있어야 해서 최상위 레이어인 App에서 관리하는 방법밖에는 없다는 생각이 들었습니다. 결국 하위의 모든 모듈을 지닐 수 있는 건 최상위 레이어이기에 이렇게 선택을 하긴 했는데 아직도 이게 맞는 방향인지 고민이네요. 
5. 고민만 엄청 하면서 질질 끌었는데 다 만들고 보니 생각보다 TCA에서는 그냥 평범하게 보편적인 방식인 것 같네요. 금용님은 전에 어떤 식으로 화면전환을 관리하셨는지 궁금합니다. 또한 TCA에 대해 아주아주 미숙하기에 현 구조에 대한 의견과 여러 지적들 부탁드립니다


## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/4939deb7-462d-4bc8-bed9-74518db9a786" width ="250">|


## 📟 관련 이슈
- Resolved: #32 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 포즈와 보관함 기능 간 탭 기반 네비게이션 추가
  * 아카이빙 기능 완전 구현 - 이미지 그리드 표시, 상세 보기, 깊은 상세 보기 화면
  * 포즈 기능에 상세 보기 및 깊은 상세 보기 화면 추가
  * 앱 시작 화면(스플래시), 인증 흐름 추가

* **개선 사항**
  * 포즈 기능 구조 개선 및 네비게이션 로직 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->