### PR TITLE
[Fix] 네트워킹 기본응답스펙 변경, 임시코드 정리에 따른 컴파일 에러 해소 핫픽스

### DIFF
--- a/Neki-iOS/Core/Sources/Network/Sources/Base/BaseResponseDTO.swift
+++ b/Neki-iOS/Core/Sources/Network/Sources/Base/BaseResponseDTO.swift
@@ -10,13 +10,11 @@ import Foundation
 public struct BaseResponseDTO<T: Decodable>: Decodable {
     let status: Int
     let message: String
-    let isSuccess: Bool
     let data: T?
     
     enum CodingKeys: String, CodingKey {
         case message, data
         case status = "resultCode"
-        case isSuccess = "success"
     }
 }
 

--- a/Neki-iOS/Core/Sources/Network/Sources/Base/Endpoint.swift
+++ b/Neki-iOS/Core/Sources/Network/Sources/Base/Endpoint.swift
@@ -45,7 +45,7 @@ extension Endpoint {
     
     public var multipartItems: [MultipartItem]? { nil }
     
-    static let defaultEncoder: JSONEncoder = JSONEncoder()
+    static var defaultEncoder: JSONEncoder { JSONEncoder() }
     
     public func asURLRequest() throws -> URLRequest {
         let encoder = Self.defaultEncoder

--- a/Neki-iOS/Core/Sources/Network/Sources/Base/NetworkError.swift
+++ b/Neki-iOS/Core/Sources/Network/Sources/Base/NetworkError.swift
@@ -8,28 +8,28 @@
 import Foundation
 
 public enum NetworkError: LocalizedError {
-    case apiError(BaseFailedResponseDTO)
+    case apiError(String)
     case requestEncodingError
     case responseDecodingError
     case responseError
     case notFound
     case internalServerError
     case networkFail
-    case unknownError
+    case unknownError(Error)
     case invalidURLError
     case badRequestError
     case unauthorizedError
     
     public var errorDescription: String? {
         switch self {
-        case .apiError(let dto): return dto.message
+        case .apiError(let message): return message
         case .requestEncodingError: return "요청 인코딩에 실패했습니다."
         case .responseDecodingError: return "응답 디코딩에 실패했습니다."
         case .responseError: return "응답 오류가 발생했습니다."
         case .notFound: return "리소스를 찾을 수 없습니다"
         case .internalServerError: return "서버 내부 오류가 발생했습니다"
         case .networkFail: return "네트워크 연결에 실패했습니다"
-        case .unknownError: return "알 수 없는 오류가 발생했습니다."
+        case .unknownError(let error): return "알 수 없는 오류가 발생했습니다.: \(error)"
         case .invalidURLError: return "잘못된 URL입니다"
         case .badRequestError: return "잘못된 요청입니다"
         case .unauthorizedError: return "인증이 필요합니다"

--- a/Neki-iOS/Core/Sources/Network/Sources/Base/NetworkProvider.swift
+++ b/Neki-iOS/Core/Sources/Network/Sources/Base/NetworkProvider.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 public protocol NetworkProvider {
-    func request(endpoint: Endpoint) async throws -> Void 
-    func request<T: Decodable>(endpoint: Endpoint) async throws -> T
+    func request(endpoint: Endpoint) async throws -> BaseResponseDTO<EmptyData>
+    func request<T: Decodable>(endpoint: Endpoint) async throws -> BaseResponseDTO<T>
 }

--- a/Neki-iOS/Core/Sources/Network/Sources/Base/TokenRefresher.swift
+++ b/Neki-iOS/Core/Sources/Network/Sources/Base/TokenRefresher.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 public protocol TokenRefresher: Sendable {
-    var destination: Endpoint { get }
+    // TODO: destination 요구
+//    var destination: Endpoint { get }
     
-    func refresh(provider: NetworkProvider) async throws(NetworkError) -> AuthTokens
+    // TODO: refresh 요구
+//    func refresh(provider: NetworkProvider) async throws(NetworkError) -> AuthTokens
 }

--- a/Neki-iOS/Core/Sources/Network/Sources/DefaultNetworkProvider.swift
+++ b/Neki-iOS/Core/Sources/Network/Sources/DefaultNetworkProvider.swift
@@ -186,9 +186,9 @@ private extension DefaultNetworkProvider {
         }
     }
     
-    func decode<T: Decodable>(data: Data) throws -> T {
+    func decode<T: Decodable>(data: Data) throws -> BaseResponseDTO<T> {
         do {
-            return try self.decoder.decode(T.self, from: data)
+            return try self.decoder.decode(BaseResponseDTO<T>.self, from: data)
         } catch {
             Logger.network.error("❌ Decoding Error: \(error.localizedDescription)")
             throw NetworkError.responseDecodingError

--- a/Neki-iOS/Core/Sources/Network/Sources/DefaultNetworkProvider.swift
+++ b/Neki-iOS/Core/Sources/Network/Sources/DefaultNetworkProvider.swift
@@ -32,18 +32,17 @@ public final actor DefaultNetworkProvider: NetworkProvider {
     /// 네트워크 요청을 수행하고 별도의 응답 데이터 없이 성공 여부만 판단합니다.
     ///
     /// voidResponse를 수행합니다.
-    /// HTTP 200~299 상태 코드는 Void 값을 반환합니다.
-    public func request(endpoint: Endpoint) async throws {
-        let _ = try await processRequest(endpoint: endpoint, retryCount: 1)
+    @discardableResult
+    public func request(endpoint: Endpoint) async throws -> BaseResponseDTO<EmptyData> {
+        try await performRequest(endpoint: endpoint, retryCount: 1)
     }
     
     /// 네트워크 요청을 수행하고 제네릭 타입으로 응답 데이터를 디코딩합니다.
     ///
     /// decodableResponse를 수행합니다.
     /// HTTP 200~299 상태 코드는 `JSONDecoder`를 통해 `T` 타입으로 디코딩하여 반환합니다.
-    public func request<T: Decodable>(endpoint: Endpoint) async throws -> T {
-        let data = try await processRequest(endpoint: endpoint, retryCount: 1)
-        return try decode(data: data)
+    public func request<T: Decodable>(endpoint: Endpoint) async throws -> BaseResponseDTO<T> {
+        try await performRequest(endpoint: endpoint, retryCount: 1)
     }
 }
 
@@ -51,31 +50,27 @@ public final actor DefaultNetworkProvider: NetworkProvider {
 // MARK: - Core Logics
 
 private extension DefaultNetworkProvider {
-    func processRequest(endpoint: Endpoint, retryCount: Int) async throws -> Data {
+    func performRequest<T: Decodable>(endpoint: Endpoint, retryCount: Int) async throws -> BaseResponseDTO<T> {
         let request = try await buildRequest(for: endpoint)
-    
-        requestLog(request)
+        let (data, response) = try await executeSession(with: request)
         
-        let (data, response) = try await session.data(for: request, delegate: nil)
-        
-        responseLog(data: data, response: response)
-        
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw NetworkError.responseError
+        switch validateResponse(response) {
+        case .success: return try decode(data: data)
+        case .unauthorized: return try await retryWithTokenRefresh(endpoint: endpoint, retryCount: retryCount)
+        case .failure(let error): throw error
         }
-        
-        if (200..<300).contains(httpResponse.statusCode) { return data }
-        
-        return try await handleFailure(statusCode: httpResponse.statusCode, data: data, endpoint: endpoint, retryCount: retryCount)
     }
     
-    func handleFailure(statusCode: Int, data: Data, endpoint: Endpoint, retryCount: Int) async throws -> Data {
-        guard statusCode == 401 else {
-            try throwIfServerError(data: data)
-            throw mapError(statusCode: statusCode)
-        }
+    func executeSession(with request: URLRequest) async throws -> (Data, URLResponse) {
+        requestLog(request)
         
-        return try await handleUnauthorized(data: data, endpoint: endpoint, retryCount: retryCount)
+        do {
+            let (data, response) = try await session.data(for: request, delegate: nil)
+            responseLog(data: data, response: response)
+            return (data, response)
+        } catch {
+            throw NetworkError.unknownError(error)
+        }
     }
 }
 
@@ -96,34 +91,34 @@ private extension DefaultNetworkProvider {
     }
     
     func appendBearerToken(to request: URLRequest) throws -> URLRequest {
-        var request = request
+        var newRequest = request
         
         do {
             let tokens = try tokenStorage.fetch()
-            request.setValue("Bearer \(tokens.accessToken)", forHTTPHeaderField: "Authorization")
-            return request
+            newRequest.setValue("Bearer \(tokens.accessToken)", forHTTPHeaderField: "Authorization")
+            return newRequest
         } catch TokenStorageError.notFound {
             throw NetworkError.unauthorizedError
         } catch {
-            Logger.network.error("Token Fetch Error: \(error.localizedDescription)")
+            Logger.network.error("❌ Token Fetch Error: \(error.localizedDescription)")
             throw error
         }
     }
     
     func appendRefreshToken(to request: URLRequest) throws -> URLRequest {
-        var request = request
+        var newRequest = request
         
         do {
             let tokens = try tokenStorage.fetch()
             let body = ["refreshToken": tokens.refreshToken]
-            request.httpBody = try JSONEncoder().encode(body)
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            return request
+            newRequest.httpBody = try JSONEncoder().encode(body)
+            newRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            return newRequest
         } catch TokenStorageError.notFound {
             throw NetworkError.unauthorizedError
         } catch let error as EncodingError {
             Logger.network.error("❌ Encoding Error: \(error.localizedDescription)")
-            throw error
+            throw NetworkError.requestEncodingError
         } catch {
             Logger.network.error("❌ Token Fetch Error: \(error.localizedDescription)")
             throw error
@@ -135,15 +130,14 @@ private extension DefaultNetworkProvider {
 // MARK: - Auth Retry Logic
 
 private extension DefaultNetworkProvider {
-    func handleUnauthorized(data: Data, endpoint: Endpoint, retryCount: Int) async throws -> Data {
-        if endpoint.authorizationType == .reissue || retryCount <= .zero {
-            try throwIfServerError(data: data)
+    func retryWithTokenRefresh<T: Decodable>(endpoint: Endpoint, retryCount: Int) async throws -> BaseResponseDTO<T> {
+        guard endpoint.authorizationType != .reissue, retryCount > .zero else {
             try? tokenStorage.delete()
             throw NetworkError.unauthorizedError
         }
         
         try await performTokenRefresh()
-        return try await processRequest(endpoint: endpoint, retryCount: retryCount - 1)
+        return try await performRequest(endpoint: endpoint, retryCount: retryCount - 1)
     }
     
     func performTokenRefresh() async throws {
@@ -153,12 +147,19 @@ private extension DefaultNetworkProvider {
             defer { refreshTask = nil }
             
             guard let refresher = tokenRefresher else { throw NetworkError.unauthorizedError }
-            let newTokens = try await refresher.refresh(provider: self)
-            try tokenStorage.store(newTokens)
+            
+            // TODO: 토큰 재발급 후 저장 로직 필요
+//            let newToken = try await refresher.refresh(provider: self)
+//            try tokenStorage.store(newToken)
         }
         
         refreshTask = task
-        try await task.value
+        
+        do {
+            try await task.value
+        } catch {
+            throw error
+        }
     }
 }
 
@@ -166,18 +167,22 @@ private extension DefaultNetworkProvider {
 // MARK: - Validate & Decode
 
 private extension DefaultNetworkProvider {
-    func throwIfServerError(data: Data) throws {
-        guard let failureDTO = try? decoder.decode(BaseFailedResponseDTO.self, from: data) else { return }
-        throw NetworkError.apiError(failureDTO)
+    enum ResponseStatus {
+        case success
+        case unauthorized
+        case failure(NetworkError)
     }
     
-    func mapError(statusCode: Int) -> NetworkError {
-        switch statusCode {
-        case 400: return .badRequestError
-        case 401: return .unauthorizedError
-        case 404: return .notFound
-        case 500..<600: return .internalServerError
-        default: return .unknownError
+    func validateResponse(_ response: URLResponse) -> ResponseStatus {
+        guard let httpResponse = response as? HTTPURLResponse else { return .failure(.responseError) }
+        
+        switch httpResponse.statusCode {
+        case 200..<300: return .success
+        case 400: return .failure(.badRequestError)
+        case 401: return .unauthorized
+        case 404: return .failure(.notFound)
+        case 500..<600: return .failure(.internalServerError)
+        default: return .failure(.networkFail)
         }
     }
     

--- a/Neki-iOS/Features/Auth/Sources/Data/Sources/AuthTokenRefresher.swift
+++ b/Neki-iOS/Features/Auth/Sources/Data/Sources/AuthTokenRefresher.swift
@@ -8,15 +8,16 @@
 import Foundation
 
 struct AuthTokenRefresher: TokenRefresher {
-    var destination: Endpoint { AuthEndpoint.reissueToken }
+    // TODO: AuthEndpoint: Endpoint
+//    var destination: Endpoint { AuthEndpoint.reissueToken }
     
-    func refresh(provider: any NetworkProvider) async throws(NetworkError) -> AuthTokens {
-        do {
-            let tokens: AuthTokens = try await provider.request(endpoint: destination)
-            return tokens
-        } catch {
-            guard let error = error as? NetworkError else { throw .unknownError }
-            throw error
-        }
-    }
+//    func refresh(provider: any NetworkProvider) async throws(NetworkError) -> AuthTokens {
+//        do {
+//            let tokens: AuthTokens = try await provider.request(endpoint: destination)
+//            return tokens
+//        } catch {
+//            guard let error = error as? NetworkError else { throw .unknownError }
+//            throw error
+//        }
+//    }
 }


### PR DESCRIPTION
## 🌴 작업한 브랜치
- `add/#35-auth-endpoint`


## ✅ 작업한 내용
1. 토큰재발급 관련 임시코드를 주석처리 했습니다. (Endpoint 프로토콜 미준수로 인한 컴파일 에러 해소)
2. 기본응답스펙 변경에 따라 네트워킹 모델 내부 로직을 수정하고 일부 코드를 정리했습니다.


## ❗️PR Point
1. `.unknownError`일 경우 URLError라도 파악하기 위해 연관값을 받도록 했습니다.
2. `.apiError`일 경우 기본실패응답을 연관값으로 받았으나, 해당 타입이 삭제됨에 따라 단순 문자열을 받도록 했습니다.
3. 네트워킹 요청에 대한 **생성, 실행, 검증, 재시도** 4단계로 구성함은 동일하지만 내부 코드가 정리되면서 살짝 변경이 가해졌습니다. 기존 로직과 동일한 동작을 하는지 더블체크 해주시면 좋겠습니다.


## 📟 관련 이슈
- Resolved: #36 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 네트워크 오류 메시지 표현과 처리 로직 개선으로 더 명확한 오류 안내 제공
  * 인증 실패 시 재시도 흐름 개선으로 토큰 재발급 처리 안정화

* **리팩토링**
  * 네트워크 응답 처리 구조를 재정비하여 응답 디코딩 및 검증 일관성 강화
  * 일부 응답 필드 매핑 제거로 응답 해석 기준이 간소화됨

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->