### PR TITLE
[Feat] 브랜드별 QR 파싱 전략 구현 1차

### DIFF
--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Repositories/DefaultQRCodeScanRepository.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Repositories/DefaultQRCodeScanRepository.swift
@@ -1,0 +1,34 @@
+//
+//  DefaultQRCodeScanRepository.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/6/26.
+//
+
+import Foundation
+
+struct DefaultQRCodeScanRepository: QRCodeReaderRepository {
+    private let strategies: [QRCodeParsingStrategy] = [
+        HaruFilmStrategy(),
+        PhotograyStrategy(),
+        PhotoSignatureStrategy(),
+        Life4CutStrategy()
+    ]
+    
+    private let networkProvider: NetworkProvider
+    
+    init(networkProvider: NetworkProvider) {
+        self.networkProvider = networkProvider
+    }
+    
+    func parse(_ url: URL) async throws(QRParseError) -> ParsedQRResult {
+        guard let host = url.host() else { throw .invalidURL }
+        
+        for strategy in strategies {
+            guard strategy.canHandle(host: host) else { continue }
+            return try await strategy.parse(url, networkProvider: networkProvider)
+        }
+        
+        throw .unsupportedBrand
+    }
+}

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Repositories/DefaultQRCodeScanRepository.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Repositories/DefaultQRCodeScanRepository.swift
@@ -12,7 +12,8 @@ struct DefaultQRCodeScanRepository: QRCodeReaderRepository {
         HaruFilmStrategy(),
         PhotograyStrategy(),
         PhotoSignatureStrategy(),
-        Life4CutStrategy()
+        Life4CutStrategy(),
+        PhotoismStrategy()
     ]
     
     private let networkProvider: NetworkProvider

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Repositories/DefaultQRCodeScanRepository.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Repositories/DefaultQRCodeScanRepository.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct DefaultQRCodeScanRepository: QRCodeReaderRepository {
+struct DefaultQRCodeScanRepository: QRCodeScanRepository {
     private let strategies: [QRCodeParsingStrategy] = [
         HaruFilmStrategy(),
         PhotograyStrategy(),

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/HaruFilmStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/HaruFilmStrategy.swift
@@ -1,0 +1,29 @@
+//
+//  HaruFilmStrategy.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/6/26.
+//
+
+import Foundation
+
+struct HaruFilmStrategy: QRCodeParsingStrategy {
+    var strategyType: ParsingStrategyType { .native }
+    
+    func canHandle(host: String) -> Bool { PhotoBoothBrand.harufilm.hostKeywords.contains(host) }
+    
+    func parse(_ url: URL, networkProvider: NetworkProvider) async throws(QRParseError) -> ParsedQRResult {
+        guard let host = url.host else { throw .invalidURL }
+        let path = url.path()
+        let id = path.trimmingCharacters(in: ["/", "@"])
+        
+        guard id.isEmpty == false else { throw .parsingFailed }
+        guard let imageURL = URL(string: "http://\(host)/download/album/\(id)/output/output.jpg") else { throw .urlConstructionFailed }
+        do {
+            let (data, _) = try await URLSession.shared.data(from: imageURL)
+            return ParsedQRResult(brand: .harufilm, originalImage: data)
+        } catch {
+            throw .imageDownloadFailed
+        }
+    }
+}

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/HaruFilmStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/HaruFilmStrategy.swift
@@ -18,7 +18,7 @@ struct HaruFilmStrategy: QRCodeParsingStrategy {
         let id = path.trimmingCharacters(in: ["/", "@"])
         
         guard id.isEmpty == false else { throw .parsingFailed }
-        guard let imageURL = URL(string: "http://\(host)/download/album/\(id)/output/output.jpg") else { throw .urlConstructionFailed }
+        guard let imageURL = URL(string: "http://\(host)/download/album/\(id)/output/output.jpg") else { throw .urlConstructionFailed } // TODO: 미보안 도메인 예외에 추가해야함
         do {
             let (data, _) = try await URLSession.shared.data(from: imageURL)
             return ParsedQRResult(brand: .harufilm, originalImage: data)

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/HaruFilmStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/HaruFilmStrategy.swift
@@ -13,7 +13,7 @@ struct HaruFilmStrategy: QRCodeParsingStrategy {
     func canHandle(host: String) -> Bool { PhotoBoothBrand.harufilm.hostKeywords.contains(host) }
     
     func parse(_ url: URL, networkProvider: NetworkProvider) async throws(QRParseError) -> ParsedQRResult {
-        guard let host = url.host else { throw .invalidURL }
+        guard let host = url.host() else { throw .invalidURL }
         let path = url.path()
         let id = path.trimmingCharacters(in: ["/", "@"])
         

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/Life4CutStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/Life4CutStrategy.swift
@@ -1,0 +1,46 @@
+//
+//  Life4CutStrategy.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/22/26.
+//
+
+import Foundation
+
+struct Life4CutStrategy: QRCodeParsingStrategy {
+    var strategyType: ParsingStrategyType { .htmlCrawling }
+    
+    func canHandle(host: String) -> Bool { PhotoBoothBrand.life4cut.hostKeywords.contains(host) }
+    
+    func parse(_ url: URL, networkProvider: any NetworkProvider) async throws(QRParseError) -> ParsedQRResult {
+        var request = URLRequest(url: url)
+        
+        let response: URLResponse
+        do {
+            (_, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw .networkError(.networkFail)
+        }
+        
+        guard let httpResponse = response as? HTTPURLResponse,
+              let finalURL = httpResponse.url,
+              let components = URLComponents(url: finalURL, resolvingAgainstBaseURL: true),
+              let bucket = components.queryItems?.first(where: { $0.name == "bucket" })?.value,
+              let region = components.queryItems?.first(where: { $0.name == "region" })?.value,
+              let folderPath = components.queryItems?.first(where: { $0.name == "folderPath" })?.value
+        else { throw .parsingFailed }
+        
+        let imageURLString = "https://\(bucket).s3.\(region).amazonaws.com\(folderPath)/image.jpg"
+        guard let imageURL = URL(string: imageURLString) else { throw .urlConstructionFailed }
+        
+        var imageRequest = URLRequest(url: imageURL)
+        imageRequest.setValue("https://download.life4cut.net", forHTTPHeaderField: "Referer")
+        
+        do {
+            let (data, _) = try await URLSession.shared.data(for: imageRequest)
+            return ParsedQRResult(brand: .life4cut, originalImage: data)
+        } catch {
+            throw .imageDownloadFailed
+        }
+    }
+}

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/Life4CutStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/Life4CutStrategy.swift
@@ -13,7 +13,7 @@ struct Life4CutStrategy: QRCodeParsingStrategy {
     func canHandle(host: String) -> Bool { PhotoBoothBrand.life4cut.hostKeywords.contains(host) }
     
     func parse(_ url: URL, networkProvider: any NetworkProvider) async throws(QRParseError) -> ParsedQRResult {
-        var request = URLRequest(url: url)
+        let request = URLRequest(url: url)
         
         let response: URLResponse
         do {

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/MonomansionStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/MonomansionStrategy.swift
@@ -1,0 +1,62 @@
+//
+//  MonomansionStrategy.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/22/26.
+//
+
+import Foundation
+
+// TODO: 모노맨션 브랜드는 나중에 출시
+//struct MonoMansionStrategy: QRCodeParsingStrategy {
+//    var strategyType: ParsingStrategyType { .htmlCrawling }
+//    
+//    func canHandle(host: String) -> Bool {
+//        PhotoBoothBrand.monoMansion.hostKeywords.contains(host)
+//    }
+//    
+//    func parse(_ url: URL, networkProvider: NetworkProvider) async throws(QRParseError) -> ParsedQRResult {
+//        // 1. HTML 데이터 요청
+//        var request = URLRequest(url: url)
+//        // 봇 차단 방지용 헤더
+//        request.setValue("Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1", forHTTPHeaderField: "User-Agent")
+//        
+//        let data: Data
+//        do {
+//            // 현재 단계에서는 URLSession 직접 사용
+//            (data, _) = try await URLSession.shared.data(for: request)
+//        } catch {
+//            guard let urlError = error as? URLError else { throw .parsingFailed }
+//            switch urlError.code {
+//            case .notConnectedToInternet, .networkConnectionLost:
+//                throw .networkError(.networkFail)
+//            default:
+//                throw .networkError(.unknownError(urlError))
+//            }
+//        }
+//        
+//        // 2. HTML 문자열 변환
+//        guard let htmlString = String(data: data, encoding: .utf8) else {
+//            throw .parsingFailed
+//        }
+//        
+//        // 3. 정규식을 통한 이미지 URL 추출
+//        // 제공된 정규식: href\s*=\s*["'](https://[^"']*ncloudstorage\.com[^"']+\.jpg)["']
+//        // 그룹 1번(괄호 안의 내용)이 실제 URL입니다.
+//        let pattern = "href\\s*=\\s*[\"'](https://[^\"']*ncloudstorage\\.com[^\"']+\\.jpg)[\"']"
+//        
+//        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+//              let match = regex.firstMatch(in: htmlString, options: [], range: NSRange(location: 0, length: htmlString.utf16.count)),
+//              let range = Range(match.range(at: 1), in: htmlString) else {
+//            throw .parsingFailed
+//        }
+//        
+//        let imageURLString = String(htmlString[range])
+//        
+//        guard let imageURL = URL(string: imageURLString) else {
+//            throw .urlConstructionFailed
+//        }
+//        
+//        return ParsedQRResult(brand: .monoMansion, originalImageURL: imageURL)
+//    }
+//}

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/PhotograyStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/PhotograyStrategy.swift
@@ -1,0 +1,54 @@
+//
+//  PhotograyStrategy.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/11/26.
+//
+
+import Foundation
+
+struct PhotograyStrategy: QRCodeParsingStrategy {
+    var strategyType: ParsingStrategyType { .htmlCrawling }
+    
+    func canHandle(host: String) -> Bool { PhotoBoothBrand.photogray.hostKeywords.contains(host) }
+    
+    func parse(_ url: URL, networkProvider: NetworkProvider) async throws(QRParseError) -> ParsedQRResult {
+        var request = URLRequest(url: url)
+        
+        let response: URLResponse
+        do {
+            (_, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            guard let urlError = error as? URLError else { throw .parsingFailed }
+            switch urlError.code {
+            case .notConnectedToInternet, .networkConnectionLost:
+                throw .networkError(.networkFail)
+            default:
+                throw .networkError(.unknownError(urlError))
+            }
+        }
+        
+        guard let httpResponse = response as? HTTPURLResponse,
+              let finalURL = httpResponse.url,
+              let components = URLComponents(url: finalURL, resolvingAgainstBaseURL: true),
+              let idValue = components.queryItems?.first(where: { $0.name == "id" })?.value,
+              let data = Data(base64Encoded: idValue),
+              let decodedString = String(data: data, encoding: .utf8)
+        else { throw .parsingFailed }
+        
+        var dummyComponents = URLComponents()
+        dummyComponents.query = decodedString
+        
+        guard let sessionID = dummyComponents.queryItems?.first(where: { $0.name == "sessionId" })?.value else { throw .parsingFailed }
+        
+        let imageURLString = "https://pg-qr-resource.aprd.io/\(sessionID)/image.jpg"
+        guard let imageURL = URL(string: imageURLString) else { throw .urlConstructionFailed }
+        
+        do {
+            let (data, _) = try await URLSession.shared.data(from: imageURL)
+            return ParsedQRResult(brand: .photogray, originalImage: data)
+        } catch {
+            throw .imageDownloadFailed
+        }
+    }
+}

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/PhotograyStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/PhotograyStrategy.swift
@@ -13,7 +13,7 @@ struct PhotograyStrategy: QRCodeParsingStrategy {
     func canHandle(host: String) -> Bool { PhotoBoothBrand.photogray.hostKeywords.contains(host) }
     
     func parse(_ url: URL, networkProvider: NetworkProvider) async throws(QRParseError) -> ParsedQRResult {
-        var request = URLRequest(url: url)
+        let request = URLRequest(url: url)
         
         let response: URLResponse
         do {

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/PhotoismStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/PhotoismStrategy.swift
@@ -1,0 +1,16 @@
+//
+//  PhotoismStrategy.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/22/26.
+//
+
+import Foundation
+
+struct PhotoismStrategy: QRCodeParsingStrategy {
+    var strategyType: ParsingStrategyType { .webView }
+    
+    func canHandle(host: String) -> Bool { PhotoBoothBrand.photoism.hostKeywords.contains(host) }
+    
+    func parse(_ url: URL, networkProvider: any NetworkProvider) async throws(QRParseError) -> ParsedQRResult { throw .fallbackToWebView(url) }
+}

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/PhotosignatureStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/PhotosignatureStrategy.swift
@@ -1,0 +1,30 @@
+//
+//  PhotosignatureStrategy.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/22/26.
+//
+
+import Foundation
+
+struct PhotoSignatureStrategy: QRCodeParsingStrategy {
+    var strategyType: ParsingStrategyType { .native }
+    
+    func canHandle(host: String) -> Bool {
+        PhotoBoothBrand.photosignature.hostKeywords.contains(host)
+    }
+    
+    func parse(_ url: URL, networkProvider: NetworkProvider) async throws(QRParseError) -> ParsedQRResult {
+        let urlString = url.absoluteString
+        let cleanString = urlString.hasSuffix("/") ? String(urlString.dropLast()) : urlString
+        let imageURLString = cleanString + "/a.jpg"
+        
+        guard let imageURL = URL(string: imageURLString) else { throw .urlConstructionFailed }
+        do {
+            let (data, _) = try await URLSession.shared.data(from: imageURL)
+            return ParsedQRResult(brand: .photosignature, originalImage: data)
+        } catch {
+            throw .imageDownloadFailed
+        }
+    }
+}

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Interfaces/QRCodeParsingStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Interfaces/QRCodeParsingStrategy.swift
@@ -1,0 +1,15 @@
+//
+//  QRCodeParsingStrategy.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/6/26.
+//
+
+import Foundation
+
+protocol QRCodeParsingStrategy {
+    var strategyType: ParsingStrategyType { get }
+    
+    func canHandle(host: String) -> Bool
+    func parse(_ url: URL, networkProvider: NetworkProvider) async throws(QRParseError) -> ParsedQRResult
+}

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Interfaces/QRCodeScanRepository.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Interfaces/QRCodeScanRepository.swift
@@ -1,0 +1,22 @@
+//
+//  QRCodeScanRepository.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/6/26.
+//
+
+import Foundation
+
+public enum QRParseError: Error {
+    case invalidURL
+    case unsupportedBrand
+    case parsingFailed
+    case urlConstructionFailed
+    case networkError(NetworkError)
+    case imageDownloadFailed
+    case fallbackToWebView(URL)
+}
+
+public protocol QRCodeScanRepository {
+    func parse(_ url: URL) async throws(QRParseError) -> ParsedQRResult
+}

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Clients/QRCodeScannerClient.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Clients/QRCodeScannerClient.swift
@@ -12,6 +12,9 @@ import ComposableArchitecture
 struct QRScannerClient {
     var checkAuthorizationStatus: @Sendable () -> AVAuthorizationStatus
     var requestAccess: @Sendable () async -> Bool
+    // TODO: 구현 필요
+//    var parse: @Sendable (_ urlString: String) async throws -> ParsedQRResult
+//    var processImage: @Sendable (_ data: Data) async -> ImageDownsamplingProcessor.ProcessedImage?
 }
 
 extension QRScannerClient: DependencyKey {

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Entities/ParsedQRResult.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Entities/ParsedQRResult.swift
@@ -1,0 +1,18 @@
+//
+//  ParsedQRResult.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/6/26.
+//
+
+import Foundation
+
+public struct ParsedQRResult: Equatable, Sendable {
+    public let brand: PhotoBoothBrand
+    public let originalImage: Data
+    
+    public init(brand: PhotoBoothBrand, originalImage: Data) {
+        self.brand = brand
+        self.originalImage = originalImage
+    }
+}

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Entities/ParsingStrategyType.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Entities/ParsingStrategyType.swift
@@ -1,0 +1,17 @@
+//
+//  ParsingStrategyType.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/6/26.
+//
+
+import Foundation
+
+enum ParsingStrategyType {
+    /// URL 계산/조립 방식
+    case native
+    /// 웹페이지 크롤링 방식
+    case htmlCrawling
+    /// 브랜드 다운로드 페이지를 웹뷰로 표시, 다운로드 및 공유 유도 방식
+    case webView
+}

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Entities/PhotoBoothBrand+URLHosts.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Entities/PhotoBoothBrand+URLHosts.swift
@@ -1,0 +1,24 @@
+//
+//  PhotoBoothBrand+URLHosts.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/6/26.
+//
+
+import Foundation
+
+
+// MARK: - PhotoBoothBrand + URLHosts
+
+extension PhotoBoothBrand {
+    var hostKeywords: [String] {
+        switch self {
+        case .life4cut: ["life4cut.net"]
+        case .photoism: ["seobuk.kr"]
+        case .photogray: ["aprd.io", "pgshort.aprd.io"]
+        case .photosignature: ["photoqr3.kr"]
+        case .planBStudio: []
+        case .harufilm: ["haru4.mx2.co.kr", "haru3.mx2.co.kr", "haru2.mx2.co.kr", "haru1.mx2.co.kr", "haru.mx2.co.kr", "harufilm"]
+        }
+    }
+}

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Utilities/ImageDownsamplingProcessor.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Utilities/ImageDownsamplingProcessor.swift
@@ -1,0 +1,52 @@
+//
+//  ImageDownsamplingProcessor.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/22/26.
+//
+
+import UIKit
+import ImageIO
+import UniformTypeIdentifiers
+
+public struct ImageDownsamplingProcessor {
+    public struct ProcessedImage {
+        /// WebP Data
+        public let data: Data
+        /// 디코딩된 이미지
+        public let uiImage: UIImage
+    }
+    
+    /// 목표 해상도: 4096px (4K)
+    /// Presigned URL 최대 용량: 5GB
+    private static let maxDimensionInPixels: CGFloat = 4096
+    
+    nonisolated public static func process(data: Data) async -> ProcessedImage? {
+        guard let imageSource = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        let properties = CGImageSourceCopyPropertiesAtIndex(imageSource, .zero, nil) as? [CFString: Any]
+        let width = properties?[kCGImagePropertyPixelWidth] as? CGFloat ?? .zero
+        let height = properties?[kCGImagePropertyPixelHeight] as? CGFloat ?? .zero
+        let maxSide = max(width, height)
+        let shouldResize = maxSide > maxDimensionInPixels
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: shouldResize ? maxDimensionInPixels : maxSide
+        ]
+        
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(imageSource, .zero, options as CFDictionary) else { return nil }
+        let mutableData = NSMutableData()
+        
+        guard let destination = CGImageDestinationCreateWithData(mutableData, UTType.webP.identifier as CFString, 1, nil) else { return nil }
+        let webPOptions: [CFString: Any] = [
+            kCGImageDestinationLossyCompressionQuality: 0.8 // 80% 압축
+        ]
+        
+        CGImageDestinationAddImage(destination, cgImage, webPOptions as CFDictionary)
+        
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        let displayImage = UIImage(cgImage: cgImage)
+        return ProcessedImage(data: mutableData as Data, uiImage: displayImage)
+    }
+}

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Utilities/ImageDownsamplingProcessor.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Utilities/ImageDownsamplingProcessor.swift
@@ -5,7 +5,6 @@
 //  Created by SwainYun on 1/22/26.
 //
 
-import UIKit
 import ImageIO
 import UniformTypeIdentifiers
 
@@ -13,8 +12,6 @@ public struct ImageDownsamplingProcessor {
     public struct ProcessedImage {
         /// WebP Data
         public let data: Data
-        /// 디코딩된 이미지
-        public let uiImage: UIImage
     }
     
     /// 목표 해상도: 4096px (4K)
@@ -46,7 +43,6 @@ public struct ImageDownsamplingProcessor {
         CGImageDestinationAddImage(destination, cgImage, webPOptions as CFDictionary)
         
         guard CGImageDestinationFinalize(destination) else { return nil }
-        let displayImage = UIImage(cgImage: cgImage)
-        return ProcessedImage(data: mutableData as Data, uiImage: displayImage)
+        return ProcessedImage(data: mutableData as Data)
     }
 }

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Utilities/ImageDownsamplingProcessor.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Utilities/ImageDownsamplingProcessor.swift
@@ -24,12 +24,14 @@ public struct ImageDownsamplingProcessor {
         let width = properties?[kCGImagePropertyPixelWidth] as? CGFloat ?? .zero
         let height = properties?[kCGImagePropertyPixelHeight] as? CGFloat ?? .zero
         let maxSide = max(width, height)
-        let shouldResize = maxSide > maxDimensionInPixels
+        
+        let targetPixelSize: CGFloat = maxSide > .zero ? (maxSide > maxDimensionInPixels) ? maxDimensionInPixels : maxSide : maxDimensionInPixels
+        
         let options: [CFString: Any] = [
             kCGImageSourceCreateThumbnailFromImageAlways: true,
             kCGImageSourceShouldCacheImmediately: true,
             kCGImageSourceCreateThumbnailWithTransform: true,
-            kCGImageSourceThumbnailMaxPixelSize: shouldResize ? maxDimensionInPixels : maxSide
+            kCGImageSourceThumbnailMaxPixelSize: targetPixelSize
         ]
         
         guard let cgImage = CGImageSourceCreateThumbnailAtIndex(imageSource, .zero, options as CFDictionary) else { return nil }

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Features/QRCodeScanFeature.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Features/QRCodeScanFeature.swift
@@ -58,10 +58,6 @@ struct QRCodeScanFeature {
                 // TODO: QR Scanner Client에 요청하여 브랜드 별 전략이 구동될 수 있도록 해야함
                 return .none
                 
-            case let .codeScanned(urlString):
-                // TODO: 확보한 URL로 파싱
-                return .none
-                
             default:
                 return .none
             }

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Features/QRCodeScanFeature.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Features/QRCodeScanFeature.swift
@@ -11,17 +11,14 @@ import AVFoundation
 
 @Reducer
 struct QRCodeScanFeature {
-    /// QR Code 스캐너 관련 얼럿 네임스페이스
-    enum ScannerAlert {
-        case manualDownloadRequired
-    }
-    
     @ObservableState
     struct State {
         var isLightOn: Bool = false
-        var scannedURL: URL?
+        var isLoading: Bool = false
         
-        var alert: ScannerAlert?
+        var webViewURL: URL?
+        
+        var isManualDownloadNeededAlertPresented: Bool = false
     }
     
     enum Action: BindableAction {
@@ -30,14 +27,20 @@ struct QRCodeScanFeature {
         case lightButtonTapped
         case codeScanned(String)
         
+        // WebView & Alert Actions
+        case openWebViewButtonTapped(URL?)
+        case webViewImageDownloadResult(Result<Data, Error>)
+        
         // Internal Actions
-        case codeDidScan(URL?)
+        case processResult(Result<ParsedQRResult, QRParseError>)
+        case imageProcessingResult(Result<ImageDownsamplingProcessor.ProcessedImage, Never>)
         
         // Binding Actions
         case binding(BindingAction<State>)
     }
     
     @Dependency(\.dismiss) private var dismiss
+    @Dependency(\.qrScannerClient) private var qrScannerClient
     
     var body: some ReducerOf<Self> {
         BindingReducer()
@@ -52,9 +55,10 @@ struct QRCodeScanFeature {
                 return .none
                 
             case .codeScanned(let urlString):
-                return .run { send in await send(.codeDidScan(URL(string: urlString))) }
+                // TODO: QR Scanner Client에 요청하여 브랜드 별 전략이 구동될 수 있도록 해야함
+                return .none
                 
-            case .codeDidScan(let url):
+            case let .codeScanned(urlString):
                 // TODO: 확보한 URL로 파싱
                 return .none
                 

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Features/QRCodeScanFeature.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Features/QRCodeScanFeature.swift
@@ -19,6 +19,7 @@ struct QRCodeScanFeature {
         var webViewURL: URL?
         
         var isManualDownloadNeededAlertPresented: Bool = false
+        var isWebViewPresented: Bool = false
     }
     
     enum Action: BindableAction {
@@ -28,7 +29,7 @@ struct QRCodeScanFeature {
         case codeScanned(String)
         
         // WebView & Alert Actions
-        case openWebViewButtonTapped(URL?)
+        case openWebViewButtonTapped
         case webViewImageDownloadResult(Result<Data, Error>)
         
         // Internal Actions
@@ -56,6 +57,10 @@ struct QRCodeScanFeature {
                 
             case .codeScanned(let urlString):
                 // TODO: QR Scanner Client에 요청하여 브랜드 별 전략이 구동될 수 있도록 해야함
+                return .none
+                
+            case .openWebViewButtonTapped:
+                state.isWebViewPresented = true
                 return .none
                 
             default:

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Views/DownloadableWebView.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Views/DownloadableWebView.swift
@@ -1,0 +1,71 @@
+//
+//  DownloadableWebView.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/22/26.
+//
+
+import SwiftUI
+import WebKit
+
+struct DownloadableWebView: UIViewRepresentable {
+    let url: URL
+    let onDownloadCompleted: (Data) -> Void
+    let onError: (Error) -> Void
+    
+    func makeUIView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.mediaTypesRequiringUserActionForPlayback = []
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = context.coordinator
+        return webView
+    }
+    
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        guard uiView.url == nil else { return }
+        let request = URLRequest(url: url)
+        uiView.load(request)
+    }
+    
+    func makeCoordinator() -> Coordinator { Coordinator(parent: self) }
+}
+
+
+// MARK: - DownloadableWebView + Nested Types
+
+extension DownloadableWebView {
+    @MainActor
+    final class Coordinator: NSObject {
+        let parent: DownloadableWebView
+        
+        init(parent: DownloadableWebView) { self.parent = parent }
+        
+        nonisolated func downloadImage(from url: URL) async {
+            do {
+                let (data, _) = try await URLSession.shared.data(from: url)
+                await MainActor.run { parent.onDownloadCompleted(data) }
+            } catch {
+                await MainActor.run { parent.onError(error) }
+            }
+        }
+    }
+}
+
+
+// MARK: - DownloadableWebView.Coordinator + WKNavigationDelegate
+
+extension DownloadableWebView.Coordinator: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
+        guard let url = navigationAction.request.url else { return .allow }
+        let targetExtensions = ["jpg", "jpeg", "png", "heic", "webp"]
+        let fileExtension = url.pathExtension.lowercased()
+        
+        guard targetExtensions.contains(fileExtension) else { return .allow }
+        Task { await downloadImage(from: url) }
+        return .cancel
+    }
+    
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: any Error) { parent.onError(error) }
+    
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: any Error) { parent.onError(error) }
+}

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Views/QRCodeScannerView.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Views/QRCodeScannerView.swift
@@ -39,6 +39,30 @@ struct QRCodeScannerView: View {
                 
                 Spacer()
             }
+            
+            if store.isLoading {
+                Color.gray900.opacity(0.6)
+                
+                ProgressView()
+                    .controlSize(.large)
+                    .tint(.white)
+            }
+            
+            if let url = store.webViewURL {
+                webViewLayer(url: url)
+            }
+        }
+        .nekiAlert(
+            isPresented: $store.isManualDownloadNeededAlertPresented,
+            style: .plain,
+            titleMessage: "갤러리에 사진을 먼저 다운받아주세요.",
+            subTitleMessage: "해당 브랜드는 웹사이트에서 사진을 저장해야 네키에 자동으로 저장돼요.",
+            confirmText: "사진 다운로드하러 가기",
+            isProcessing: false
+        ) {
+            store.send(.openWebViewButtonTapped(store.webViewURL))
+        } onCancel: {
+            // 취소 동작 없음
         }
     }
     
@@ -74,6 +98,14 @@ struct QRCodeScannerView: View {
                 .padding(.vertical, 15)
                 .background(.ultraThinMaterial)
                 .clipShape(.circle)
+        }
+    }
+    
+    private func webViewLayer(url: URL) -> some View {
+        DownloadableWebView(url: url) { data in
+            store.send(.webViewImageDownloadResult(.success(data)))
+        } onError: { error in
+            store.send(.webViewImageDownloadResult(.failure(error)))
         }
     }
 }

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Views/QRCodeScannerView.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Views/QRCodeScannerView.swift
@@ -48,7 +48,7 @@ struct QRCodeScannerView: View {
                     .tint(.white)
             }
             
-            if let url = store.webViewURL {
+            if store.isWebViewPresented, let url = store.webViewURL {
                 webViewLayer(url: url)
             }
         }
@@ -60,7 +60,7 @@ struct QRCodeScannerView: View {
             confirmText: "사진 다운로드하러 가기",
             isProcessing: false
         ) {
-            store.send(.openWebViewButtonTapped(store.webViewURL))
+            store.send(.openWebViewButtonTapped)
         } onCancel: {
             // 취소 동작 없음
         }


### PR DESCRIPTION
## 🌴 작업한 브랜치
- `feat/#27-parsing-strategies`


## ✅ 작업한 내용

**주요 변경사항**
1. 조사된 브랜드별 파싱 전략을 구현했습니다.
2. 서로 다른 브랜드별 파싱 방법에 대하여 최대한 통일감있는 비즈니스 플로우로 이루어질 수 있도록 했습니다.
    * Native: 즉각 원본 이미지를 확보합니다.
    * HTML Crawling: 리다이렉팅 된 URL에서 원본 이미지 URL을 확보한 뒤, 원본 이미지를 요청해 얻습니다.
    * WebView: 웹뷰를 동작시켜 사용자로 하여금 이미지를 다운로드 하도록 유도하고, 원본 이미지를 확보합니다.
3. WebView 파싱 방법을 위해 WebView를 UIViewRepresentable로 구현했습니다.



## ❗️PR Point
1. 실제로 예상되는 동작과 같은지 확인하기 전입니다.
2. 뷰에서 리듀서로, 리듀서에서 클라이언트로, 클라이언트에서 레포지토리로 이어지는 비즈니스 플로우는 연결하지 않았습니다. 추후 태스크에서 진행 예정입니다.
3. 웹뷰 동작 시 디자인 가이드가 없습니다. 임시로 작업했습니다.


## 📸 스크린샷
생략합니다.


## 📟 관련 이슈
- Resolved: #27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 여러 포토부스 브랜드(HaruFilm, Photogray, PhotoSignature, Life4Cut, Photoism 등)에 대한 QR 코드 파싱 전략 추가
  * 전략 기반의 통합 파싱 흐름 및 파싱 결과(브랜드·원본 이미지) 반환 도입
  * 웹뷰에서 이미지 직접 다운로드 가능한 컴포넌트 추가(성공/오류 콜백 포함)
  * 상세한 QR 파싱 오류 타입과 이미지 다운샘플링(WebP 인코딩) 유틸 추가
  * 스캔 화면에 로딩 오버레이 및 웹뷰 연동 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->