### PR TITLE
[Fix] #63 장소 상세보기 카드가 탭바에 의해 가려지는 문제 해결

### DIFF
--- a/Neki-iOS/Core/Sources/ImagePicker/Domain/ImageUploadEntity.swift
+++ b/Neki-iOS/Core/Sources/ImagePicker/Domain/ImageUploadEntity.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ImageUploadEntity: Identifiable {
+public struct ImageUploadEntity: Identifiable, Sendable {
     public let id: UUID
     public let data: Data
     public let format: ImageFileFormat
@@ -26,7 +26,7 @@ public struct ImageUploadEntity: Identifiable {
     }
 }
 
-public enum ImageFileFormat {
+public enum ImageFileFormat: Sendable {
     case jpeg
     case png
     case webp

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
@@ -329,7 +329,8 @@ private extension NaverMapView {
             .background(.white)
             .clipShape(RoundedRectangle(cornerRadius: 20))
             .shadow(color: .gray400, radius: 8, y: 4)
-            .padding([.horizontal, .bottom])
+            .padding(.horizontal)
+            .padding(.bottom, 72)
         }
         .transition(.move(edge: .bottom))
     }


### PR DESCRIPTION
## 🌴 작업한 브랜치
- `fix/#63-map-popup-layout`


## ✅ 작업한 내용
커스텀 탭바의 높이와 간격을 계산해서 레이아웃을 변경했습니다.
탭바 높이 52 + 간격 20 = 패딩 72


## ❗️PR Point
생략합니다.


## 📸 스크린샷
노션 QA 시트로 대체합니다.

## 📟 관련 이슈
- Resolved: #63


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 이미지 업로드 엔티티 타입에 동시성 안전성 지원 추가.

* **Style**
  * 지도 상세 카드의 하단 여백 조정.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->