### PR TITLE
[Feat] 지도 컨트롤 컴포넌트 보완 및 API 연결

### DIFF
--- a/Neki-iOS.xcodeproj/project.pbxproj
+++ b/Neki-iOS.xcodeproj/project.pbxproj
@@ -419,8 +419,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Neki-iOS/Info.plist";
-				INFOPLIST_KEY_NSCameraUsageDescription = "";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "";
+				INFOPLIST_KEY_NSCameraUsageDescription = "${NSCameraUsageDescription}";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "${NSLocationWhenInUseUsageDescription}";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -467,8 +467,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Neki-iOS/Info.plist";
-				INFOPLIST_KEY_NSCameraUsageDescription = "";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "";
+				INFOPLIST_KEY_NSCameraUsageDescription = "${NSCameraUsageDescription}";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "${NSLocationWhenInUseUsageDescription}";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Neki-iOS.xcodeproj/project.pbxproj
+++ b/Neki-iOS.xcodeproj/project.pbxproj
@@ -419,8 +419,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Neki-iOS/Info.plist";
-				INFOPLIST_KEY_NSCameraUsageDescription = "${NSCameraUsageDescription}";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "${NSLocationWhenInUseUsageDescription}";
+				INFOPLIST_KEY_NSCameraUsageDescription = "";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -467,8 +467,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Neki-iOS/Info.plist";
-				INFOPLIST_KEY_NSCameraUsageDescription = "${NSCameraUsageDescription}";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "${NSLocationWhenInUseUsageDescription}";
+				INFOPLIST_KEY_NSCameraUsageDescription = "";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Neki-iOS.xcodeproj/project.pbxproj
+++ b/Neki-iOS.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		6C499D3A2F05594E006BE1DB /* Exceptions for "Neki-iOS" folder in "Neki-iOS" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
-				Features/Map/Sources/Data/Sources/.gitkeep,
 				Info.plist,
 			);
 			target = 6C4998DC2EF7EF62006BE1DB /* Neki-iOS */;

--- a/Neki-iOS/Core/Sources/Network/Sources/Base/Endpoint.swift
+++ b/Neki-iOS/Core/Sources/Network/Sources/Base/Endpoint.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import os
 
 /// 인증 타입
 public enum AuthorizationType {
@@ -42,6 +43,14 @@ public protocol Endpoint {
 }
 
 extension Endpoint {
+    public var baseURL: String {
+        guard let baseURLString = Bundle.main.infoDictionary?["BASE_URL"] as? String else {
+            Logger.data.fault("Base URL not found in Bundle")
+            fatalError()
+        }
+        return baseURLString
+    }
+    
     public var queryParameters: [String: String]? { nil }
     
     public var multipartItems: [MultipartItem]? { nil }

--- a/Neki-iOS/Features/Map/Sources/Data/Sources/DTOs/FetchNearbyPhotoBoothsDTO.swift
+++ b/Neki-iOS/Features/Map/Sources/Data/Sources/DTOs/FetchNearbyPhotoBoothsDTO.swift
@@ -13,7 +13,14 @@ enum FetchNearbyPhotoBoothsDTO {
         let longitude: Double
         let latitude: Double
         let radiusInMeters: Int
-        let brandIDs: [Int] = []
+        let brandIDs: [Int]
+        
+        init(longitude: Double, latitude: Double, radiusInMeters: Int, brandIDs: [Int] = []) {
+            self.longitude = longitude
+            self.latitude = latitude
+            self.radiusInMeters = radiusInMeters
+            self.brandIDs = brandIDs
+        }
         
         enum CodingKeys: String, CodingKey {
             case longitude, latitude, radiusInMeters

--- a/Neki-iOS/Features/Map/Sources/Data/Sources/DTOs/FetchNearbyPhotoBoothsDTO.swift
+++ b/Neki-iOS/Features/Map/Sources/Data/Sources/DTOs/FetchNearbyPhotoBoothsDTO.swift
@@ -1,0 +1,31 @@
+//
+//  FetchNearbyPhotoBoothsDTO.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/26/26.
+//
+
+import Foundation
+
+/// 특정 좌표 기준 반경 내 포토부스 조회
+enum FetchNearbyPhotoBoothsDTO {
+    struct Request: Encodable {
+        let longitude: Double
+        let latitude: Double
+        let radiusInMeters: Int
+        let brandIDs: [Int] = []
+        
+        enum CodingKeys: String, CodingKey {
+            case longitude, latitude, radiusInMeters
+            case brandIDs = "brandIds"
+        }
+    }
+    
+    struct Response: Decodable {
+        let photoBooths: [PhotoBoothDTO]
+        
+        enum CodingKeys: String, CodingKey {
+            case photoBooths = "items"
+        }
+    }
+}

--- a/Neki-iOS/Features/Map/Sources/Data/Sources/DTOs/FetchPhotoBoothsDTO.swift
+++ b/Neki-iOS/Features/Map/Sources/Data/Sources/DTOs/FetchPhotoBoothsDTO.swift
@@ -1,0 +1,39 @@
+//
+//  FetchPhotoBoothsDTO.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/26/26.
+//
+
+import Foundation
+
+/// 지도 영역 내 포토부스 조회
+enum FetchPhotoBoothsDTO {
+    struct Request: Encodable {
+        /// 좌상단부터 시계방향으로 5개의 꼭짓점으로 표현된 영역
+        let coordinates: [GeographicCoordinate]
+        let brandIDs: [Int] = []
+        
+        enum CodingKeys: String, CodingKey {
+            case coordinates
+            case brandIDs = "brandIds"
+        }
+        
+        init(bounds: GeographicBoundingBox) {
+            let topLeft = GeographicCoordinate(latitude: bounds.maxLatitude, longitude: bounds.minLongitude)
+            let topRight = GeographicCoordinate(latitude: bounds.maxLatitude, longitude: bounds.maxLongitude)
+            let bottomRight = GeographicCoordinate(latitude: bounds.minLatitude, longitude: bounds.maxLongitude)
+            let bottomLeft = GeographicCoordinate(latitude: bounds.minLatitude, longitude: bounds.minLongitude)
+            self.coordinates = [topLeft, topRight, bottomRight, bottomLeft, topLeft]
+        }
+    }
+    
+    struct Response: Decodable {
+        let photoBooths: [PhotoBoothDTO]
+        
+        enum CodingKeys: String, CodingKey {
+            case photoBooths = "items"
+        }
+    }
+}
+

--- a/Neki-iOS/Features/Map/Sources/Data/Sources/DTOs/FetchPhotoBrandsDTO.swift
+++ b/Neki-iOS/Features/Map/Sources/Data/Sources/DTOs/FetchPhotoBrandsDTO.swift
@@ -1,0 +1,12 @@
+//
+//  FetchPhotoBrandsDTO.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/26/26.
+//
+
+import Foundation
+
+enum FetchPhotoBrandsDTO {
+    typealias Response = [PhotoBoothBrandDTO]
+}

--- a/Neki-iOS/Features/Map/Sources/Data/Sources/DTOs/PhotoBoothBrandDTO.swift
+++ b/Neki-iOS/Features/Map/Sources/Data/Sources/DTOs/PhotoBoothBrandDTO.swift
@@ -1,0 +1,34 @@
+//
+//  PhotoBoothBrandDTO.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/26/26.
+//
+
+import Foundation
+
+struct PhotoBoothBrandDTO: Decodable {
+    let id: Int
+    let brandName: String
+    let brandNameEnglish: String
+    let imageURL: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case brandName = "name"
+        case brandNameEnglish = "code"
+        case imageURL = "imageUrl"
+    }
+    
+    func toEntity() -> PhotoBoothBrand? {
+        switch brandName {
+        case "플랜비 스튜디오": return .planBStudio
+        case "하루필름": return .harufilm
+        case "포토시그니처": return .photosignature
+        case "포토그레이": return .photogray
+        case "인생네컷": return .life4cut
+        case "포토이즘": return .photoism
+        default: return nil
+        }
+    }
+}

--- a/Neki-iOS/Features/Map/Sources/Data/Sources/DTOs/PhotoBoothDTO.swift
+++ b/Neki-iOS/Features/Map/Sources/Data/Sources/DTOs/PhotoBoothDTO.swift
@@ -1,0 +1,24 @@
+//
+//  PhotoBoothDTO.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/26/26.
+//
+
+import Foundation
+
+struct PhotoBoothDTO: Decodable {
+    let id: Int
+    let brandName: String
+    let branchName: String
+    let address: String
+    let longitude: Double
+    let latitude: Double
+    let nearbyDistance: Int?
+    
+    enum CodingKeys: String, CodingKey {
+        case id, address, longitude, latitude, brandName, branchName
+        case nearbyDistance = "distance"
+    }
+}
+

--- a/Neki-iOS/Features/Map/Sources/Data/Sources/DefaultPhotoBoothRepository.swift
+++ b/Neki-iOS/Features/Map/Sources/Data/Sources/DefaultPhotoBoothRepository.swift
@@ -165,4 +165,17 @@ extension DefaultPhotoBoothRepository: PhotoBoothRepository {
         continuation.onTermination = { _ in task.cancel() }
         return stream
     }
+    
+    func readNearbyPhotoBooths(coordinate: GeographicCoordinate) async throws -> [PhotoBooth] {
+        let brands = try await ensureBrandsLoaded()
+        let defaultRadius: Int = 1000
+        let requestDTO = FetchNearbyPhotoBoothsDTO.Request(longitude: coordinate.longitude, latitude: coordinate.latitude, radiusInMeters: defaultRadius)
+        let endpoint = MapEndpoint.point(dto: requestDTO)
+        let responseDTO: BaseResponseDTO<FetchNearbyPhotoBoothsDTO.Response> = try await networkProvider.request(endpoint: endpoint)
+        let photoBooths = responseDTO.data?.photoBooths.compactMap { dto -> PhotoBooth? in
+            guard let brand = brands[dto.brandName] else { return nil }
+            return PhotoBooth(id: dto.id, brand: brand, name: dto.branchName, coordinate: .init(latitude: dto.latitude, longitude: dto.longitude), address: dto.address, nearbyDistance: dto.nearbyDistance)
+        } ?? []
+        return photoBooths
+    }
 }

--- a/Neki-iOS/Features/Map/Sources/Data/Sources/DefaultPhotoBoothRepository.swift
+++ b/Neki-iOS/Features/Map/Sources/Data/Sources/DefaultPhotoBoothRepository.swift
@@ -1,0 +1,168 @@
+//
+//  DefaultPhotoBoothRepository.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/26/26.
+//
+
+import Foundation
+import CoreLocation
+import Dependencies
+import DependenciesMacros
+import os
+
+private enum TileSystem {
+    static let defaultZoomLevel: Int = 15
+    
+    /// 특정 Bounds(화면 영역)에 걸쳐 있는 모든 Tile 리스트를 계산합니다.
+    static func getTiles(in bounds: GeographicBoundingBox, zoom: Int = defaultZoomLevel) -> [MapTile] {
+        let minTile = convert(coordinate: .init(latitude: bounds.maxLatitude, longitude: bounds.minLongitude), zoom: zoom)
+        let maxTile = convert(coordinate: .init(latitude: bounds.minLatitude, longitude: bounds.maxLongitude), zoom: zoom)
+        
+        var tiles: [MapTile] = []
+        for x in minTile.x...maxTile.x {
+            for y in minTile.y...maxTile.y {
+                tiles.append(MapTile(x: x, y: y, z: zoom))
+            }
+        }
+        return tiles
+    }
+    
+    /// 단일 좌표를 타일 좌표로 변환합니다.
+    static func convert(coordinate: GeographicCoordinate, zoom: Int) -> MapTile {
+        let n = pow(2.0, Double(zoom))
+        let x = Int((coordinate.longitude + 180.0) / 360.0 * n)
+        
+        let latRad = coordinate.latitude * .pi / 180.0
+        let y = Int((1.0 - log(tan(latRad) + 1.0 / cos(latRad)) / .pi) / 2.0 * n)
+        
+        return MapTile(x: x, y: y, z: zoom)
+    }
+    
+    /// 타일 하나가 커버하는 지리적 영역(BoundingBox)을 계산합니다.
+    static func getBoundingBox(for tile: MapTile) -> GeographicBoundingBox {
+        let n = pow(2.0, Double(tile.z))
+        
+        let west = Double(tile.x) / n * 360.0 - 180.0
+        let east = Double(tile.x + 1) / n * 360.0 - 180.0
+        
+        let northRad = atan(sinh(.pi * (1.0 - 2.0 * Double(tile.y) / n)))
+        let southRad = atan(sinh(.pi * (1.0 - 2.0 * Double(tile.y + 1) / n)))
+        
+        let north = northRad * 180.0 / .pi
+        let south = southRad * 180.0 / .pi
+        
+        return GeographicBoundingBox(minLatitude: south, minLongitude: west, maxLatitude: north, maxLongitude: east)
+    }
+}
+
+public final actor DefaultPhotoBoothRepository {
+    typealias BrandID = String
+    
+    @Dependency(\.networkProvider) private var networkProvider
+    
+    private var cache: [MapTile: [PhotoBooth]] = [:]
+    private var brandMap: [BrandID: PhotoBoothBrand]?
+    private var brandFetchTask: Task<[BrandID: PhotoBoothBrand], Error>?
+    
+    public init() {}
+    
+    private func ensureBrandsLoaded() async throws -> [BrandID: PhotoBoothBrand] {
+        if let existingMap = brandMap { return existingMap }
+        
+        if let existingTask = brandFetchTask { return try await existingTask.value }
+        
+        let task = Task<[BrandID: PhotoBoothBrand], Error> {
+            let endpoint = MapEndpoint.fetchBrands
+            let responseDTO: BaseResponseDTO<FetchPhotoBrandsDTO.Response> = try await networkProvider.request(endpoint: endpoint)
+            return responseDTO.data?.reduce(into: [:]) { $0[$1.brandName] = $1.toEntity() } ?? [:]
+        }
+        
+        brandFetchTask = task
+        
+        do {
+            let map = try await task.value
+            brandMap = map
+            brandFetchTask = nil
+            return map
+        } catch {
+            brandFetchTask = nil
+            throw error
+        }
+    }
+}
+
+
+// MARK: - DefaultPhotoBoothRepository + PhotoBoothRepository
+
+extension DefaultPhotoBoothRepository: PhotoBoothRepository {
+    func readPhotoBooths(in bounds: GeographicBoundingBox) -> AsyncStream<[PhotoBooth]> {
+        let (stream, continuation) = AsyncStream<[PhotoBooth]>.makeStream()
+        let task = Task {
+            do {
+                try Task.checkCancellation()
+
+                let brands = try await ensureBrandsLoaded()
+                
+                try Task.checkCancellation()
+                
+                let requiredTiles = TileSystem.getTiles(in: bounds)
+                let missingTiles = requiredTiles.filter { cache[$0] == nil }
+                
+                var cachedBooths: [PhotoBooth] = []
+                for tile in requiredTiles {
+                    if let cached = cache[tile] {
+                        cachedBooths.append(contentsOf: cached)
+                    }
+                }
+                
+                if !cachedBooths.isEmpty {
+                    continuation.yield(cachedBooths)
+                }
+                
+                if !missingTiles.isEmpty {
+                    try Task.checkCancellation()
+                    
+                    try await withThrowingTaskGroup(of: (MapTile, [PhotoBooth]).self) { group in
+                        for tile in missingTiles {
+                            group.addTask { [networkProvider] in
+                                try Task.checkCancellation()
+                                
+                                let tileBounds = TileSystem.getBoundingBox(for: tile)
+                                let requestDTO = FetchPhotoBoothsDTO.Request(bounds: tileBounds)
+                                let endpoint = MapEndpoint.polygon(dto: requestDTO)
+                                let responseDTO: BaseResponseDTO<FetchPhotoBoothsDTO.Response> = try await networkProvider.request(endpoint: endpoint)
+                                let photoBooths = responseDTO.data?.photoBooths.compactMap { dto -> PhotoBooth? in
+                                    guard let brand = brands[dto.brandName] else {
+                                        Logger.data.error("Brand Mapping Failed: '\(dto.brandName)' not found in brand keys: \(brands.keys)")
+                                        return nil
+                                    }
+                                    return PhotoBooth(id: dto.id, brand: brand, name: dto.branchName, coordinate: .init(latitude: dto.latitude, longitude: dto.longitude), address: dto.address, nearbyDistance: dto.nearbyDistance)
+                                } ?? []
+                                
+                                return (tile, photoBooths)
+                            }
+                        }
+                        
+                        for try await (tile, booths) in group {
+                            self.cache[tile] = booths
+                            continuation.yield(booths)
+                        }
+                    }
+                }
+                
+                continuation.finish()
+                
+            } catch is CancellationError {
+                Logger.data.debug("Fetching photoBooths stream is cancelled.")
+                continuation.finish()
+            } catch {
+                Logger.data.error("POI Stream error: \(error)")
+                continuation.finish()
+            }
+        }
+        
+        continuation.onTermination = { _ in task.cancel() }
+        return stream
+    }
+}

--- a/Neki-iOS/Features/Map/Sources/Data/Sources/MapEndpoint.swift
+++ b/Neki-iOS/Features/Map/Sources/Data/Sources/MapEndpoint.swift
@@ -1,0 +1,50 @@
+//
+//  MapEndpoint.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/26/26.
+//
+
+import Foundation
+
+enum MapEndpoint {
+    case polygon(dto: FetchPhotoBoothsDTO.Request)
+    case point(dto: FetchNearbyPhotoBoothsDTO.Request)
+    case fetchBrands
+}
+
+
+// MARK: - MapEndpoint + Endpoint
+
+extension MapEndpoint: Endpoint {
+    var authorizationType: AuthorizationType { .bearer }
+    
+    var contentType: HTTPContentType {
+        switch self {
+        case .polygon, .point, .fetchBrands: return .json
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .polygon: return "/photo-booths/polygon"
+        case .point: return "/photo-booths/point"
+        case .fetchBrands: return "/photo-booths/brand"
+        }
+    }
+    
+    var method: HTTPMethodType {
+        switch self {
+        case .polygon, .point: return .post
+        case .fetchBrands: return .get
+        }
+    }
+    
+    var body: (any Encodable)? {
+        switch self {
+        case let .polygon(dto): return dto
+        case let .point(dto): return dto
+        case .fetchBrands: return nil
+        }
+    }
+}

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Clients/MapClient.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Clients/MapClient.swift
@@ -42,7 +42,7 @@ extension MapClient {
         var authStatusContinuation: AsyncStream<CLAuthorizationStatus>.Continuation?
         var sdkAuthStatusContinuation: AsyncStream<Bool>.Continuation?
         var locationContinuation: CheckedContinuation<CLLocation, Error>?
-        var trackingContinuation: AsyncStream<CLLocation>.Continuation?
+        var trackingContinuations: [UUID: AsyncStream<CLLocation>.Continuation] = [:]
         
         override init() {
             super.init()
@@ -67,16 +67,14 @@ extension MapClient {
             locationManager.requestLocation()
         }
         
-        func startMonitoring(_ continuation: AsyncStream<CLLocation>.Continuation) {
-            trackingContinuation?.finish()
-            trackingContinuation = continuation
-            locationManager.startUpdatingLocation()
+        func startMonitoring(id: UUID, _ continuation: AsyncStream<CLLocation>.Continuation) {
+            if trackingContinuations.isEmpty { locationManager.startUpdatingLocation() }
+            trackingContinuations[id] = continuation
         }
         
-        func stopMonitoring() {
-            trackingContinuation?.finish()
-            trackingContinuation = nil
-            locationManager.stopUpdatingLocation()
+        func stopMonitoring(id: UUID) {
+            trackingContinuations[id] = nil
+            if trackingContinuations.isEmpty { locationManager.stopUpdatingLocation() }
         }
     }
 }
@@ -105,7 +103,9 @@ extension MapClient.MapDelegate: CLLocationManagerDelegate {
                 self.locationContinuation = nil
             }
             
-            trackingContinuation?.yield(latestLocation)
+            for continuation in trackingContinuations.values {
+                continuation.yield(latestLocation)
+            }
         }
     }
     
@@ -113,6 +113,9 @@ extension MapClient.MapDelegate: CLLocationManagerDelegate {
         Task { @MainActor in
             locationContinuation?.resume(throwing: error)
             locationContinuation = nil
+            
+            guard trackingContinuations.isEmpty == false else { return }
+            Logger.domain.error("Location Update Failed: \(error.localizedDescription)")
         }
     }
 }
@@ -124,12 +127,16 @@ extension MapClient.MapDelegate: NMFAuthManagerDelegate {
     nonisolated func authorized(_ state: NMFAuthState, error: Error?) {
         Task { @MainActor in
             if let error = error {
-                // TODO: 네이버 지도 설정 에러 로그하기
+                Logger.domain.error("Naver Map Auth Failed: \(error.localizedDescription)")
                 sdkAuthStatusContinuation?.yield(false)
                 return
             }
             
-            guard case .authorized = state else { sdkAuthStatusContinuation?.yield(false); return }
+            guard case .authorized = state else {
+                Logger.domain.warning("Naver Map Auth State: \(String(describing: state))")
+                sdkAuthStatusContinuation?.yield(false)
+                return
+            }
             sdkAuthStatusContinuation?.yield(true)
         }
     }
@@ -185,13 +192,15 @@ extension MapClient: DependencyKey {
             }
         } trackingLocation: {
             AsyncStream { continuation in
+                let observerID = UUID()
+                
                 Task { @MainActor in
-                    sharedDelegate.startMonitoring(continuation)
+                    sharedDelegate.startMonitoring(id: observerID, continuation)
                 }
                 
                 continuation.onTermination = { _ in
                     Task { @MainActor in
-                        sharedDelegate.stopMonitoring()
+                        sharedDelegate.stopMonitoring(id: observerID)
                     }
                 }
             }

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Clients/MapClient.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Clients/MapClient.swift
@@ -9,6 +9,17 @@ import Foundation
 import CoreLocation
 import ComposableArchitecture
 import NMapsMap
+import os
+
+public struct MapClientConfiguration: Equatable, Sendable {
+    public var distanceFilter: CLLocationDistance
+    public var desiredAccuracy: CLLocationAccuracy
+    
+    public init(distanceFilter: CLLocationDistance = 10, desiredAccuracy: CLLocationAccuracy = kCLLocationAccuracyNearestTenMeters) {
+        self.distanceFilter = distanceFilter
+        self.desiredAccuracy = desiredAccuracy
+    }
+}
 
 @DependencyClient
 public struct MapClient {
@@ -17,6 +28,7 @@ public struct MapClient {
     var checkSDKAuthorizationStatus: @Sendable () async -> AsyncStream<Bool> = { .finished }
     var getCurrentLocation: @Sendable () async throws -> CLLocation
     var trackingLocation: @Sendable () async -> AsyncStream<CLLocation> = { .finished }
+    var configure: @Sendable (MapClientConfiguration) async -> Void
 }
 
 
@@ -38,6 +50,11 @@ extension MapClient {
             locationManager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
             locationManager.distanceFilter = 10
             NMFAuthManager.shared().delegate = self
+        }
+        
+        func updateConfiguration(_ config: MapClientConfiguration) {
+            locationManager.desiredAccuracy = config.desiredAccuracy
+            locationManager.distanceFilter = config.distanceFilter
         }
         
         func requestLocation(_ continuation: CheckedContinuation<CLLocation, Error>) {
@@ -178,6 +195,10 @@ extension MapClient: DependencyKey {
                     }
                 }
             }
+        } configure: { config in
+            await Task { @MainActor in
+                sharedDelegate.updateConfiguration(config)
+            }.value
         }
     }()
 }

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Clients/PhotoBoothClient.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Clients/PhotoBoothClient.swift
@@ -12,6 +12,8 @@ import ComposableArchitecture
 public struct PhotoBoothClient {
     /// 지도 영역(bounds) 내의 포토부스 데이터를 가져옵니다.
     public var fetchPhotoBooths: @Sendable (_ bounds: GeographicBoundingBox) async throws -> AsyncStream<[PhotoBooth]>
+    /// 중심 좌표 주변 거리순으로 포토부스 데이터를 가져옵니다.
+    public var fetchNearbyPhotoBooths: @Sendable (_ coordinate: GeographicCoordinate) async throws -> [PhotoBooth]
 }
 
 
@@ -23,6 +25,8 @@ extension PhotoBoothClient: DependencyKey {
         
         return PhotoBoothClient { bounds in
             await photoBoothRepository.readPhotoBooths(in: bounds)
+        } fetchNearbyPhotoBooths: { coordinate in
+            try await photoBoothRepository.readNearbyPhotoBooths(coordinate: coordinate)
         }
     }()
 }

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Clients/PhotoBoothClient.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Clients/PhotoBoothClient.swift
@@ -11,30 +11,20 @@ import ComposableArchitecture
 @DependencyClient
 public struct PhotoBoothClient {
     /// 지도 영역(bounds) 내의 포토부스 데이터를 가져옵니다.
-    public var fetchPhotoBooths: @Sendable (_ bounds: GeographicBoundingBox) async throws -> [PhotoBooth]
+    public var fetchPhotoBooths: @Sendable (_ bounds: GeographicBoundingBox) async throws -> AsyncStream<[PhotoBooth]>
 }
 
 
 // MARK: - PhotoBoothClient + DependencyKey
 
 extension PhotoBoothClient: DependencyKey {
-    public static let liveValue = Self { bounds in
-        try await Task.sleep(nanoseconds: 500_000_000)
+    public static let liveValue: Self = {
+        @Dependency(\.photoBoothRepository) var photoBoothRepository
         
-        let filteredBooths = fixedMockBooths.filter { booth in
-            bounds.contains(booth.coordinate)
+        return PhotoBoothClient { bounds in
+            await photoBoothRepository.readPhotoBooths(in: bounds)
         }
-        
-        return filteredBooths
-    }
-    
-    public static let testValue = Self()
-    
-    public static let previewValue = Self { bounds in
-        return fixedMockBooths.filter { booth in
-            bounds.contains(booth.coordinate)
-        }
-    }
+    }()
 }
 
 
@@ -45,19 +35,4 @@ public extension DependencyValues {
         get { self[PhotoBoothClient.self] }
         set { self[PhotoBoothClient.self] = newValue }
     }
-}
-
-
-// MARK: - PhotoBoothClient + Mock
-
-extension PhotoBoothClient {
-    private static let fixedMockBooths: [PhotoBooth] = [
-        .init(id: UUID(), brand: .life4cut, name: "인생네컷 강남점", coordinate: .init(latitude: 37.4981, longitude: 127.0276), address: "서울 강남구 1"),
-        .init(id: UUID(), brand: .harufilm, name: "하루필름 역삼점", coordinate: .init(latitude: 37.4991, longitude: 127.0286), address: "서울 강남구 2"),
-        .init(id: UUID(), brand: .photoism, name: "포토이즘 강남CGV점", coordinate: .init(latitude: 37.5015, longitude: 127.0260), address: "서울 강남구 3"),
-        .init(id: UUID(), brand: .photogray, name: "포토그레이 신논현점", coordinate: .init(latitude: 37.5038, longitude: 127.0241), address: "서울 강남구 4"),
-        .init(id: UUID(), brand: .planBStudio, name: "플랜비 강남역점", coordinate: .init(latitude: 37.4970, longitude: 127.0250), address: "서울 강남구 5"),
-        .init(id: UUID(), brand: .life4cut, name: "인생네컷 서초점", coordinate: .init(latitude: 37.4950, longitude: 127.0290), address: "서울 서초구 1"),
-        .init(id: UUID(), brand: .photosignature, name: "포토시그니처 뱅뱅사거리점", coordinate: .init(latitude: 37.4890, longitude: 127.0300), address: "서울 강남구 6")
-    ]
 }

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/GeographicBoundingBox.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/GeographicBoundingBox.swift
@@ -13,6 +13,8 @@ public struct GeographicBoundingBox: Equatable, Sendable {
     let maxLatitude: Double
     let maxLongitude: Double
     
+    var center: GeographicCoordinate { .init(latitude: (minLatitude + maxLatitude) / 2, longitude: (minLongitude + maxLongitude) / 2) }
+    
     init(minLatitude: Double, minLongitude: Double, maxLatitude: Double, maxLongitude: Double) {
         precondition(GeographicLimit.isValidLatitude(minLatitude), "최소 위도\(minLatitude)는 유효하지 않습니다.")
         precondition(GeographicLimit.isValidLatitude(maxLatitude), "최대 위도\(maxLatitude)는 유효하지 않습니다.")

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/GeographicCoordinate.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/GeographicCoordinate.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct GeographicCoordinate: Hashable, Sendable {
+public struct GeographicCoordinate: Hashable, Sendable, Encodable {
     /// 위도 (가로선)
     public let latitude: Double
     /// 경도 (세로선)

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/MapTile.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/MapTile.swift
@@ -1,0 +1,19 @@
+//
+//  MapTile.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/26/26.
+//
+
+import Foundation
+
+public struct MapTile: Equatable, Hashable, Sendable {
+    public static let kDefaultZoomLevel: Int = 15
+    public let x, y, z: Int
+    
+    public init(x: Int, y: Int, z: Int = kDefaultZoomLevel) {
+        self.x = x
+        self.y = y
+        self.z = z
+    }
+}

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/PhotoBooth.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/PhotoBooth.swift
@@ -8,20 +8,22 @@
 import Foundation
 
 /// 포토부스 지점 정보
-public struct PhotoBooth: Identifiable, Sendable, Equatable {
-    public let id: UUID
+public struct PhotoBooth: Identifiable, Sendable, Equatable, Hashable {
+    public let id: Int
     public let brand: PhotoBoothBrand
     public let name: String
     public let coordinate: GeographicCoordinate
     public let address: String
+    public let nearbyDistance: Int?
     public let detailInformationURL: URL?
     
     public init(
-        id: UUID,
+        id: Int,
         brand: PhotoBoothBrand,
         name: String,
         coordinate: GeographicCoordinate,
         address: String,
+        nearbyDistance: Int? = nil,
         detailInformationURL: URL? = nil
     ) {
         self.id = id
@@ -29,6 +31,7 @@ public struct PhotoBooth: Identifiable, Sendable, Equatable {
         self.name = name
         self.coordinate = coordinate
         self.address = address
+        self.nearbyDistance = nearbyDistance
         self.detailInformationURL = detailInformationURL
     }
 }

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Extensions/Foundation/Int.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Extensions/Foundation/Int.swift
@@ -1,0 +1,20 @@
+//
+//  Int.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 1/28/26.
+//
+
+import Foundation
+
+public extension Int {
+    var distanceString: String {
+        guard self > 1000 else { return "\(self)m" }
+        let km = Double(self) / 1000.0
+        let formatter = NumberFormatter()
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 1
+        let value = formatter.string(from: NSNumber(value: km)) ?? "\(km)"
+        return "\(value)km"
+    }
+}

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Interfaces/PhotoBoothRepository.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Interfaces/PhotoBoothRepository.swift
@@ -13,6 +13,11 @@ protocol PhotoBoothRepository {
     /// - Parameter bounds: 조회 시점의 지리적 영역
     /// - Returns: 해당 영역 내의 포토부스 배열 스트림
     func readPhotoBooths(in bounds: GeographicBoundingBox) async -> AsyncStream<[PhotoBooth]>
+    
+    /// 기준 좌표에서 거리순으로 포토부스 목록을 가져옵니다.
+    /// - Parameter coordinate: 기준 좌표
+    /// - Returns: 거리순으로 정렬된 포토부스 배열
+    func readNearbyPhotoBooths(coordinate: GeographicCoordinate) async throws -> [PhotoBooth]
 }
 
 private enum PhotoBoothRepositoryKey: DependencyKey {

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Interfaces/PhotoBoothRepository.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Interfaces/PhotoBoothRepository.swift
@@ -6,10 +6,24 @@
 //
 
 import Foundation
+import Dependencies
 
 protocol PhotoBoothRepository {
     /// 특정 지도 영역 내의 포토부스 목록을 가져옵니다.
     /// - Parameter bounds: 조회 시점의 지리적 영역
-    /// - Returns: 해당 영역 내의 포토부스 배열
-    func readPhotoBooths(in bounds: GeographicBoundingBox) async throws -> [PhotoBooth]
+    /// - Returns: 해당 영역 내의 포토부스 배열 스트림
+    func readPhotoBooths(in bounds: GeographicBoundingBox) async -> AsyncStream<[PhotoBooth]>
+}
+
+private enum PhotoBoothRepositoryKey: DependencyKey {
+    static let liveValue: PhotoBoothRepository = {
+        DefaultPhotoBoothRepository()
+    }()
+}
+
+extension DependencyValues {
+    var photoBoothRepository: PhotoBoothRepository {
+        get { self[PhotoBoothRepositoryKey.self] }
+        set {self[PhotoBoothRepositoryKey.self] = newValue }
+    }
 }

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
@@ -12,11 +12,6 @@ import os
 
 @Reducer
 public struct MapFeature {
-    private enum Constants {
-        /// 재검색 버튼 노출 기준 거리: 2Km
-        static let searchTriggerDistanceThreshold: Double = 2000.0
-    }
-    
     enum SheetStage {
         case first, second, third, photoBoothSelected
         
@@ -36,13 +31,13 @@ public struct MapFeature {
         var isSDKAuthSuccessful: Bool = false
         var detent: NekiSheetDetent = SheetStage.first.detent
         var isSearchHereButtonVisible: Bool = false
+        var isFirstLoad: Bool = true
         
         // Map State
         var cameraPosition: GeographicCoordinate?
         var currentBounds: GeographicBoundingBox?
-        var lastFetchedLocation: GeographicCoordinate?
         
-        // User Location & Tracking
+        // User Location
         var locationAuthorizationStatus: CLAuthorizationStatus = .notDetermined
         var userLocation: CLLocation?
         var isUserTrackingMode: Bool = false
@@ -52,6 +47,7 @@ public struct MapFeature {
         // Data
         var photoBooths: IdentifiedArrayOf<PhotoBooth> = []
         var visiblePhotoBooths: IdentifiedArrayOf<PhotoBooth> = []
+        
         var selectedBooth: PhotoBooth?
         var directionSheetPhotoBooth: PhotoBooth?
         
@@ -72,23 +68,30 @@ public struct MapFeature {
         case didTapDirectionAppsButton
         case didTapSearchHereButton
         
-        // Internal Actions
+        // Internal Logic Actions
         case updateLocationAuthorization(CLAuthorizationStatus)
         case updateSDKAuthStatus(Bool)
         case updateUserLocation(Result<CLLocation, Error>)
         case setUserTrackingMode(Bool)
         case didDetectMapInteraction
-        case photoBoothChunkLoaded([PhotoBooth])
-        case photoBoothStreamFinished
-        case photoBoothStreamFailure(Error)
+        
+        // Map Logic Actions
         case cameraMotionStarted
         case cameraMotionEnded(GeographicBoundingBox)
         case updateSearchButtonVisibility(isVisible: Bool)
         
-        // Binding Action
-        case binding(BindingAction<State>)
+        // Data Handling Actions
+        case fetchPhotoBooths(bounds: GeographicBoundingBox)
+        case photoBoothChunkLoaded([PhotoBooth])
+        case photoBoothStreamFinished
+        case photoBoothStreamFailure(Error)
         
-        // Child Actions
+        /// 비동기 계산: 브랜드 필터링 (Pruning 로직 삭제됨)
+        case startBackgroundCalculation
+        case didFinishBackgroundCalculation(visible: IdentifiedArrayOf<PhotoBooth>)
+        
+        // Binding & Child
+        case binding(BindingAction<State>)
         case photoBoothListAction(PhotoBoothListFeature.Action)
     }
     
@@ -97,7 +100,7 @@ public struct MapFeature {
         case locationStream
         case locationAuthorizationStream
         case sdkAuthorizationStream
-        case distanceCalculation
+        case calculation
     }
     
     @Dependency(\.mapClient) private var mapClient
@@ -172,7 +175,7 @@ public struct MapFeature {
                     return .send(.openAppSettings)
                 case .authorizedAlways, .authorizedWhenInUse, .authorized:
                     state.isUserTrackingMode = true
-                    if let location = state.userLocation { updateCameraPosition(&state, to: .init(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude)) }
+                    if let location = state.userLocation { updateCameraPosition(&state, to: location.coordinate) }
                     return .none
                 @unknown default:
                     return .none
@@ -180,13 +183,11 @@ public struct MapFeature {
                 
             case let .updateUserLocation(.success(location)):
                 state.userLocation = location
-                if state.isUserTrackingMode {
-                    updateCameraPosition(&state, to: .init(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude))
-                    state.isSearchHereButtonVisible = false
-                }
                 
-                guard state.lastFetchedLocation == nil else { return .none }
-                return .send(.didTapSearchHereButton)
+                guard state.isUserTrackingMode else { return .none }
+                updateCameraPosition(&state, to: location.coordinate)
+                state.isSearchHereButtonVisible = false
+                return .none
                 
             case .updateUserLocation(.failure):
                 state.isUserTrackingMode = false
@@ -197,50 +198,76 @@ public struct MapFeature {
                 return .none
                 
                 // MARK: - Map Camera & Search Logic
+            case .didDetectMapInteraction:
+                state.isUserTrackingMode = false
+                return .none
+                
             case .cameraMotionStarted:
                 return .cancel(id: CancelID.photoBoothFetch)
                 
             case let .cameraMotionEnded(bounds):
                 state.currentBounds = bounds
-                guard let lastFetchedLocation = state.lastFetchedLocation else { return .none }
-                return .run { send in
-                    let distance = calculateDistance(bounds: bounds, lastFetched: lastFetchedLocation)
-                    let isVisible = distance >= Constants.searchTriggerDistanceThreshold
-                    await send(.updateSearchButtonVisibility(isVisible: isVisible))
-                }.cancellable(id: CancelID.distanceCalculation, cancelInFlight: true)
+                
+                if state.isFirstLoad {
+                    state.isFirstLoad = false
+                    return .send(.fetchPhotoBooths(bounds: bounds))
+                }
+                
+                guard state.isUserTrackingMode == false else { return .none }
+                return .send(.updateSearchButtonVisibility(isVisible: true))
                 
             case let .updateSearchButtonVisibility(isVisible):
                 state.isSearchHereButtonVisible = isVisible
                 return .none
                 
-            case .didDetectMapInteraction:
-                state.isUserTrackingMode = false
-                return .none
-                
             case .didTapSearchHereButton:
                 guard let bounds = state.currentBounds else { return .none }
+                return .send(.fetchPhotoBooths(bounds: bounds))
+                
+                // MARK: - Data Fetching
+            case let .fetchPhotoBooths(bounds):
                 state.isSearchHereButtonVisible = false
-                state.lastFetchedLocation = bounds.center
+                state.photoBooths.removeAll()
+                state.photoBoothListState.photoBooths.removeAll()
+                
                 return .run { send in
-                    let stream = try await photoBoothClient.fetchPhotoBooths(bounds)
-                    
-                    for await chunk in stream { await send(.photoBoothChunkLoaded(chunk)) }
+                    let stream = try await photoBoothClient.fetchPhotoBooths(bounds: bounds)
+                    for await chunk in stream {
+                        await send(.photoBoothChunkLoaded(chunk))
+                    }
                     await send(.photoBoothStreamFinished)
                 } catch: { error, send in
                     await send(.photoBoothStreamFailure(error))
-                }
-                .cancellable(id: CancelID.photoBoothFetch, cancelInFlight: true)
+                }.cancellable(id: CancelID.photoBoothFetch, cancelInFlight: true)
                 
             case let .photoBoothChunkLoaded(chunk):
                 state.photoBooths.append(contentsOf: chunk)
-                handleFilterOptionChanged(&state)
-                return .none
+                return .send(.startBackgroundCalculation)
                 
             case .photoBoothStreamFinished:
                 return .none
                 
             case let .photoBoothStreamFailure(error):
                 Logger.presentation.error("PhotoBooth stream error: \(error)")
+                return .none
+                
+            case .startBackgroundCalculation:
+                let allBooths = state.photoBooths
+                let activeFilters = state.photoBoothListState.filteredBrands
+                return .run { send in
+                    let visibleBooths: IdentifiedArrayOf<PhotoBooth>
+                    if activeFilters.isEmpty {
+                        visibleBooths = allBooths
+                    } else {
+                        visibleBooths = allBooths.filter { activeFilters.contains($0.brand) }
+                    }
+                    
+                    await send(.didFinishBackgroundCalculation(visible: visibleBooths))
+                }.cancellable(id: CancelID.calculation, cancelInFlight: true)
+                
+            case let .didFinishBackgroundCalculation(visible):
+                state.visiblePhotoBooths = visible
+                state.photoBoothListState.photoBooths = visible
                 return .none
                 
             case .didTapGoBackToMapButton:
@@ -266,8 +293,7 @@ public struct MapFeature {
                 return .none
                 
             case .photoBoothListAction(.selectFilterOption):
-                handleFilterOptionChanged(&state)
-                return .none
+                return .send(.startBackgroundCalculation)
                 
             case let .photoBoothListAction(.didTapBooth(photoBooth)):
                 return .send(.didTapBooth(photoBooth))
@@ -295,25 +321,7 @@ private extension MapFeature {
         state.cameraPosition = photoBooth.coordinate
     }
     
-    func handleFilterOptionChanged(_ state: inout State) {
-        let activeFilters = state.photoBoothListState.filteredBrands
-        if activeFilters.isEmpty {
-            state.visiblePhotoBooths = state.photoBooths
-        } else {
-            state.visiblePhotoBooths = state.photoBooths.filter { activeFilters.contains($0.brand) }
-        }
-        
-        state.photoBoothListState.photoBooths = state.visiblePhotoBooths
-    }
-    
-    func updateCameraPosition(_ state: inout State, to location: GeographicCoordinate) {
-        state.cameraPosition = .init(latitude: location.latitude, longitude: location.longitude)
-    }
-    
-    func calculateDistance(bounds: GeographicBoundingBox, lastFetched: GeographicCoordinate) -> Double {
-        let currentCenter = bounds.center
-        let from = CLLocation(latitude: currentCenter.latitude, longitude: currentCenter.longitude)
-        let to = CLLocation(latitude: lastFetched.latitude, longitude: lastFetched.longitude)
-        return from.distance(from: to)
+    func updateCameraPosition(_ state: inout State, to coordinate: CLLocationCoordinate2D) {
+        state.cameraPosition = .init(latitude: coordinate.latitude, longitude: coordinate.longitude)
     }
 }

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
@@ -63,7 +63,6 @@ public struct MapFeature {
         case openAppSettings
         case didTapGoBackToMapButton
         case didTapBooth(PhotoBooth)
-        case didTapBoothCard
         case didTapCloseDetail
         case didTapCurrentLocationButton
         case didTapDirectionAppsButton
@@ -172,7 +171,6 @@ public struct MapFeature {
                 
                 // MARK: - User Location Interaction
             case .didTapCurrentLocationButton:
-                resetToMapMode(&state, for: .first)
                 switch state.locationAuthorizationStatus {
                 case .notDetermined:
                     return .send(.requestPermission)
@@ -216,7 +214,6 @@ public struct MapFeature {
                 
             case let .cameraMotionEnded(bounds):
                 state.currentBounds = bounds
-                state.cameraPosition = bounds.center
                 
                 if state.isFirstLoad {
                     state.isFirstLoad = false
@@ -316,15 +313,10 @@ public struct MapFeature {
                 selectPhotoBooth(&state, photoBooth: photoBooth)
                 return .none
                 
-            case .didTapBoothCard:
-                state.isUserTrackingMode = false
-                guard let photoBooth = state.selectedBooth else { return .none }
-                selectPhotoBooth(&state, photoBooth: photoBooth)
-                return .none
-                
             case .didTapCloseDetail:
                 resetToMapMode(&state, for: .second)
                 return .none
+                
                 
             case .didTapDirectionAppsButton:
                 state.directionSheetPhotoBooth = state.selectedBooth
@@ -360,7 +352,7 @@ private extension MapFeature {
     func selectPhotoBooth(_ state: inout State, photoBooth: PhotoBooth) {
         state.selectedBooth = photoBooth
         state.detent = SheetStage.photoBoothSelected.detent
-        state.cameraPosition = photoBooth.coordinate   
+        state.cameraPosition = photoBooth.coordinate
     }
     
     func updateCameraPosition(_ state: inout State, to coordinate: CLLocationCoordinate2D) {

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
@@ -56,6 +56,7 @@ public struct MapFeature {
         case didTapCloseDetail
         case didTapCurrentLocationButton
         case didTapDirectionAppsButton
+        case didTapSearchHereButton
         
         // Internal Actions
         case updateLocationAuthorization(CLAuthorizationStatus)
@@ -149,7 +150,6 @@ public struct MapFeature {
             case .didTapCurrentLocationButton:
                 switch state.locationAuthorizationStatus {
                 case .authorizedAlways, .authorizedWhenInUse:
-                    // TODO: 현위치 돌아가기 버튼 누르면 Stage 수준 몇으로 돌아가는지 확인 필요
                     return .run { send in
                         await send(.setUserTrackingMode(true))
                         
@@ -168,7 +168,8 @@ public struct MapFeature {
                     
                 case .denied, .restricted:
                     state.isUserTrackingMode = false
-                    return .send(.openAppSettings)
+                    // TODO: 프리퍼미션 얼럿 노출
+                    return .none
                     
                 @unknown default:
                     state.isUserTrackingMode = false
@@ -178,6 +179,13 @@ public struct MapFeature {
             case .didTapDirectionAppsButton:
                 state.directionSheetPhotoBooth = state.selectedBooth
                 return .none
+                
+            case .didTapSearchHereButton:
+                guard let bounds = state.currentBounds else { return .none }
+                return .run { send in
+                    await send(.fetchPhotoBoothInBounds(Result { try await photoBoothClient.fetchPhotoBooths(bounds: bounds) }))
+                }
+                .cancellable(id: CancelID.photoBoothFetch, cancelInFlight: true)
                 
             case .updateLocationAuthorization(let status):
                 state.locationAuthorizationStatus = status

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
@@ -8,9 +8,15 @@
 import UIKit
 import ComposableArchitecture
 import CoreLocation
+import os
 
 @Reducer
 public struct MapFeature {
+    private enum Constants {
+        /// 재검색 버튼 노출 기준 거리: 2Km
+        static let searchTriggerDistanceThreshold: Double = 2000.0
+    }
+    
     enum SheetStage {
         case first, second, third, photoBoothSelected
         
@@ -26,22 +32,30 @@ public struct MapFeature {
     
     @ObservableState
     public struct State {
+        // UI Control
         var isSDKAuthSuccessful: Bool = false
+        var detent: NekiSheetDetent = SheetStage.first.detent
+        var isSearchHereButtonVisible: Bool = false
+        
+        // Map State
+        var cameraPosition: GeographicCoordinate?
+        var currentBounds: GeographicBoundingBox?
+        var lastFetchedLocation: GeographicCoordinate?
+        
+        // User Location & Tracking
         var locationAuthorizationStatus: CLAuthorizationStatus = .notDetermined
         var userLocation: CLLocation?
         var isUserTrackingMode: Bool = false
-        var cameraPosition: GeographicCoordinate?
-        var currentBounds: GeographicBoundingBox?
-        
-        var detent: NekiSheetDetent = SheetStage.first.detent
-        var selectedBooth: PhotoBooth?
-        var photoBooths: IdentifiedArrayOf<PhotoBooth> = []
-        var visiblePhotoBooths: IdentifiedArrayOf<PhotoBooth> = []
-        var directionSheetPhotoBooth: PhotoBooth?
-        
         var locationAuthorizationNeeded: Bool = true
         var isLocationAuthorized: Bool { locationAuthorizationStatus == .authorizedAlways || locationAuthorizationStatus == .authorizedWhenInUse }
         
+        // Data
+        var photoBooths: IdentifiedArrayOf<PhotoBooth> = []
+        var visiblePhotoBooths: IdentifiedArrayOf<PhotoBooth> = []
+        var selectedBooth: PhotoBooth?
+        var directionSheetPhotoBooth: PhotoBooth?
+        
+        // Child State
         var photoBoothListState = PhotoBoothListFeature.State()
     }
     
@@ -64,9 +78,12 @@ public struct MapFeature {
         case updateUserLocation(Result<CLLocation, Error>)
         case setUserTrackingMode(Bool)
         case didDetectMapInteraction
-        case fetchPhotoBoothInBounds(Result<[PhotoBooth], Error>)
+        case photoBoothChunkLoaded([PhotoBooth])
+        case photoBoothStreamFinished
+        case photoBoothStreamFailure(Error)
         case cameraMotionStarted
         case cameraMotionEnded(GeographicBoundingBox)
+        case updateSearchButtonVisibility(isVisible: Bool)
         
         // Binding Action
         case binding(BindingAction<State>)
@@ -77,9 +94,10 @@ public struct MapFeature {
     
     private enum CancelID {
         case photoBoothFetch
+        case locationStream
         case locationAuthorizationStream
         case sdkAuthorizationStream
-        case locationStream
+        case distanceCalculation
     }
     
     @Dependency(\.mapClient) private var mapClient
@@ -93,39 +111,50 @@ public struct MapFeature {
         
         Reduce { (state: inout State, action: Action) -> Effect<Action> in
             switch action {
+                
+                // MARK: - Life Cycle & Streams
             case .onAppear:
                 return .merge(
                     .run { send in
                         for await status in await mapClient.locationAuthorizationStatus() {
                             await send(.updateLocationAuthorization(status))
                         }
-                    }
-                        .cancellable(id: CancelID.locationAuthorizationStream, cancelInFlight: true),
+                    }.cancellable(id: CancelID.locationAuthorizationStream, cancelInFlight: true),
                     .run { send in
                         for await isAuthorized in await mapClient.checkSDKAuthorizationStatus() {
                             await send(.updateSDKAuthStatus(isAuthorized))
                         }
-                    }
-                        .cancellable(id: CancelID.sdkAuthorizationStream, cancelInFlight: true),
-                    .run { send in
-                        for await location in await mapClient.trackingLocation() {
-                            await send(.updateUserLocation(.success(location)))
-                        }
-                    }
-                        .cancellable(id: CancelID.locationStream, cancelInFlight: true)
+                    }.cancellable(id: CancelID.sdkAuthorizationStream, cancelInFlight: true)
                 )
                 
             case .onDisappear:
-                return .merge(
-                    .cancel(id: CancelID.locationAuthorizationStream),
-                    .cancel(id: CancelID.sdkAuthorizationStream),
-                    .cancel(id: CancelID.locationStream),
-                    .cancel(id: CancelID.photoBoothFetch)
-                )
+                return .cancel(id: CancelID.locationStream)
                 
+                // MARK: - Permission Flow
             case .requestPermission:
                 state.locationAuthorizationNeeded = true
                 return .run { _ in await mapClient.requestLocationAuthorization() }
+                
+            case .updateLocationAuthorization(let status):
+                state.locationAuthorizationStatus = status
+                switch status {
+                case .authorizedAlways, .authorizedWhenInUse:
+                    return .merge(
+                        .run { send in
+                            for await location in await mapClient.trackingLocation() {
+                                await send(.updateUserLocation(.success(location)))
+                            }
+                        }.cancellable(id: CancelID.locationStream, cancelInFlight: true),
+                        .send(.didTapCurrentLocationButton)
+                    )
+                    
+                case .notDetermined:
+                    return state.locationAuthorizationNeeded ? .send(.requestPermission) : .none
+                    
+                default:
+                    state.isUserTrackingMode = false
+                    return .none
+                }
                 
             case .openAppSettings:
                 // TODO: 설정 앱 동작 전에 안내문구 따위를 보여주도록 해야하는데 디자인 가이드가 없습니다.
@@ -133,6 +162,86 @@ public struct MapFeature {
                     guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
                     await openURL(url)
                 }
+                
+                // MARK: - User Location Interaction
+            case .didTapCurrentLocationButton:
+                switch state.locationAuthorizationStatus {
+                case .notDetermined:
+                    return .send(.requestPermission)
+                case .restricted, .denied:
+                    return .send(.openAppSettings)
+                case .authorizedAlways, .authorizedWhenInUse, .authorized:
+                    state.isUserTrackingMode = true
+                    if let location = state.userLocation { updateCameraPosition(&state, to: .init(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude)) }
+                    return .none
+                @unknown default:
+                    return .none
+                }
+                
+            case let .updateUserLocation(.success(location)):
+                state.userLocation = location
+                if state.isUserTrackingMode {
+                    updateCameraPosition(&state, to: .init(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude))
+                    state.isSearchHereButtonVisible = false
+                }
+                
+                guard state.lastFetchedLocation == nil else { return .none }
+                return .send(.didTapSearchHereButton)
+                
+            case .updateUserLocation(.failure):
+                state.isUserTrackingMode = false
+                return .none
+                
+            case let .setUserTrackingMode(isUserTrackingMode):
+                state.isUserTrackingMode = isUserTrackingMode
+                return .none
+                
+                // MARK: - Map Camera & Search Logic
+            case .cameraMotionStarted:
+                return .cancel(id: CancelID.photoBoothFetch)
+                
+            case let .cameraMotionEnded(bounds):
+                state.currentBounds = bounds
+                guard let lastFetchedLocation = state.lastFetchedLocation else { return .none }
+                return .run { send in
+                    let distance = calculateDistance(bounds: bounds, lastFetched: lastFetchedLocation)
+                    let isVisible = distance >= Constants.searchTriggerDistanceThreshold
+                    await send(.updateSearchButtonVisibility(isVisible: isVisible))
+                }.cancellable(id: CancelID.distanceCalculation, cancelInFlight: true)
+                
+            case let .updateSearchButtonVisibility(isVisible):
+                state.isSearchHereButtonVisible = isVisible
+                return .none
+                
+            case .didDetectMapInteraction:
+                state.isUserTrackingMode = false
+                return .none
+                
+            case .didTapSearchHereButton:
+                guard let bounds = state.currentBounds else { return .none }
+                state.isSearchHereButtonVisible = false
+                state.lastFetchedLocation = bounds.center
+                return .run { send in
+                    let stream = try await photoBoothClient.fetchPhotoBooths(bounds)
+                    
+                    for await chunk in stream { await send(.photoBoothChunkLoaded(chunk)) }
+                    await send(.photoBoothStreamFinished)
+                } catch: { error, send in
+                    await send(.photoBoothStreamFailure(error))
+                }
+                .cancellable(id: CancelID.photoBoothFetch, cancelInFlight: true)
+                
+            case let .photoBoothChunkLoaded(chunk):
+                state.photoBooths.append(contentsOf: chunk)
+                handleFilterOptionChanged(&state)
+                return .none
+                
+            case .photoBoothStreamFinished:
+                return .none
+                
+            case let .photoBoothStreamFailure(error):
+                Logger.presentation.error("PhotoBooth stream error: \(error)")
+                return .none
                 
             case .didTapGoBackToMapButton:
                 resetToMapMode(&state, for: .first)
@@ -147,115 +256,16 @@ public struct MapFeature {
                 resetToMapMode(&state, for: .second)
                 return .none
                 
-            case .didTapCurrentLocationButton:
-                switch state.locationAuthorizationStatus {
-                case .authorizedAlways, .authorizedWhenInUse:
-                    return .run { send in
-                        await send(.setUserTrackingMode(true))
-                        
-                        do {
-                            let location = try await mapClient.getCurrentLocation()
-                            await send(.updateUserLocation(.success(location)))
-                        } catch {
-                            await send(.setUserTrackingMode(false))
-                            await send(.updateUserLocation(.failure(error)))
-                        }
-                    }
-                    
-                case .notDetermined:
-                    state.isUserTrackingMode = false
-                    return .send(.requestPermission)
-                    
-                case .denied, .restricted:
-                    state.isUserTrackingMode = false
-                    // TODO: 프리퍼미션 얼럿 노출
-                    return .none
-                    
-                @unknown default:
-                    state.isUserTrackingMode = false
-                    return .none
-                }
                 
             case .didTapDirectionAppsButton:
                 state.directionSheetPhotoBooth = state.selectedBooth
                 return .none
                 
-            case .didTapSearchHereButton:
-                guard let bounds = state.currentBounds else { return .none }
-                return .run { send in
-                    await send(.fetchPhotoBoothInBounds(Result { try await photoBoothClient.fetchPhotoBooths(bounds: bounds) }))
-                }
-                .cancellable(id: CancelID.photoBoothFetch, cancelInFlight: true)
-                
-            case .updateLocationAuthorization(let status):
-                state.locationAuthorizationStatus = status
-                switch status {
-                case .authorizedAlways, .authorizedWhenInUse:
-                    guard state.userLocation == nil else { return .none }
-                    return .send(.didTapCurrentLocationButton)
-                    
-                case .notDetermined:
-                    guard state.locationAuthorizationNeeded == true else { return .none }
-                    return .send(.requestPermission)
-                    
-                default:
-                    return .none
-                }
-                
             case .updateSDKAuthStatus(let isAuthorized):
                 state.isSDKAuthSuccessful = isAuthorized
                 return .none
                 
-            case let .updateUserLocation(result):
-                switch result {
-                case let .success(location):
-                    state.userLocation = location
-                    
-                    guard state.isUserTrackingMode else { return .none }
-                    updateCameraPosition(&state, to: .init(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude))
-                    return .none
-                    
-                case let .failure(error):
-                    // TODO: 에러 핸들링 로직이나 로그 찍기
-                    print(error.localizedDescription)
-                    return .none
-                }
-                
-            case let .setUserTrackingMode(isUserTrackingMode):
-                state.isUserTrackingMode = isUserTrackingMode
-                return .none
-                
-            case .didDetectMapInteraction:
-                state.isUserTrackingMode = false
-                return .none
-                
-            case let .fetchPhotoBoothInBounds(.success(photoBooths)):
-                let photoBooths = IdentifiedArray(uniqueElements: photoBooths)
-                state.photoBooths = photoBooths
-                handleFilterOptionChanged(&state)
-                return .none
-                
-            case let .fetchPhotoBoothInBounds(.failure(error)):
-                // TODO: 에러 핸들링 로직이나 로그를 찍는다던지 그런 작업은 이곳에 작성
-                print(error.localizedDescription)
-                return .none
-                
-            case .cameraMotionStarted:
-                return .cancel(id: CancelID.photoBoothFetch)
-                
-            case let .cameraMotionEnded(bounds):
-                state.currentBounds = bounds
-                return .run { send in
-                    await send(.fetchPhotoBoothInBounds(
-                        Result {
-                            try await photoBoothClient.fetchPhotoBooths(bounds: bounds)
-                        }
-                    ))
-                }
-                .debounce(id: CancelID.photoBoothFetch, for: 0.3, scheduler: DispatchQueue.main)
-                .cancellable(id: CancelID.photoBoothFetch, cancelInFlight: true)
-                
-            case let .photoBoothListAction(.selectFilterOption(brand)):
+            case .photoBoothListAction(.selectFilterOption):
                 handleFilterOptionChanged(&state)
                 return .none
                 
@@ -298,5 +308,12 @@ private extension MapFeature {
     
     func updateCameraPosition(_ state: inout State, to location: GeographicCoordinate) {
         state.cameraPosition = .init(latitude: location.latitude, longitude: location.longitude)
+    }
+    
+    func calculateDistance(bounds: GeographicBoundingBox, lastFetched: GeographicCoordinate) -> Double {
+        let currentCenter = bounds.center
+        let from = CLLocation(latitude: currentCenter.latitude, longitude: currentCenter.longitude)
+        let to = CLLocation(latitude: lastFetched.latitude, longitude: lastFetched.longitude)
+        return from.distance(from: to)
     }
 }

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
@@ -63,6 +63,7 @@ public struct MapFeature {
         case openAppSettings
         case didTapGoBackToMapButton
         case didTapBooth(PhotoBooth)
+        case didTapBoothCard
         case didTapCloseDetail
         case didTapCurrentLocationButton
         case didTapDirectionAppsButton
@@ -171,6 +172,7 @@ public struct MapFeature {
                 
                 // MARK: - User Location Interaction
             case .didTapCurrentLocationButton:
+                resetToMapMode(&state, for: .first)
                 switch state.locationAuthorizationStatus {
                 case .notDetermined:
                     return .send(.requestPermission)
@@ -214,6 +216,7 @@ public struct MapFeature {
                 
             case let .cameraMotionEnded(bounds):
                 state.currentBounds = bounds
+                state.cameraPosition = bounds.center
                 
                 if state.isFirstLoad {
                     state.isFirstLoad = false
@@ -313,10 +316,15 @@ public struct MapFeature {
                 selectPhotoBooth(&state, photoBooth: photoBooth)
                 return .none
                 
+            case .didTapBoothCard:
+                state.isUserTrackingMode = false
+                guard let photoBooth = state.selectedBooth else { return .none }
+                selectPhotoBooth(&state, photoBooth: photoBooth)
+                return .none
+                
             case .didTapCloseDetail:
                 resetToMapMode(&state, for: .second)
                 return .none
-                
                 
             case .didTapDirectionAppsButton:
                 state.directionSheetPhotoBooth = state.selectedBooth
@@ -352,7 +360,7 @@ private extension MapFeature {
     func selectPhotoBooth(_ state: inout State, photoBooth: PhotoBooth) {
         state.selectedBooth = photoBooth
         state.detent = SheetStage.photoBoothSelected.detent
-        state.cameraPosition = photoBooth.coordinate
+        state.cameraPosition = photoBooth.coordinate   
     }
     
     func updateCameraPosition(_ state: inout State, to coordinate: CLLocationCoordinate2D) {

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
@@ -81,14 +81,16 @@ public struct MapFeature {
         case updateSearchButtonVisibility(isVisible: Bool)
         
         // Data Handling Actions
+        // Map
         case fetchPhotoBooths(bounds: GeographicBoundingBox)
         case photoBoothChunkLoaded([PhotoBooth])
         case photoBoothStreamFinished
         case photoBoothStreamFailure(Error)
-        
-        /// 비동기 계산: 브랜드 필터링 (Pruning 로직 삭제됨)
+        // Sheet
+        case fetchNearbyPhotoBooths(GeographicCoordinate)
+        case nearbyPhotoBoothResponse(Result<[PhotoBooth], Error>)
         case startBackgroundCalculation
-        case didFinishBackgroundCalculation(visible: IdentifiedArrayOf<PhotoBooth>)
+        case didFinishBackgroundCalculation(map: IdentifiedArrayOf<PhotoBooth>, list: IdentifiedArrayOf<PhotoBooth>)
         
         // Binding & Child
         case binding(BindingAction<State>)
@@ -96,7 +98,8 @@ public struct MapFeature {
     }
     
     private enum CancelID {
-        case photoBoothFetch
+        case mapFetch
+        case listFetch
         case locationStream
         case locationAuthorizationStream
         case sdkAuthorizationStream
@@ -203,18 +206,24 @@ public struct MapFeature {
                 return .none
                 
             case .cameraMotionStarted:
-                return .cancel(id: CancelID.photoBoothFetch)
+                return .merge(
+                    .send(.updateSearchButtonVisibility(isVisible: true)),
+                    .cancel(id: CancelID.mapFetch),
+                    .cancel(id: CancelID.listFetch)
+                )
                 
             case let .cameraMotionEnded(bounds):
                 state.currentBounds = bounds
                 
                 if state.isFirstLoad {
                     state.isFirstLoad = false
-                    return .send(.fetchPhotoBooths(bounds: bounds))
+                    return .merge(
+                        .send(.fetchPhotoBooths(bounds: bounds)),
+                        .send(.fetchNearbyPhotoBooths(bounds.center))
+                    )
                 }
                 
-                guard state.isUserTrackingMode == false else { return .none }
-                return .send(.updateSearchButtonVisibility(isVisible: true))
+                return .none
                 
             case let .updateSearchButtonVisibility(isVisible):
                 state.isSearchHereButtonVisible = isVisible
@@ -222,13 +231,15 @@ public struct MapFeature {
                 
             case .didTapSearchHereButton:
                 guard let bounds = state.currentBounds else { return .none }
-                return .send(.fetchPhotoBooths(bounds: bounds))
+                return .merge(
+                    .send(.fetchPhotoBooths(bounds: bounds)),
+                    .send(.fetchNearbyPhotoBooths(bounds.center))
+                )
                 
                 // MARK: - Data Fetching
             case let .fetchPhotoBooths(bounds):
                 state.isSearchHereButtonVisible = false
                 state.photoBooths.removeAll()
-                state.photoBoothListState.photoBooths.removeAll()
                 
                 return .run { send in
                     let stream = try await photoBoothClient.fetchPhotoBooths(bounds: bounds)
@@ -238,7 +249,7 @@ public struct MapFeature {
                     await send(.photoBoothStreamFinished)
                 } catch: { error, send in
                     await send(.photoBoothStreamFailure(error))
-                }.cancellable(id: CancelID.photoBoothFetch, cancelInFlight: true)
+                }.cancellable(id: CancelID.mapFetch, cancelInFlight: true)
                 
             case let .photoBoothChunkLoaded(chunk):
                 state.photoBooths.append(contentsOf: chunk)
@@ -251,23 +262,46 @@ public struct MapFeature {
                 Logger.presentation.error("PhotoBooth stream error: \(error)")
                 return .none
                 
+            case let .fetchNearbyPhotoBooths(coordinate):
+                state.photoBoothListState.photoBooths.removeAll()
+                
+                return .run { send in
+                    let booths = try await photoBoothClient.fetchNearbyPhotoBooths(coordinate: coordinate)
+                    await send(.nearbyPhotoBoothResponse(.success(booths)))
+                } catch: { error, send in
+                    await send(.nearbyPhotoBoothResponse(.failure(error)))
+                }.cancellable(id: CancelID.listFetch, cancelInFlight: true)
+                
+            case let .nearbyPhotoBoothResponse(.success(booths)):
+                state.photoBoothListState.photoBooths = IdentifiedArray(uniqueElements: booths)
+                return .send(.startBackgroundCalculation)
+                
+            case let .nearbyPhotoBoothResponse(.failure(error)):
+                Logger.presentation.error("Nearby PhotoBooths fetch error: \(error)")
+                return .none
+                
             case .startBackgroundCalculation:
-                let allBooths = state.photoBooths
+                let mapBooths = state.photoBooths
+                let listBooths = state.photoBoothListState.photoBooths
                 let activeFilters = state.photoBoothListState.filteredBrands
                 return .run { send in
-                    let visibleBooths: IdentifiedArrayOf<PhotoBooth>
+                    let visibleMapBooths: IdentifiedArrayOf<PhotoBooth>
+                    let visibleListBooths: IdentifiedArrayOf<PhotoBooth>
                     if activeFilters.isEmpty {
-                        visibleBooths = allBooths
+                        visibleMapBooths = mapBooths
+                        visibleListBooths = listBooths
                     } else {
-                        visibleBooths = allBooths.filter { activeFilters.contains($0.brand) }
+                        visibleMapBooths = mapBooths.filter { activeFilters.contains($0.brand) }
+                        visibleListBooths = listBooths.filter { activeFilters.contains($0.brand) }
                     }
                     
-                    await send(.didFinishBackgroundCalculation(visible: visibleBooths))
-                }.cancellable(id: CancelID.calculation, cancelInFlight: true)
+                    await send(.didFinishBackgroundCalculation(map: visibleMapBooths, list: visibleListBooths))
+                }
+                .cancellable(id: CancelID.calculation, cancelInFlight: true)
                 
-            case let .didFinishBackgroundCalculation(visible):
-                state.visiblePhotoBooths = visible
-                state.photoBoothListState.photoBooths = visible
+            case let .didFinishBackgroundCalculation(map, list):
+                state.visiblePhotoBooths = map
+                state.photoBoothListState.visibleBooths = list
                 return .none
                 
             case .didTapGoBackToMapButton:

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/PhotoBoothListFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/PhotoBoothListFeature.swift
@@ -16,6 +16,7 @@ public struct PhotoBoothListFeature {
         var filteredBrands: Set<PhotoBoothBrand> = []
         
         var photoBooths: IdentifiedArrayOf<PhotoBooth> = []
+        var visibleBooths: IdentifiedArrayOf<PhotoBooth> = []
         
         var isWarningAlertPresented: Bool = false
     }

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/PhotoBoothListFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/PhotoBoothListFeature.swift
@@ -18,14 +18,13 @@ public struct PhotoBoothListFeature {
         var photoBooths: IdentifiedArrayOf<PhotoBooth> = []
         var visibleBooths: IdentifiedArrayOf<PhotoBooth> = []
         
-        var isWarningAlertPresented: Bool = false
+        @Shared(.appStorage("NearbyTooltipVisibility")) var isTooltipPresented: Bool = true
     }
     
     public enum Action: BindableAction {
         // View Actions
         case selectFilterOption(PhotoBoothBrand)
-        case showWarningAlert
-        case dismissWarningAlert
+        case toggleTooltip
         
         // Delegate Actions
         case didTapBooth(PhotoBooth)
@@ -43,12 +42,8 @@ public struct PhotoBoothListFeature {
                 toggleFilterOptionSelection(&state, brand: brand)
                 return .none
                 
-            case .showWarningAlert:
-                state.isWarningAlertPresented = true
-                return .none
-                
-            case .dismissWarningAlert:
-                state.isWarningAlertPresented = false
+            case .toggleTooltip:
+                state.$isTooltipPresented.withLock { $0.toggle() }
                 return .none
                 
             default:

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
@@ -265,6 +265,9 @@ public struct NaverMapView: View {
         .sheet(item: $store.directionSheetPhotoBooth) { photoBooth in
             DirectionAppsSheet(photoBooth: photoBooth)
         }
+        .overlay(alignment: .top) {
+            searchHereControl
+        }
         .nekiSheet(selection: $store.detent) {
             NearPhotoBoothListSheet(store: store.scope(state: \.photoBoothListState, action: \.photoBoothListAction))
                 .scrollDisabled(store.detent != .large)
@@ -361,6 +364,28 @@ private extension NaverMapView {
         }
         .padding(.horizontal, 20)
         .shadow(color: .gray400, radius: 8, y: 4)
+    }
+    
+    var searchHereControl: some View {
+        Button {
+            store.send(.didTapSearchHereButton)
+        } label: {
+            HStack(spacing: 6.55) {
+                Image(.iconRotate)
+                
+                Text("현 위치에서 탐색")
+                    .nekiFont(.body14SemiBold)
+                    .foregroundStyle(.gray800)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .background(
+                Capsule()
+                    .fill(.white)
+                    .strokeBorder(.gray100)
+            )
+        }
+        .safeAreaPadding(.top)
     }
 }
 

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
@@ -345,6 +345,8 @@ private extension NaverMapView {
             .background(.white)
             .clipShape(RoundedRectangle(cornerRadius: 20))
             .shadow(color: .gray400, radius: 8, y: 4)
+            .contentShape(.rect)
+            .onTapGesture { store.send(.didTapBoothCard) }
             .padding(.horizontal)
             .padding(.bottom, 72)
         }

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
@@ -13,8 +13,8 @@ fileprivate enum Constants {
     // Map Settings
     static let defaultInitialPosition = NMGLatLng(lat: 37.498095, lng: 127.027610)
     static let animationDuration: TimeInterval = 0.3
-    static let minZoomLevel: Double = 5.0
-    static let maxZoomLevel: Double = 18.0
+    static let minZoomLevel: Double = 12.0
+    static let maxZoomLevel: Double = 20.0
     
     // Marker Size
     static let normalSize = CGSize(width: 54, height: 62)
@@ -101,6 +101,7 @@ private extension NaverMapRepresentable {
         view.showIndoorLevelPicker = false
         view.mapView.minZoomLevel = Constants.minZoomLevel
         view.mapView.maxZoomLevel = Constants.maxZoomLevel
+        view.mapView.extent = NMGLatLngBounds(southWestLat: 31.43, southWestLng: 122.37, northEastLat: 44.35, northEastLng: 132)
         view.mapView.mapType = .basic
     }
     
@@ -274,7 +275,9 @@ public struct NaverMapView: View {
             DirectionAppsSheet(photoBooth: photoBooth)
         }
         .overlay(alignment: .top) {
-            searchHereControl
+            if store.isSearchHereButtonVisible {
+                searchHereControl
+            }
         }
         .nekiSheet(selection: $store.detent) {
             NearPhotoBoothListSheet(store: store.scope(state: \.photoBoothListState, action: \.photoBoothListAction))

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
@@ -9,11 +9,21 @@ import SwiftUI
 import ComposableArchitecture
 import NMapsMap
 
-struct NaverMapRepresentable: UIViewRepresentable {
-    private enum Constants {
-        static let defaultInitialPosition: NMGLatLng = .init(lat: 37.498095, lng: 127.027610)
-    }
+fileprivate enum Constants {
+    // Map Settings
+    static let defaultInitialPosition = NMGLatLng(lat: 37.498095, lng: 127.027610)
+    static let animationDuration: TimeInterval = 0.3
+    static let minZoomLevel: Double = 5.0
+    static let maxZoomLevel: Double = 18.0
     
+    // Marker Size
+    static let normalSize = CGSize(width: 54, height: 62)
+    static let selectedSize = CGSize(width: 72, height: 83)
+    static let zIndexNormal: Int = 0
+    static let zIndexSelected: Int = 100
+}
+
+struct NaverMapRepresentable: UIViewRepresentable {
     /// 마커 이미지 리소스
     fileprivate enum MarkerImageResources {
         enum State {
@@ -45,14 +55,7 @@ struct NaverMapRepresentable: UIViewRepresentable {
         let view = NMFNaverMapView()
         
         // UI 초기 설정
-        view.showZoomControls = false
-        view.showLocationButton = false
-        view.showCompass = false
-        view.showScaleBar = false
-        view.showIndoorLevelPicker = false
-        view.mapView.minZoomLevel = 5.0
-        view.mapView.maxZoomLevel = 18.0
-        view.mapView.mapType = .basic
+        configureMapView(view)
         
         // 초기 카메라 이동
         let startPosition = store.cameraPosition.map { NMGLatLng(lat: $0.latitude, lng: $0.longitude) } ?? Constants.defaultInitialPosition
@@ -70,25 +73,10 @@ struct NaverMapRepresentable: UIViewRepresentable {
     
     func updateUIView(_ uiView: NMFNaverMapView, context: Context) {
         // 현위치 모드 업데이트
-        if isLocationAuthorized {
-            let mode: NMFMyPositionMode = store.isUserTrackingMode ? .direction : .normal
-            
-            if uiView.mapView.positionMode != mode {
-                uiView.mapView.positionMode = mode
-            }
-        } else {
-            uiView.mapView.positionMode = .disabled
-        }
+        updateLocationOverlay(uiView.mapView, isAuthorized: isLocationAuthorized)
         
         // State 변경 시 카메라 이동
-        if let cameraPosition = store.cameraPosition, cameraPosition != context.coordinator.lastCameraPosition {
-            let nmapCameraPosition = NMGLatLng(lat: cameraPosition.latitude, lng: cameraPosition.longitude)
-            let cameraUpdate = NMFCameraUpdate(scrollTo: nmapCameraPosition)
-            cameraUpdate.animation = .linear
-            cameraUpdate.animationDuration = 0.3
-            uiView.mapView.moveCamera(cameraUpdate)
-            context.coordinator.lastCameraPosition = cameraPosition
-        }
+        updateCameraPosition(uiView.mapView, context: context)
         
         // 마커 업데이트
         context.coordinator.updateMarkers(
@@ -97,12 +85,56 @@ struct NaverMapRepresentable: UIViewRepresentable {
             selectedBoothID: store.selectedBooth?.id
         )
         
+        updateContentInset(uiView.mapView)
+    }
+}
+
+
+// MARK: - NaverMapRepresentable + Helper Methods
+
+private extension NaverMapRepresentable {
+    func configureMapView(_ view: NMFNaverMapView) {
+        view.showZoomControls = false
+        view.showLocationButton = false
+        view.showCompass = false
+        view.showScaleBar = false
+        view.showIndoorLevelPicker = false
+        view.mapView.minZoomLevel = Constants.minZoomLevel
+        view.mapView.maxZoomLevel = Constants.maxZoomLevel
+        view.mapView.mapType = .basic
+    }
+    
+    func updateLocationOverlay(_ mapView: NMFMapView, isAuthorized: Bool) {
+        if isLocationAuthorized {
+            let mode: NMFMyPositionMode = store.isUserTrackingMode ? .direction : .normal
+            
+            if mapView.positionMode != mode {
+                mapView.positionMode = mode
+            }
+        } else {
+            mapView.positionMode = .disabled
+        }
+    }
+    
+    func updateCameraPosition(_ mapView: NMFMapView, context: Context) {
+        guard let cameraPosition = store.cameraPosition,
+              cameraPosition != context.coordinator.lastCameraPosition
+        else { return }
+        let nmapCameraPosition = NMGLatLng(lat: cameraPosition.latitude, lng: cameraPosition.longitude)
+        let cameraUpdate = NMFCameraUpdate(scrollTo: nmapCameraPosition)
+        cameraUpdate.animation = .linear
+        cameraUpdate.animationDuration = Constants.animationDuration
+        mapView.moveCamera(cameraUpdate)
+        context.coordinator.lastCameraPosition = cameraPosition
+    }
+    
+    func updateContentInset(_ mapView: NMFMapView) {
         let sheetHeight = store.detent.resolve(in: UIScreen.main.bounds.height, inset: .screenTabBarHeight)
         let targetInset = store.detent == .large ? .zero : UIEdgeInsets(top: .zero, left: .zero, bottom: sheetHeight, right: .zero)
-        if uiView.mapView.contentInset != targetInset {
-            UIView.animate(withDuration: 0.3, delay: .zero) {
-                uiView.mapView.contentInset = targetInset
-                uiView.layoutIfNeeded()
+        if mapView.contentInset != targetInset {
+            UIView.animate(withDuration: Constants.animationDuration, delay: .zero) {
+                mapView.contentInset = targetInset
+                mapView.layoutIfNeeded()
             }
         }
     }
@@ -118,8 +150,8 @@ extension NaverMapRepresentable {
         
         var lastCameraPosition: GeographicCoordinate?
         
-        private var markers: [UUID: NMFMarker] = [:]
-        private var lastSelectedBoothID: UUID?
+        private var markers: [Int: NMFMarker] = [:]
+        private var lastSelectedBoothID: Int?
         
         let parent: NaverMapRepresentable
         
@@ -128,47 +160,28 @@ extension NaverMapRepresentable {
         func updateMarkers(
             mapView: NMFMapView,
             photoBooths: IdentifiedArrayOf<PhotoBooth>,
-            selectedBoothID: UUID?
+            selectedBoothID: Int?
         ) {
-            let visibleIDs = Set(photoBooths.ids)
-            let cachedIDs = Set(markers.keys)
+            let newIDs = Set(photoBooths.ids)
+            let currentIDs = Set(markers.keys)
             
-            let idsToHide = cachedIDs.subtracting(visibleIDs)
-            for id in idsToHide {
+            let idsToRemove = currentIDs.subtracting(newIDs)
+            for id in idsToRemove {
                 markers[id]?.mapView = nil
+                markers[id] = nil
             }
             
-            for id in visibleIDs {
-                guard let booth = photoBooths[id: id] else { continue }
-                let isTargetSelected = (id == selectedBoothID)
+            for booth in photoBooths {
+                let isSelected = (booth.id == selectedBoothID)
                 
-                if let existingMarker = markers[id] {
-                    guard existingMarker.mapView == nil else { continue }
-                    configureMarkerStyle(existingMarker, brand: booth.brand, isSelected: isTargetSelected)
-                    existingMarker.mapView = mapView
+                if let existingMarker = markers[booth.id] {
+                    updateMarkerStyleIfNeeded(existingMarker, brand: booth.brand, isSelected: isSelected)
                 } else {
-                    let newMarker = createMarker(for: booth, isSelected: isTargetSelected)
+                    let newMarker = createMarker(for: booth)
+                    updateMarkerStyleIfNeeded(newMarker, brand: booth.brand, isSelected: isSelected)
                     newMarker.mapView = mapView
-                    markers[id] = newMarker
+                    markers[booth.id] = newMarker
                 }
-            }
-            
-            if lastSelectedBoothID != selectedBoothID {
-                if let oldID = lastSelectedBoothID,
-                   let oldMarker = markers[oldID],
-                   oldMarker.mapView != nil {
-                    let brand = photoBooths[id: oldID]?.brand ?? .life4cut
-                    configureMarkerStyle(oldMarker, brand: brand, isSelected: false)
-                }
-                
-                if let newID = selectedBoothID,
-                   let newMarker = markers[newID],
-                   newMarker.mapView != nil {
-                    let brand = photoBooths[id: newID]?.brand ?? .life4cut
-                    configureMarkerStyle(newMarker, brand: brand, isSelected: true)
-                }
-                
-                lastSelectedBoothID = selectedBoothID
             }
         }
     }
@@ -178,45 +191,40 @@ extension NaverMapRepresentable {
 // MARK: - NaverMapRepresentable.Coordinator + Factory Helpers
 
 private extension NaverMapRepresentable.Coordinator {
-    /// 새 마커 생성
-    func createMarker(for photoBooth: PhotoBooth, isSelected: Bool) -> NMFMarker {
+    func createMarker(for booth: PhotoBooth) -> NMFMarker {
         let marker = NMFMarker()
-        marker.position = NMGLatLng(lat: photoBooth.coordinate.latitude, lng: photoBooth.coordinate.longitude)
-        
-        // 기본 캡션 설정
-        marker.captionText = photoBooth.name
+        marker.position = NMGLatLng(lat: booth.coordinate.latitude, lng: booth.coordinate.longitude)
+        marker.captionText = "\(booth.brand.displayName)\n\(booth.name)"
         marker.captionColor = .init(hex: 0x202227)
         marker.captionHaloColor = .white
         marker.captionTextSize = 12
         
-        // 탭 핸들러 설정
         marker.touchHandler = { [weak self] _ in
-            self?.parent.store.send(.didTapBooth(photoBooth))
+            self?.parent.store.send(.didTapBooth(booth))
             return true
         }
-        
-        // 스타일 설정
-        configureMarkerStyle(marker, brand: photoBooth.brand, isSelected: isSelected)
-        
         return marker
     }
     
-    /// 마커 스타일 설정
-    func configureMarkerStyle(_ marker: NMFMarker, brand: PhotoBoothBrand, isSelected: Bool) {
-        marker.userInfo["isSelected"] = isSelected
+    func updateMarkerStyleIfNeeded(_ marker: NMFMarker, brand: PhotoBoothBrand, isSelected: Bool) {
+        let isFirstRender = marker.userInfo["isSelected"] == nil
+        let currentSelectionState = marker.userInfo["isSelected"] as? Bool ?? false
+        
+        guard isFirstRender || currentSelectionState != isSelected else { return }
+        let targetImage = MarkerImageResources.image(for: brand, state: isSelected ? .selected : .normal)
+        marker.iconImage = targetImage
         
         if isSelected {
-            marker.iconImage = MarkerImageResources.image(for: brand, state: .selected)
-            marker.width = 72
-            marker.height = 83
-            marker.zIndex = 100 // 맨 위로
+            marker.width = Constants.selectedSize.width
+            marker.height = Constants.selectedSize.height
+            marker.zIndex = Constants.zIndexSelected
         } else {
-            // 일반 상태
-            marker.iconImage = MarkerImageResources.image(for: brand, state: .normal)
-            marker.width = 54
-            marker.height = 62
-            marker.zIndex = 0
+            marker.width = Constants.normalSize.width
+            marker.height = Constants.normalSize.height
+            marker.zIndex = Constants.zIndexNormal
         }
+        
+        marker.userInfo["isSelected"] = isSelected
     }
 }
 
@@ -277,7 +285,9 @@ public struct NaverMapView: View {
         .nekiSheetBottomInset()
         .overlay(alignment: .bottom) {
             if case .large = store.detent {
-                ChipFloatingButton(.map) { store.send(.didTapGoBackToMapButton, animation: .default) }.safeAreaPadding()
+                ChipFloatingButton(.map) { store.send(.didTapGoBackToMapButton, animation: .default) }
+                    .padding(.bottom, 52)
+                    .safeAreaPadding()
             }
         }
         .animation(.easeInOut, value: store.detent)
@@ -306,16 +316,16 @@ private extension NaverMapView {
                 
                 VStack(alignment: .leading, spacing: 4) {
                     HStack(spacing: 4) {
-                        Text("인생네컷") // TODO: 실제 지점 정보를 표시해야 합니다.
+                        Text(photoBooth.brand.displayName)
                             .nekiFont(.title20SemiBold)
                             .foregroundStyle(.gray900)
                         
-                        Text("사당역점") // TODO: 실제 지점 정보를 표시해야 합니다.
+                        Text(photoBooth.name)
                             .nekiFont(.body14Medium)
                             .foregroundStyle(.gray600)
                     }
                     
-                    Text("300m") // TODO: 실제 거리 값을 표시해야 합니다
+                    Text("\(photoBooth.nearbyDistance ?? .zero)") // TODO: 거리 단위 표시하기, 1000 미만이라면 m, 이상이라면 소수점 한자리 Km
                         .nekiFont(.body14Medium)
                         .foregroundStyle(.gray400)
                 }
@@ -410,10 +420,5 @@ extension NMGLatLng {
 }
 
 #Preview {
-    TabView {
-        NaverMapView(store: Store(initialState: MapFeature.State(), reducer: { MapFeature() }))
-            .tabItem {
-                Label("네컷지도", systemImage: "mappin.and.ellipse")
-            }
-    }
+    AppCoordinatorView(store: .init(initialState: AppCoordinator.State.mainTab(.init()), reducer: { AppCoordinator() }))
 }

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
@@ -328,7 +328,7 @@ private extension NaverMapView {
                             .foregroundStyle(.gray600)
                     }
                     
-                    Text("\(photoBooth.nearbyDistance ?? .zero)") // TODO: 거리 단위 표시하기, 1000 미만이라면 m, 이상이라면 소수점 한자리 Km
+                    Text(photoBooth.nearbyDistance?.distanceString ?? "")
                         .nekiFont(.body14Medium)
                         .foregroundStyle(.gray400)
                 }

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
@@ -345,8 +345,6 @@ private extension NaverMapView {
             .background(.white)
             .clipShape(RoundedRectangle(cornerRadius: 20))
             .shadow(color: .gray400, radius: 8, y: 4)
-            .contentShape(.rect)
-            .onTapGesture { store.send(.didTapBoothCard) }
             .padding(.horizontal)
             .padding(.bottom, 72)
         }

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NearPhotoBoothListSheet.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NearPhotoBoothListSheet.swift
@@ -125,11 +125,11 @@ private extension NearPhotoBoothListSheet {
             
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 4) {
-                    Text(photoBooth.name)
+                    Text(photoBooth.brand.displayName)
                         .nekiFont(.title18SemiBold)
                         .foregroundStyle(.gray900)
                     
-                    Text("사당역점") // TODO: 실제 지점 정보를 표시해야 합니다.
+                    Text(photoBooth.name)
                         .nekiFont(.caption12Medium)
                         .foregroundStyle(.gray600)
                 }

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NearPhotoBoothListSheet.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NearPhotoBoothListSheet.swift
@@ -91,7 +91,7 @@ private extension NearPhotoBoothListSheet {
                 unavailableView
             } else {
                 LazyVStack(alignment: .leading) {
-                    ForEach(store.photoBooths) { photoBooth in
+                    ForEach(store.visibleBooths) { photoBooth in
                         nearByPhotoBoothCell(photoBooth)
                     }
                 }
@@ -134,7 +134,7 @@ private extension NearPhotoBoothListSheet {
                         .foregroundStyle(.gray600)
                 }
                 
-                Text("300m") // TODO: 실제 거리 값을 표시해야 합니다
+                Text(photoBooth.nearbyDistance?.distanceString ?? "")
                     .nekiFont(.caption12Medium)
                     .foregroundStyle(.gray400)
             }

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NearPhotoBoothListSheet.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NearPhotoBoothListSheet.swift
@@ -18,9 +18,6 @@ struct NearPhotoBoothListSheet: View {
             photoBoothBrandFilterOptionsSection
             nearByPhotoBoothListSection
         }
-        .nekiWarningAlert(isPresented: $store.isWarningAlertPresented, titleMessage: "가까운 네컷 사진 브랜드는 1km 기준으로 표시돼요.") { // TODO: 얼럿 등장 위치 상위 화면으로 옮겨야 할 수도 있음
-            store.send(.dismissWarningAlert)
-        }
     }
 }
 
@@ -107,7 +104,8 @@ private extension NearPhotoBoothListSheet {
                 
                 Image(systemName: "exclamationmark.circle")
                     .foregroundStyle(.gray400)
-                    .onTapGesture { store.send(.showWarningAlert) }
+                    .onTapGesture { store.send(.toggleTooltip) }
+                    .nekiTooltip(isPresented: $store.isTooltipPresented, "가까운 네컷 사진 브랜드는\n1Km 기준으로 표시돼요.")
             }
             .nekiFont(.title18Bold)
             .padding(.horizontal, 20)
@@ -145,16 +143,10 @@ private extension NearPhotoBoothListSheet {
         .padding(.vertical, 4)
     }
     
-    var unavailableView: some View { // TODO: 디자인 수정될 여지 있습니다.
+    var unavailableView: some View {
         Text("1km 이내에 가까운 네컷 사진관이 없어요!")
             .nekiFont(.body16Medium)
             .foregroundStyle(.gray500)
-            .frame(height: 375) // TODO: 스크롤뷰 내부 요소는 상단 정렬이라, 여기서 고정 높이를 줘서 디자인 시안과 맞췄습니다.
-    }
-}
-
-#Preview {
-    TabView {
-        NaverMapView(store: Store(initialState: MapFeature.State(), reducer: { MapFeature() }))
+            .frame(height: 375)
     }
 }

--- a/Neki-iOS/Shared/DesignSystem/Resources/Assets.xcassets/Common/icon_rotate.imageset/Contents.json
+++ b/Neki-iOS/Shared/DesignSystem/Resources/Assets.xcassets/Common/icon_rotate.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "ic_rotate-cw.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Neki-iOS/Shared/DesignSystem/Resources/Assets.xcassets/Common/icon_rotate.imageset/ic_rotate-cw.svg
+++ b/Neki-iOS/Shared/DesignSystem/Resources/Assets.xcassets/Common/icon_rotate.imageset/ic_rotate-cw.svg
@@ -1,0 +1,11 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_3370_2504)">
+<path d="M15.333 2.66602V6.66602H11.333" stroke="#FF5647" stroke-width="1.63636" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.6602 10.0007C13.2269 11.2273 12.4066 12.2798 11.323 12.9997C10.2394 13.7195 8.95122 14.0677 7.65253 13.9917C6.35383 13.9157 5.11501 13.4197 4.12275 12.5784C3.13048 11.7371 2.43853 10.5961 2.15116 9.32736C1.86378 8.05859 1.99656 6.73079 2.52949 5.54404C3.06241 4.35729 3.9666 3.3759 5.10581 2.74775C6.24502 2.1196 7.55753 1.87873 8.84555 2.06142C10.1336 2.24412 11.3273 2.84049 12.2469 3.76066L15.3336 6.66733" stroke="#FF5647" stroke-width="1.63636" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_3370_2504">
+<rect width="16" height="16" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/Neki-iOS/Shared/DesignSystem/Sources/Component/NekiTooltip/NekiTooltip.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Component/NekiTooltip/NekiTooltip.swift
@@ -12,7 +12,7 @@ public enum NekiTooltipStyle {
     
     var backgroundColor: Color {
         switch self {
-        case .dark: return .gray700
+        case .dark: return .gray800
         case .light: return .gray25
         }
     }
@@ -76,8 +76,8 @@ struct NekiTooltipView: View {
                 arrowArea(pointsUp: false)
             }
         }
-        .fixedSize()
         .shadow(color: .black.opacity(0.15), radius: 8, y: 4)
+        .fixedSize()
     }
     
     private var contentArea: some View {
@@ -85,7 +85,7 @@ struct NekiTooltipView: View {
             Text(text)
                 .nekiFont(.body14Medium)
                 .foregroundStyle(style.foregroundColor)
-                .multilineTextAlignment(.center)
+                .multilineTextAlignment(.leading)
             
             if let onDismiss = onDismiss {
                 Button(action: onDismiss) {
@@ -107,5 +107,12 @@ struct NekiTooltipView: View {
             .rotationEffect(pointsUp ? .degrees(0) : .degrees(180))
             .offset(x: arrowOffset)
             .zIndex(1)
+    }
+}
+
+import ComposableArchitecture
+#Preview {
+    TabView {
+        NaverMapView(store: Store(initialState: MapFeature.State(), reducer: { MapFeature() }))
     }
 }


### PR DESCRIPTION
## 🌴 작업한 브랜치
- `feat/#71-map-controls


## ✅ 작업한 내용
지도 기반 POI 탐색 기능의 UX 개선 및 데이터 스트리밍 로직 최적화를 진행했습니다.

1. **UX & Interaction 최적화**
    * **New Fetch UX**: 지도 이동 시 '현 위치에서 탐색' 버튼을 통한 수동 탐색이 가능하도록 만들었습니다.
    * **Instant Interaction**: 복잡한 계산 없이 지도 이동 시 버튼을 노출하여 직관성을 높였습니다.
    * **Data Accumulation**: 사용자가 지도에서 이동한 것과 관계없이 마커 오버레이를 그리기 위한 데이터를 유지합니다. 메모리 관리를 위해 일정 범위를 벗어나면 이전 POI 데이터를 지우는 비즈니스 로직을 준비했었으나, 기획수준 검토 후 다시 원복되었습니다.
2. **Repository & Data Efficiency**
    * **Tile-Based Request**: `TileSystem`을 도입하여 보고 있는 지도 영역 및 POI 검색 영역에 대한 가상의 타일 영역을 계산하고 중복 요청을 방지합니다.
    * **Parallel & Progressive fetching**: 캐시 미스한 타일에 대하여 병렬 로드하며, 빨리 로드되는 대로 yield하여 지도에 마커 오버레이를 그리도록 합니다. 많은 POI를 그리기 위해 UI는 기다리지 않으며 사용성이 개선되었습니다.
    * **Actor-Safe Streaming**: `AsyncStream`을 사용해 로드되는 POI를 즉각적으로 그릴 수 있게 하면서도, `Actor` 기반의 레포지토리 구현으로 내부 캐시에 대한 스레드 안전성을 보장합니다.
3. **Rendering Optimization**
    * 지도 업데이트 로직은 이전부터 지속적으로 최적화 하고 있었습니다. 변경된 비즈니스 규칙에 맞추어 기본설정값을 변경하였고 Diffing 알고리즘에 기반해 마커 렌더링 성능을 최적화합니다. 코드 정리 수준의 변경이 있었습니다.

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


## ❗️PR Point
1. 브랜드 종류 및 정보에 대한 API는 지도 탭에 진입할 때마다 호출할 것을 가정하여 구현되었다고 합니다. 단, 저는 앱 실행 후 최초 POI 요청 시점에 데이터를 받아오고 중복 요청은 하지 않도록 했습니다. (브랜드 정보가 자주 바뀌지 않을 것으로 예상됩니다.)
2. 지점 POI 데이터를 계속 쌓아두면 메모리 부담이 클 것 같다고 예상했습니다. (캐시 + Reducer 이중 보관) 따라서 일정 범위를 벗어나면 이전의 데이터를 지우는 것으로 로직을 짜놓았으나 UX 측면에서 어색하다는 리뷰를 받았습니다. 따라서 POI 데이터를 계속 받아오되, 다른 좌표에서 재검색할 경우에 버퍼를 비우도록 했습니다.
3. 최소 줌 레벨은 14로 고정되었으며, 타일 계산에서는 15를 기준으로 합니다. 줌 레벨을 낮추거나 높이면 병렬 처리 효율성이 떨어지거나, 너무 과한 API 요청이 발생할 수 있어서 적절한 값을 찾으면 좋을 것 같습니다. 혹은 현재 보고 있는 지도의 줌 레벨을 사용해서 계산에 활용할 수도 있을 것 같구요. 또 화면 중앙에 가까운 타일부터 TaskGroup에 추가하는 걸로 중심부 데이터가 먼저 그려지게 하는 센스도 넣으면 좋을 것 같아요. 아이디어는 많이 떠오르는데 이번 작업에는 포함하지 않았습니다. 좋은 아이디어 있으면 말씀해주세요!


## 📸 스크린샷
스크린샷은 생략하고 단체 QA를 위한 테스트빌드로 대체합니다.

## 📟 관련 이슈
- Resolved: #71


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 지도에서 영역/현재 위치 기반으로 포토부스 검색(스트리밍/근접검색) 및 브랜드 조회 추가
  * 포토부스 리스트와 지도 간 상호작용(선택, 상세, 거리 표시) 향상
  * 위치 클라이언트 구성(정밀도/필터) 적용 기능 추가

* **개선 사항**
  * 지도 마커 스타일·선택 동작 및 카메라/오버레이 업데이트 개선
  * 거리 표현 포맷 개선(m/km)
  * 권한 흐름·오류 로깅 강화

* **버그 수정**
  * 설정된 Info.plist 키를 빌드 설정에서 읽도록 변경 (설명 텍스트 연결)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->