### PR TITLE
[Fix] 병렬처리된 지도 POI 계산 로직 보완

### DIFF
--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
@@ -91,6 +91,8 @@ public struct MapFeature {
         case fetchNearbyPhotoBooths(GeographicCoordinate)
         case nearbyPhotoBoothResponse(Result<[PhotoBooth], Error>)
         case startBackgroundCalculation
+        case processNewChunk([PhotoBooth], isFirstBatch: Bool)
+        case appendProcessedChunk(map: [PhotoBooth], list: [PhotoBooth], isFirstBatch: Bool)
         case didFinishBackgroundCalculation(map: IdentifiedArrayOf<PhotoBooth>, list: IdentifiedArrayOf<PhotoBooth>)
         
         // Binding & Child
@@ -256,7 +258,26 @@ public struct MapFeature {
                 
             case let .photoBoothChunkLoaded(chunk):
                 state.photoBooths.append(contentsOf: chunk)
-                return .send(.startBackgroundCalculation)
+                let isFirstBatch = state.photoBooths.count == chunk.count
+                return .send(.processNewChunk(chunk, isFirstBatch: isFirstBatch))
+                
+            case let .processNewChunk(chunk, isFirstBatch):
+                let activeFilters = state.photoBoothListState.filteredBrands
+                return .run { send in
+                    let filteredChunk: [PhotoBooth]
+                    filteredChunk = activeFilters.isEmpty ? chunk : chunk.filter { activeFilters.contains($0.brand) }
+                    await send(.appendProcessedChunk(map: filteredChunk, list: filteredChunk, isFirstBatch: isFirstBatch))
+                }
+                
+            case let .appendProcessedChunk(map, list, isFirstBatch):
+                if isFirstBatch {
+                    state.visiblePhotoBooths = IdentifiedArray(uniqueElements: map)
+                    state.photoBoothListState.visibleBooths = IdentifiedArrayOf(uniqueElements: list)
+                } else {
+                    state.visiblePhotoBooths.append(contentsOf: map)
+                    state.photoBoothListState.visibleBooths.append(contentsOf: list)
+                }
+                return .none
                 
             case .photoBoothStreamFinished:
                 return .none

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
@@ -92,7 +92,7 @@ public struct MapFeature {
         case nearbyPhotoBoothResponse(Result<[PhotoBooth], Error>)
         case startBackgroundCalculation
         case processNewChunk([PhotoBooth], isFirstBatch: Bool)
-        case appendProcessedChunk(map: [PhotoBooth], list: [PhotoBooth], isFirstBatch: Bool)
+        case appendProcessedChunk(map: [PhotoBooth], isFirstBatch: Bool)
         case didFinishBackgroundCalculation(map: IdentifiedArrayOf<PhotoBooth>, list: IdentifiedArrayOf<PhotoBooth>)
         
         // Binding & Child
@@ -266,16 +266,14 @@ public struct MapFeature {
                 return .run { send in
                     let filteredChunk: [PhotoBooth]
                     filteredChunk = activeFilters.isEmpty ? chunk : chunk.filter { activeFilters.contains($0.brand) }
-                    await send(.appendProcessedChunk(map: filteredChunk, list: filteredChunk, isFirstBatch: isFirstBatch))
+                    await send(.appendProcessedChunk(map: filteredChunk, isFirstBatch: isFirstBatch))
                 }
                 
-            case let .appendProcessedChunk(map, list, isFirstBatch):
+            case let .appendProcessedChunk(map, isFirstBatch):
                 if isFirstBatch {
                     state.visiblePhotoBooths = IdentifiedArray(uniqueElements: map)
-                    state.photoBoothListState.visibleBooths = IdentifiedArrayOf(uniqueElements: list)
                 } else {
                     state.visiblePhotoBooths.append(contentsOf: map)
-                    state.photoBoothListState.visibleBooths.append(contentsOf: list)
                 }
                 return .none
                 
@@ -311,14 +309,8 @@ public struct MapFeature {
                 return .run { send in
                     let visibleMapBooths: IdentifiedArrayOf<PhotoBooth>
                     let visibleListBooths: IdentifiedArrayOf<PhotoBooth>
-                    if activeFilters.isEmpty {
-                        visibleMapBooths = mapBooths
-                        visibleListBooths = listBooths
-                    } else {
-                        visibleMapBooths = mapBooths.filter { activeFilters.contains($0.brand) }
-                        visibleListBooths = listBooths.filter { activeFilters.contains($0.brand) }
-                    }
-                    
+                    visibleMapBooths = activeFilters.isEmpty ? mapBooths : mapBooths.filter { activeFilters.contains($0.brand) }
+                    visibleListBooths = activeFilters.isEmpty ? listBooths : listBooths.filter { activeFilters.contains($0.brand) }
                     await send(.didFinishBackgroundCalculation(map: visibleMapBooths, list: visibleListBooths))
                 }
                 .cancellable(id: CancelID.calculation, cancelInFlight: true)


### PR DESCRIPTION
## 🌴 작업한 브랜치
- fix/#83-dealing-chunk-incrementally


## ✅ 작업한 내용
카메라 이동 등 사용자 인터랙션 발생 시, 데이터 처리 흐름을 개선하여 **이미 수신된 데이터가 취소되지 않고 안전하게 표시**되도록 변경했습니다.

1. **데이터 수신과 처리의 의존성 분리**
   - 기존: 지도 이동 시 `CancelID`에 의해 데이터 수신과 처리가 모두 중단되어, 직전에 들어온 청크가 무시되는 현상 발생
   - **변경**: `mapFetch`(수신)와 `processNewChunk`(계산 및 UI반영) 액션을 분리.
     - 지도가 이동하면 **새로운 데이터 수신은 중단**하되,
     - **이미 수신되어 계산 대기 중인 청크**는 취소되지 않고 끝까지 처리되도록 개선.

2. **기존 로직 유지 및 보수**
   - 리팩토링 과정에서 UI 데이터 교체 시점(`isFirstBatch`)과 필터링 로직이 유실되지 않도록 기존 스펙을 준수하여 재구현.

## ❗️PR Point
생략합니다.


## 📸 스크린샷
생략합니다.


## 📟 관련 이슈
- Resolved: #83


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 맵 화면에서 사진 부스를 배치 단위로 로드하고 순차 처리하는 파이프라인 도입
  * 첫 번째 배치에서 보이는 항목 초기화 및 이후 배치에서 안전하게 추가
  * 활성 브랜드 기반 필터링으로 지도 및 리스트 뷰에 반영되는 데이터 최적화
  * 백그라운드 계산 결과를 필터된 데이터로 적용하여 표시 일관성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->