### PR TITLE
[Fix] 마이페이지 QA 수정요청 대응

### DIFF
--- a/Neki-iOS/APP/Sources/Application/Neki_iOSApp.swift
+++ b/Neki-iOS/APP/Sources/Application/Neki_iOSApp.swift
@@ -7,8 +7,6 @@
 
 import SwiftUI
 import ComposableArchitecture
-import KakaoSDKCommon
-import KakaoSDKAuth
 
 @main
 struct Neki_iOSApp: App {

--- a/Neki-iOS/APP/Sources/Coordinator/AppCoordinator.swift
+++ b/Neki-iOS/APP/Sources/Coordinator/AppCoordinator.swift
@@ -65,9 +65,14 @@ struct AppCoordinator {
                 }
                 
             case let .userSessionStatusChanged(newStatus):
+                if state.userSessionStatus != newStatus { state.$userSessionStatus.withLock { $0 = newStatus } }
                 switch newStatus {
                 case let .signedIn(user):
-                    if case .mainTab = state.route { return .none }
+                    if case var .mainTab(mainTabState) = state.route {
+                        mainTabState.user = user
+                        state.route = .mainTab(.init(user: user))
+                        return .none
+                    }
                     state.route = .mainTab(.init(user: user))
                     return .none
                     

--- a/Neki-iOS/APP/Sources/Coordinator/AppCoordinator.swift
+++ b/Neki-iOS/APP/Sources/Coordinator/AppCoordinator.swift
@@ -94,6 +94,10 @@ struct AppCoordinator {
                 state.route = .auth(.init())
                 return .none
                 
+            case let .route(.mainTab(.delegate(.profileUpdated(user)))):
+                state.$userSessionStatus.withLock { $0 = .signedIn(user) }
+                return .none
+                
             default:
                 return .none
             }

--- a/Neki-iOS/APP/Sources/Coordinator/MainTabCoordinator.swift
+++ b/Neki-iOS/APP/Sources/Coordinator/MainTabCoordinator.swift
@@ -46,6 +46,7 @@ struct MainTabCoordinator {
         case delegate(Delegate)
         enum Delegate {
             case signedOut
+            case profileUpdated(User)
         }
     }
     
@@ -80,6 +81,9 @@ struct MainTabCoordinator {
                 
             case .myPage(.delegate(.didLogout)), .myPage(.delegate(.didWithdraw)):
                 return .send(.delegate(.signedOut))
+                
+            case let .myPage(.delegate(.profileUpdated(user))):
+                return .send(.delegate(.profileUpdated(user)))
                 
             default:
                 return .none

--- a/Neki-iOS/Core/Sources/Auth/Sources/Domain/Sources/Clients/AuthClient.swift
+++ b/Neki-iOS/Core/Sources/Auth/Sources/Domain/Sources/Clients/AuthClient.swift
@@ -29,7 +29,7 @@ public struct AuthClient {
     public var autoLogin: @Sendable () async throws -> User
     public var signOut: @Sendable () async throws -> Void
     public var withdraw: @Sendable () async throws -> Void
-    public var updateProfile: @Sendable (_ nickname: String?, _ updateAction: ProfileImageUpdateAction) async throws -> Void
+    public var updateProfile: @Sendable (_ nickname: String?, _ updateAction: ProfileImageUpdateAction) async throws -> User
     public var handleKakaoOpenURL: @Sendable (_ url: URL) -> Void
 }
 
@@ -98,7 +98,7 @@ extension AuthClient: DependencyKey {
             }
         }
         
-        @Sendable func updateProfile(_ nickname: String?, _ updateAction: ProfileImageUpdateAction) async throws -> Void {
+        @Sendable func updateProfile(_ nickname: String?, _ updateAction: ProfileImageUpdateAction) async throws -> User {
             let editAction: ProfileImageEditAction
             switch updateAction {
             case .new(let data):
@@ -136,6 +136,7 @@ extension AuthClient: DependencyKey {
             
             do {
                 try await authRepository.updateProfile(nickname: nickname, editAction: editAction)
+                return try await authRepository.fetchUser()
             } catch {
                 throw AuthClient.mapError(error)
             }

--- a/Neki-iOS/Core/Sources/Auth/Sources/Domain/Sources/Clients/AuthClient.swift
+++ b/Neki-iOS/Core/Sources/Auth/Sources/Domain/Sources/Clients/AuthClient.swift
@@ -14,6 +14,7 @@ import KakaoSDKUser
 import KakaoSDKCert
 import KakaoSDKCommon
 import os
+import UniformTypeIdentifiers
 
 public enum ProfileImageUpdateAction: Sendable, Equatable {
     case new(Data)
@@ -102,7 +103,24 @@ extension AuthClient: DependencyKey {
             switch updateAction {
             case .new(let data):
                 do {
-                    let imageEntity = ImageUploadEntity(data: data, format: .jpeg)
+                    let detectedType = data.detectedContentType
+                    let finalData: Data
+                    let finalFormat: ImageFileFormat
+                    
+                    if let detectedType, detectedType.conforms(to: .png) {
+                        finalData = data
+                        finalFormat = .png
+                    } else {
+                        if let processedImage = await ImageDownsamplingProcessor.process(data: data) {
+                            finalData = processedImage.data
+                            finalFormat = .jpeg
+                        } else {
+                            finalData = data
+                            finalFormat = .jpeg
+                        }
+                    }
+                    
+                    let imageEntity = ImageUploadEntity(data: finalData, format: finalFormat)
                     guard let id = try await imageUploadRepository.upload(items: [imageEntity], mediaType: .userProfile).first else { throw AuthClientError.serverError("프로필 이미지 업로드 실패") }
                     editAction = .update(id)
                 } catch {

--- a/Neki-iOS/Core/Sources/ImagePicker/Presentation/Extension/Data+.swift
+++ b/Neki-iOS/Core/Sources/ImagePicker/Presentation/Extension/Data+.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import ImageIO
+import UniformTypeIdentifiers
 
 extension Data {
     /// 데이터의 매직넘버(MagicNumber)를 확인하여 이미지 포맷을 판별합니다.
@@ -32,5 +34,12 @@ extension Data {
         
         // 나머지는 JPEG로
         return .jpeg
+    }
+    
+    var detectedContentType: UTType? {
+        guard let source = CGImageSourceCreateWithData(self as CFData, nil),
+              let typeIdentifier = CGImageSourceGetType(source)
+        else { return nil }
+        return UTType(typeIdentifier as String)
     }
 }

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Clients/MapClient.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Clients/MapClient.swift
@@ -39,7 +39,7 @@ extension MapClient {
     final class MapDelegate: NSObject {
         let locationManager = CLLocationManager()
         
-        var authStatusContinuation: AsyncStream<CLAuthorizationStatus>.Continuation?
+        var authStatusContinuations: [UUID: AsyncStream<CLAuthorizationStatus>.Continuation] = [:]
         var sdkAuthStatusContinuation: AsyncStream<Bool>.Continuation?
         var locationContinuation: CheckedContinuation<CLLocation, Error>?
         var trackingContinuations: [UUID: AsyncStream<CLLocation>.Continuation] = [:]
@@ -67,6 +67,15 @@ extension MapClient {
             locationManager.requestLocation()
         }
         
+        func registerAuthStatus(id: UUID, continuation: AsyncStream<CLAuthorizationStatus>.Continuation) {
+            authStatusContinuations[id] = continuation
+            continuation.yield(locationManager.authorizationStatus)
+        }
+        
+        func unregisterAuthStatus(id: UUID) {
+            authStatusContinuations[id] = nil
+        }
+        
         func startMonitoring(id: UUID, _ continuation: AsyncStream<CLLocation>.Continuation) {
             if trackingContinuations.isEmpty { locationManager.startUpdatingLocation() }
             trackingContinuations[id] = continuation
@@ -84,7 +93,9 @@ extension MapClient {
 
 extension MapClient.MapDelegate: CLLocationManagerDelegate {
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        authStatusContinuation?.yield(manager.authorizationStatus)
+        for continuation in authStatusContinuations.values {
+            continuation.yield(manager.authorizationStatus)
+        }
         
         switch manager.authorizationStatus {
         case .authorizedAlways, .authorizedWhenInUse:
@@ -152,14 +163,15 @@ extension MapClient: DependencyKey {
     public static var liveValue: MapClient = {
         MapClient {
             AsyncStream { continuation in
+                let id = UUID()
                 Task { @MainActor in
-                    sharedDelegate.authStatusContinuation = continuation
+                    sharedDelegate.registerAuthStatus(id: id, continuation: continuation)
                     continuation.yield(sharedDelegate.locationManager.authorizationStatus)
                 }
                 
                 continuation.onTermination = { _ in
                     Task { @MainActor in
-                        sharedDelegate.authStatusContinuation = nil
+                        sharedDelegate.unregisterAuthStatus(id: id)
                     }
                 }
             }

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Clients/MapClient.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Clients/MapClient.swift
@@ -69,7 +69,6 @@ extension MapClient {
         
         func registerAuthStatus(id: UUID, continuation: AsyncStream<CLAuthorizationStatus>.Continuation) {
             authStatusContinuations[id] = continuation
-            continuation.yield(locationManager.authorizationStatus)
         }
         
         func unregisterAuthStatus(id: UUID) {

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Coordinator/MyPageCoordinator.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Coordinator/MyPageCoordinator.swift
@@ -32,14 +32,15 @@ struct MyPageCoordinator {
         }
     }
     
+    @Dependency(\.openURL) private var openURL
+    
     var body: some ReducerOf<Self> {
         Scope(state: \.root, action: \.root) { MyPageFeature() }
         
         Reduce { (state: inout State, action: Action) -> Effect<Action> in
             switch action {
             case let .root(.cellTapped(cellItem)):
-                routeMyPageCellTapped(state: &state, cellItem)
-                return .none
+                return routeMyPageCellTapped(state: &state, cellItem)
                 
             case .root(.profileTapped):
                 state.path.append(.accountPreference(.init(user: state.root.user)))
@@ -65,23 +66,32 @@ struct MyPageCoordinator {
         .forEach(\.path, action: \.path)
     }
     
-    private func routeMyPageCellTapped(state: inout State, _ cellItem: MyPageFeature.SectionCellItem) {
+    private func routeMyPageCellTapped(state: inout State, _ cellItem: MyPageFeature.SectionCellItem) -> Effect<Action> {
         switch cellItem {
         case .deviceAuthorization:
             state.path.append(.deviceAuthorizationPreference(.init()))
+            return .none
             
         case .support:
-            // TODO: 노션 등 외부 웹페이지로 이동
-            break
+            return .run { _ in
+                guard let url = URL(string: "https://tally.so/r/obGpRX") else { return }
+                await openURL(url)
+            }
+            
         case .termsOfService:
-            // TODO: 노션 등 외부 웹페이지로 이동
-            break
+            return .run { _ in
+                guard let url = URL(string: "https://lydian-tip-26b.notion.site/2ee0d9441db0807c8684ce3e2d4b8aca?source=copy_link") else { return }
+                await openURL(url)
+            }
+            
         case .privacyPolicy:
-            // TODO: 노션 등 외부 웹페이지로 이동
-            break
+            return .run { _ in
+                guard let url = URL(string: "https://lydian-tip-26b.notion.site/2ee0d9441db0807cb850f78145db6dd3?pvs=74") else { return }
+                await openURL(url)
+            }
+            
         case .version:
-            // Version 섹션은 라우팅할 수 있는 셀이 아님
-            break
+            return .none
         }
     }
 }

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Coordinator/MyPageCoordinator.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Coordinator/MyPageCoordinator.swift
@@ -28,6 +28,7 @@ struct MyPageCoordinator {
         enum Delegate {
             case didLogout
             case didWithdraw
+            case profileUpdated(User)
         }
     }
     
@@ -53,6 +54,9 @@ struct MyPageCoordinator {
                 
             case .path(.element(id: _, action: .accountPreference(.didWithdraw))):
                 return .send(.delegate(.didWithdraw))
+                
+            case let .path(.element(id: _, action: .profileEdit(.profileUpdated(user)))):
+                return .send(.delegate(.profileUpdated(user)))
                 
             default:
                 return .none

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/DeviceAuthorizationPreferenceFeature.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/DeviceAuthorizationPreferenceFeature.swift
@@ -175,7 +175,7 @@ struct DeviceAuthorizationPreferenceFeature {
                 
             case let .updateCameraStatus(status):
                 state.cameraAuthorizationStatus = status
-                return.none
+                return .none
                 
             case let .updatePhotosStatus(status):
                 state.photosAuthorizationStatus = status

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/DeviceAuthorizationPreferenceFeature.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/DeviceAuthorizationPreferenceFeature.swift
@@ -92,7 +92,7 @@ struct DeviceAuthorizationPreferenceFeature {
                         }
                     },
                     .run { send in
-                        let status = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
+                        let status = PHPhotoLibrary.authorizationStatus(for: .addOnly)
                         await send(.updatePhotosStatus(status))
                     }
                 )

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/DeviceAuthorizationPreferenceFeature.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/DeviceAuthorizationPreferenceFeature.swift
@@ -5,7 +5,7 @@
 //  Created by SwainYun on 1/20/26.
 //
 
-import Foundation
+import UIKit
 import ComposableArchitecture
 import AVFoundation
 import CoreLocation
@@ -17,33 +17,176 @@ import Photos
 struct DeviceAuthorizationPreferenceFeature {
     @ObservableState
     struct State: Equatable {
-        @ObservationStateIgnored private var cameraAuthorizationStatus: AVAuthorizationStatus = .notDetermined
-        @ObservationStateIgnored private var locationAuthorizationStatus: CLAuthorizationStatus = .notDetermined
-        @ObservationStateIgnored private var photosAuthorizationStatus: PHAuthorizationStatus = .notDetermined
+        var cameraAuthorizationStatus: AVAuthorizationStatus = .notDetermined
+        var locationAuthorizationStatus: CLAuthorizationStatus = .notDetermined
+        var photosAuthorizationStatus: PHAuthorizationStatus = .notDetermined
         
         var isCameraAuthorized: Bool { cameraAuthorizationStatus == .authorized }
         var isLocationAuthorized: Bool { locationAuthorizationStatus == .authorizedAlways || locationAuthorizationStatus == .authorizedWhenInUse }
         var isPhotosAuthorized: Bool { photosAuthorizationStatus == .authorized || photosAuthorizationStatus == .limited }
+        
+        var isAlertPresented: Bool = false
+        var alertItem: AlertItem?
     }
     
-    enum Action {
+    enum Action: BindableAction {
         // View Actions
         case onAppear
         case dismissButtonTapped
+        case cameraCellTapped
+        case locationCellTapped
+        case photosCellTapped
+        
+        // Internal Actions
+        case updateCameraStatus(AVAuthorizationStatus)
+        case updateLocationStatus(CLAuthorizationStatus)
+        case updatePhotosStatus(PHAuthorizationStatus)
+        case openAppSettings
+        case alertDismissed
+        
+        // Binding Actions
+        case binding(BindingAction<State>)
+    }
+    
+    enum AlertItem {
+        case notification, photos, location, camera
+        
+        var title: String {
+            switch self {
+            case .notification: return "알림 권한"
+            case .photos: return "갤러리 권한"
+            case .location: return "위치 권한"
+            case .camera: return "카메라 권한"
+            }
+        }
+        
+        var description: String {
+            switch self {
+            case .notification: return "사진 저장 완료 오류 안내를 알려드리기 위해 알림 권한이 필요해요."
+            case .photos: return "사진을 불러와 네키에 저장 및 관리하기 위해 갤러리 접근 권한이 필요해요."
+            case .location: return "주변 포토부스를 찾기 위해 위치 사용 권한이 필요해요"
+            case .camera: return "QR 인식을 위해 카메라 접근이 필요해요."
+            }
+        }
     }
     
     @Dependency(\.dismiss) private var dismiss
+    @Dependency(\.qrScannerClient) private var qrScannerClient
+    @Dependency(\.mapClient) private var mapClient
+    @Dependency(\.openURL) private var openURL
     
     var body: some ReducerOf<Self> {
+        BindingReducer()
+        
         Reduce { (state: inout State, action: Action) -> Effect<Action> in
-            // TODO: 액션 추가되면 로직 작성하기
             switch action {
             case .onAppear:
-                // TODO: 클라이언트 의존성에서 권한 상태값 구독하기
-                return .none
+                return .merge(
+                    .run { send in
+                        let status = qrScannerClient.checkAuthorizationStatus()
+                        await send(.updateCameraStatus(status))
+                    },
+                    .run { send in
+                        for await status in await mapClient.locationAuthorizationStatus() {
+                            await send(.updateLocationStatus(status))
+                        }
+                    },
+                    .run { send in
+                        let status = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
+                        await send(.updatePhotosStatus(status))
+                    }
+                )
                 
             case .dismissButtonTapped:
                 return .run { _ in await dismiss() }
+                
+            case .cameraCellTapped:
+                switch state.cameraAuthorizationStatus {
+                case .notDetermined:
+                    return .run { send in
+                        _ = await qrScannerClient.requestAccess()
+                        let newStatus = qrScannerClient.checkAuthorizationStatus()
+                        await send(.updateCameraStatus(newStatus))
+                    }
+                    
+                case .denied, .restricted:
+                    state.alertItem = .camera
+                    state.isAlertPresented = true
+                    return .none
+                    
+                case .authorized:
+                    return .send(.openAppSettings)
+                    
+                @unknown default:
+                    return .none
+                }
+                
+            case .locationCellTapped:
+                switch state.locationAuthorizationStatus {
+                case .notDetermined:
+                    return .run { send in
+                        await mapClient.requestLocationAuthorization()
+                    }
+                    
+                case .denied, .restricted:
+                    state.alertItem = .location
+                    state.isAlertPresented = true
+                    return .none
+                    
+                case .authorizedAlways, .authorizedWhenInUse:
+                    return .send(.openAppSettings)
+                    
+                @unknown default:
+                    return .none
+                }
+                
+            case .photosCellTapped:
+                switch state.photosAuthorizationStatus {
+                case .notDetermined:
+                    return .run { send in
+                        let newStatus = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
+                        await send(.updatePhotosStatus(newStatus))
+                    }
+                    
+                case .denied, .restricted:
+                    state.alertItem = .photos
+                    state.isAlertPresented = true
+                    return .none
+                    
+                case .authorized, .limited:
+                    return .send(.openAppSettings)
+                    
+                @unknown default:
+                    return .none
+                }
+                
+            case .openAppSettings:
+                state.alertItem = nil
+                state.isAlertPresented = false
+                return .run { send in
+                    guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                    await openURL(url)
+                }
+                
+            case .alertDismissed:
+                state.alertItem = nil
+                state.isAlertPresented = false
+                return .none
+                
+            case let .updateCameraStatus(status):
+                state.cameraAuthorizationStatus = status
+                return.none
+                
+            case let .updatePhotosStatus(status):
+                state.photosAuthorizationStatus = status
+                return .none
+                
+            case let .updateLocationStatus(status):
+                state.locationAuthorizationStatus = status
+                return .none
+                
+            default:
+                return .none
             }
         }
     }

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/MyPageFeature.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/MyPageFeature.swift
@@ -20,15 +20,9 @@ struct MyPageFeature {
         case profileTapped
     }
     
-    @Dependency(\.openURL) private var openURL
-    
     var body: some ReducerOf<Self> {
         Reduce { (state: inout State, action: Action) -> Effect<Action> in
             switch action {
-            case let .cellTapped(item):
-                // TODO: 노션 이동시키기
-                return .none
-                
             default:
                 return .none
             }
@@ -41,7 +35,7 @@ struct MyPageFeature {
 
 extension MyPageFeature {
     enum SectionItem: String {
-        case authorizationSettings = "권한 설정"
+        case authorizationSettings = "권한"
         case support = "서비스 정보 및 지원"
         
         var title: String { rawValue }
@@ -55,7 +49,7 @@ extension MyPageFeature {
     }
     
     enum SectionCellItem: String, Identifiable {
-        case deviceAuthorization = "기기 권한"
+        case deviceAuthorization = "권한 설정하기"
         case support = "Neki에 문의하기"
         case termsOfService = "이용약관"
         case privacyPolicy = "개인정보 처리방침"

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/ProfileEditFeature.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/ProfileEditFeature.swift
@@ -48,6 +48,8 @@ struct ProfileEditFeature {
         case binding(BindingAction<State>)
     }
     
+    private enum CancelID { case imageLoad }
+    
     @Dependency(\.dismiss) private var dismiss
     @Dependency(\.authClient) private var authClient
     
@@ -62,7 +64,7 @@ struct ProfileEditFeature {
                 state.selectedImageData = nil
                 state.currentProfileImageURL = nil
                 state.isDefaultImageSelected = true
-                return .none
+                return .cancel(id: CancelID.imageLoad)
                 
             case let .pickerItemChanged(item):
                 guard let item else { return .none }
@@ -75,6 +77,7 @@ struct ProfileEditFeature {
                         await send(.imageLoaded(nil))
                     }
                 }
+                .cancellable(id: CancelID.imageLoad, cancelInFlight: true)
             
             case let .imageLoaded(data):
                 guard let data, let image = UIImage(data: data) else { return .none }

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/ProfileEditFeature.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/ProfileEditFeature.swift
@@ -46,10 +46,13 @@ struct ProfileEditFeature {
         case doneButtonTapped
         
         // Internal & Network Actions
-        case updateProfileResponse(Result<Void, Error>)
+        case updateProfileResponse(Result<User, Error>)
         
         // Binding Actions
         case binding(BindingAction<State>)
+        
+        // Delegate Actions
+        case profileUpdated(User)
     }
     
     private enum CancelID { case imageLoad }
@@ -119,16 +122,19 @@ struct ProfileEditFeature {
                 
                 return .run { [user = state.user, nickname = state.nickname, imageAction] send in
                     do {
-                        try await authClient.updateProfile(nickname: user.nickname == nickname ? nil : nickname, updateAction: imageAction)
-                        await send(.updateProfileResponse(.success(())))
+                        let user = try await authClient.updateProfile(nickname: user.nickname == nickname ? nil : nickname, updateAction: imageAction)
+                        await send(.updateProfileResponse(.success(user)))
                     } catch {
                         await send(.updateProfileResponse(.failure(error)))
                     }
                 }
                 
-            case .updateProfileResponse(.success):
+            case let .updateProfileResponse(.success(user)):
                 state.isLoading = false
-                return .run { _ in await dismiss() }
+                return .run { send in
+                    await send(.profileUpdated(user))
+                    await dismiss()
+                }
                 
             case let .updateProfileResponse(.failure(error)):
                 state.isLoading = false

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/ProfileEditFeature.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/ProfileEditFeature.swift
@@ -27,6 +27,8 @@ struct ProfileEditFeature {
         var isLoading: Bool = false
         let nicknameLengthLimit: Int = 10
         
+        var isProfileSelectionAlertPresented: Bool = false
+        
         init(user: User) {
             self.user = user
             nickname = user.nickname
@@ -36,6 +38,8 @@ struct ProfileEditFeature {
     
     enum Action: BindableAction {
         // View Actions
+        case openProfileEditAlert
+        case closeProfileEditAlert
         case changeToDefaultProfileImage
         case pickerItemChanged(PhotosPickerItem?)
         case imageLoaded(Data?)
@@ -58,12 +62,21 @@ struct ProfileEditFeature {
         
         Reduce { (state: inout State, action: Action) -> Effect<Action> in
             switch action {
+            case .openProfileEditAlert:
+                state.isProfileSelectionAlertPresented = true
+                return .none
+                
+            case .closeProfileEditAlert:
+                state.isProfileSelectionAlertPresented = false
+                return .none
+                
             case .changeToDefaultProfileImage:
                 state.selectedPickerItem = nil
                 state.selectedProfileImage = nil
                 state.selectedImageData = nil
                 state.currentProfileImageURL = nil
                 state.isDefaultImageSelected = true
+                state.isProfileSelectionAlertPresented = false
                 return .cancel(id: CancelID.imageLoad)
                 
             case let .pickerItemChanged(item):

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/AccountPreferenceView.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/AccountPreferenceView.swift
@@ -74,6 +74,7 @@ private extension AccountPreferenceView {
                 .onFailureImage(.iconDefaultProfile)
                 .scaledToFill()
                 .frame(width: 142, height: 142)
+                .clipShape(.circle)
             
             HStack(spacing: 9) {
                 Text(store.user.nickname)

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/DeviceAuthorizationPreferenceView.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/DeviceAuthorizationPreferenceView.swift
@@ -59,6 +59,7 @@ struct DeviceAuthorizationPreferenceView: View {
             onConfirm: { store.send(.openAppSettings) },
             onCancel: { store.send(.alertDismissed) }
         )
+        .onAppear { store.send(.onAppear) }
     }
 }
 

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/DeviceAuthorizationPreferenceView.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/DeviceAuthorizationPreferenceView.swift
@@ -16,15 +16,15 @@ struct DeviceAuthorizationPreferenceView: View {
             Section {
                 VStack(spacing: 24) {
                     cell(for: .camera, isAuthorized: store.isCameraAuthorized) {
-                        // TODO: 카메라 권한 요청 로직 작성
+                        store.send(.cameraCellTapped)
                     }
                     
                     cell(for: .location, isAuthorized: store.isLocationAuthorized) {
-                        // TODO: 위치 권한 요청 로직 작성
+                        store.send(.locationCellTapped)
                     }
                     
                     cell(for: .photos, isAuthorized: store.isPhotosAuthorized) {
-                        // TODO: 사진앱 권한 요청 로직 작성
+                        store.send(.photosCellTapped)
                     }
                     
                     // TODO: 알림 기능부터 구현 필요
@@ -48,7 +48,17 @@ struct DeviceAuthorizationPreferenceView: View {
         } center: {
             NekiToolBar.textCenter("기기 권한")
         }
-
+        .nekiAlert(
+            isPresented: $store.isAlertPresented,
+            style: .cancelable,
+            title: store.alertItem?.title ?? "권한 안내",
+            subtitle: store.alertItem?.description ?? "원활한 서비스 제공을 위해 권한을 허용해주세요.",
+            confirmText: "허용",
+            cancelText: "취소",
+            hasIcon: true,
+            onConfirm: { store.send(.openAppSettings) },
+            onCancel: { store.send(.alertDismissed) }
+        )
     }
 }
 

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/ProfileEditView.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/ProfileEditView.swift
@@ -14,7 +14,6 @@ struct ProfileEditView: View {
     @Environment(\.dismiss) private var dismiss
     @FocusState private var isFocused
     @Bindable var store: StoreOf<ProfileEditFeature>
-    @State private var isProfileSelectionAlertPresented: Bool = false
     
     var body: some View {
         ZStack {
@@ -36,7 +35,7 @@ struct ProfileEditView: View {
                     .clipShape(.circle)
                     
                     Button {
-                        isProfileSelectionAlertPresented = true
+                        store.send(.openProfileEditAlert)
                     } label: {
                         Image(.iconProfileCamera)
                     }
@@ -62,7 +61,7 @@ struct ProfileEditView: View {
             center: { NekiToolBar.textCenter("프로필 편집") },
             right: { NekiToolBar.textRight("완료", isEnabled: store.doneButtonDisabled == false) { store.send(.doneButtonTapped) } }
         )
-        .nekiSelectAlert(isPresented: $isProfileSelectionAlertPresented) {
+        .nekiSelectAlert(isPresented: $store.isProfileSelectionAlertPresented) {
             // 별도의 onExit 동작 없음
         } content: {
             VStack(spacing: 4) {
@@ -81,7 +80,7 @@ struct ProfileEditView: View {
                 }
                 .onChange(of: store.selectedPickerItem) { _, newValue in
                     guard newValue != nil else { return }
-                    isProfileSelectionAlertPresented = false
+                    store.send(.closeProfileEditAlert)
                 }
             }
             .padding(.vertical, 12)

--- a/Neki-iOS/Shared/DesignSystem/Sources/Component/Modal/NekiAlertModal.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Component/Modal/NekiAlertModal.swift
@@ -38,10 +38,11 @@ public struct NekiAlertModal<Content: View, Actions: View>: View {
             
             content
                 .padding(.horizontal, 12)
-            
-            actions
                 .padding(.top, 24)
                 .padding(.bottom, 12)
+            
+            actions
+                .padding(.vertical, 12)
                 .padding(.horizontal, 12)
         }
         .frame(maxWidth: .infinity)

--- a/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiAlertModifier.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiAlertModifier.swift
@@ -156,19 +156,3 @@ public extension View {
         ))
     }
 }
-
-#Preview {
-    VStack {
-        
-    }
-    .nekiAlert(
-        isPresented: .constant(true),
-        style: .cancelable,
-        title: "로그아웃 하시겠습니까?",
-        subtitle: "다시 로그인해야 서비스를 이용할 수 있어요.",
-        confirmText: "확인",
-        cancelText: "취소",
-        isProcessing: false,
-        hasIcon: false
-    )
-}

--- a/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiAlertModifier.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiAlertModifier.swift
@@ -43,7 +43,7 @@ struct NekiAlertModifier: ViewModifier {
                     }
                 
                 NekiAlertModal(hasIcon: hasIcon) {
-                    VStack(spacing: 2) {
+                    VStack(spacing: 4) {
                         Text(title)
                             .nekiFont(.title18Bold)
                             .foregroundStyle(.gray900)
@@ -155,4 +155,20 @@ public extension View {
             onSecondary: onSecondary
         ))
     }
+}
+
+#Preview {
+    VStack {
+        
+    }
+    .nekiAlert(
+        isPresented: .constant(true),
+        style: .cancelable,
+        title: "로그아웃 하시겠습니까?",
+        subtitle: "다시 로그인해야 서비스를 이용할 수 있어요.",
+        confirmText: "확인",
+        cancelText: "취소",
+        isProcessing: false,
+        hasIcon: false
+    )
 }


### PR DESCRIPTION
## 🌴 작업한 브랜치
- fix/#95-myPage-qa


## ✅ 작업한 내용

1. 앱 모듈에서 KakaoSDK 불필요 임포팅 코드를 정리했습니다.
2. 세션 상태 변경이 AppStorage에 반영될 수 있도록 동기화했습니다.
3. 프로필사진 관련 방어코드를 추가했습니다. (취소 동작, 원형 클리핑, 확장자 체크 및 JPEG 변환)
4. NekiAlert 레이아웃이 디자인 시안과 다른 문제를 해결했습니다.
5. 각종 기기권한을 추적하고 프리퍼미션 얼럿 등과 함께 설정 앱으로 이동할 수 있도록 했습니다.
6. 그 외 노션 이동 등 마이페이지 관련 미구현 사항에 대해 작업했습니다.


## ❗️PR Point
네트워킹 모델 반환타입 변경을 준비 중입니다. (QA 사항 중 일부)
그런데 이걸 바꾸면 모든 모듈의 레포지토리에서 Endpoint 쏘는 부분을 아주 양껏 수정해야할 것 같습니다.
따라서 디스코드 화면공유 하면서 어떻게 바뀌는지 설명드리고, 리팩토링하면 좋을 것 같습니다!


## 📸 스크린샷
QA 시트로 대체, 생략합니다.


## 📟 관련 이슈
- Resolved: #95


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로필 편집 시 이미지 업로드/삭제/유지 옵션 추가
  * 프로필 업데이트 후 변경된 정보가 즉시 반영되도록 알림 전파

* **UI/디자인**
  * 프로필 이미지 원형 표시
  * 알림(Modal) 레이아웃 및 간격 조정

* **개선사항**
  * 기기 권한 관리 UI 강화(카메라/위치/사진) 및 권한 관련 안내·설정 이동 지원
  * 사용자 세션 상태 동기화 및 권한 상태 처리 최적화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->