### PR TITLE
[Fix] 포즈 QA 수정요청 대응

### DIFF
--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/PoseView.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/PoseView.swift
@@ -53,7 +53,6 @@ struct PoseView: View {
                         .autoSizingDetent($sheetHeight)
                 }
             }
-            .presentationDetents([.height(sheetHeight)])
             .presentationCornerRadius(20)
             .presentationDragIndicator(.hidden)
         }

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/PoseView.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/PoseView.swift
@@ -14,6 +14,7 @@ struct PoseView: View {
     
     @State private var isFilterBarVisible: Bool = true
     @State private var lastDragPoint: CGFloat = 0
+    @State private var sheetHeight: CGFloat = 1
     
     //MARK: - Properties
     
@@ -42,10 +43,19 @@ struct PoseView: View {
             right: { NekiToolBar.icon(.iconBellFill) }
         )
         .sheet(item: $store.sheetItem) { item in
-            switch item {
-            case .peopleCountFilter: filterSheetView
-            case .randomPoseCountSelection: randomPoseFilterSheetView
+            Group {
+                switch item {
+                case .peopleCountFilter:
+                    PeopleCountFilterSheet(contentHeight: $sheetHeight, store: store)
+                        .autoSizingDetent($sheetHeight)
+                case .randomPoseCountSelection:
+                    RandomPoseSelectionSheet(contentHeight: $sheetHeight, store: store)
+                        .autoSizingDetent($sheetHeight)
+                }
             }
+            .presentationDetents([.height(sheetHeight)])
+            .presentationCornerRadius(20)
+            .presentationDragIndicator(.hidden)
         }
         .task {
             await store.send(.onAppear).finish()
@@ -138,121 +148,146 @@ private extension PoseView {
             }
         }
     }
-    
-    @ViewBuilder
-    var filterSheetView: some View {
-        VStack(spacing: 4) {
-            Capsule()
-                .frame(width: 45, height: 4)
-                .padding(.horizontal, 165)
-                .padding(.vertical, 10)
-                .foregroundStyle(.gray100)
-            
-            VStack(alignment: .leading, spacing: 24) {
-                Text("인원 수")
-                    .nekiFont(.title20SemiBold)
-                    .foregroundStyle(.gray900)
+}
+
+
+// MARK: - Subviews
+
+private extension PoseView {
+    struct PeopleCountFilterSheet: View {
+        @Binding var contentHeight: CGFloat
+        
+        let store: StoreOf<PoseFeature>
+        
+        var body: some View {
+            VStack(spacing: 4) {
+                Capsule()
+                    .frame(width: 45, height: 4)
+                    .padding(.horizontal, 165)
+                    .padding(.vertical, 10)
+                    .foregroundStyle(.gray100)
                 
-                ForEach(PeopleCountOption.allCases.filter({ $0 != .overQuartet }), id: \.self) { option in
-                    Button {
-                        store.send(.selectPeopleCount(option))
-                    } label: {
-                        HStack(alignment: .center, spacing: 8) {
-                            let isHighlighted = store.selectedCountFilterOption == option
-                            if isHighlighted {
-                                Image(.iconCheckmark)
+                VStack(alignment: .leading, spacing: 24) {
+                    Text("인원 수")
+                        .nekiFont(.title20SemiBold)
+                        .foregroundStyle(.gray900)
+                    
+                    ForEach(PeopleCountOption.allCases.filter({ $0 != .overQuartet }), id: \.self) { option in
+                        Button {
+                            store.send(.selectPeopleCount(option))
+                        } label: {
+                            HStack(alignment: .center, spacing: 8) {
+                                let isHighlighted = store.selectedCountFilterOption == option
+                                if isHighlighted {
+                                    Image(.iconCheckmark)
+                                }
+                                
+                                Text(option.displayName)
+                                    .nekiFont(isHighlighted ? .body16SemiBold : .body16Medium)
+                                    .foregroundStyle(isHighlighted ? .gray900 : .gray600)
                             }
-                            
-                            Text(option.displayName)
-                                .nekiFont(isHighlighted ? .body16SemiBold : .body16Medium)
-                                .foregroundStyle(isHighlighted ? .gray900 : .gray600)
+                            .frame(maxWidth: .infinity, alignment: .leading)
                         }
-                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
-                
-                Spacer()
+                .padding()
             }
-            .padding()
+            .ignoresSafeArea(.container, edges: .bottom)
+            .safeAreaPadding(.bottom)
+            .presentationBackground(.white)
         }
-        .background(.white)
-        .presentationDetents([.height(308)])
-        .presentationCornerRadius(20)
-        .presentationDragIndicator(.hidden)
     }
     
-    var randomPoseFilterSheetView: some View {
-        VStack(spacing: 4) {
-            Capsule()
-                .frame(width: 45, height: 4)
-                .padding(.horizontal, 165)
-                .padding(.vertical, 10)
-                .foregroundStyle(.gray100)
-            
-            VStack(alignment: .leading, spacing: 24) {
-                Text("랜덤 포즈 추천을 위해\n촬영 중인 인원수를 선택해주세요")
-                    .nekiFont(.title20SemiBold)
-                    .foregroundStyle(.gray900)
+    struct RandomPoseSelectionSheet: View {
+        @Binding var contentHeight: CGFloat
+        
+        let store: StoreOf<PoseFeature>
+        
+        var body: some View {
+            VStack(spacing: 4) {
+                Capsule()
+                    .frame(width: 45, height: 4)
+                    .padding(.horizontal, 165)
+                    .padding(.vertical, 10)
+                    .foregroundStyle(.gray100)
                 
-                ForEach(PeopleCountOption.allCases.filter({ $0 != .overQuartet }), id: \.self) { option in
-                    Button {
-                        store.send(.selectPeopleCountForRandomPose(option))
-                    } label: {
-                        HStack(alignment: .center, spacing: 8) {
-                            let isHighlighted: Bool = store.selectedRandomPoseCountSelectionOption == option
-                            if isHighlighted {
-                                Image(.iconCheckmark)
+                VStack(alignment: .leading, spacing: 24) {
+                    Text("랜덤 포즈 추천을 위해\n촬영 중인 인원수를 선택해주세요")
+                        .nekiFont(.title20SemiBold)
+                        .foregroundStyle(.gray900)
+                    
+                    ForEach(PeopleCountOption.allCases.filter({ $0 != .overQuartet }), id: \.self) { option in
+                        Button {
+                            store.send(.selectPeopleCountForRandomPose(option))
+                        } label: {
+                            HStack(alignment: .center, spacing: 8) {
+                                let isHighlighted: Bool = store.selectedRandomPoseCountSelectionOption == option
+                                if isHighlighted {
+                                    Image(.iconCheckmark)
+                                }
+                                
+                                Text(option.displayName)
+                                    .nekiFont(isHighlighted ? .body16SemiBold : .body16Medium)
+                                    .foregroundStyle(isHighlighted ? .gray900 : .gray600)
                             }
-                            
-                            Text(option.displayName)
-                                .nekiFont(isHighlighted ? .body16SemiBold : .body16Medium)
-                                .foregroundStyle(isHighlighted ? .gray900 : .gray600)
+                            .frame(maxWidth: .infinity, alignment: .leading)
                         }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                }
-                
-                HStack(spacing: 12) {
-                    let designTotalWidth: CGFloat = 375.0
-                    let designPadding: CGFloat = 20.0 * 2
-                    let designSpacing: CGFloat = 12.0
-                    let contentWidth = designTotalWidth - designPadding - designSpacing
-                    let cancelFactor = 93.0 / contentWidth
-                    let selectFactor = 230.0 / contentWidth
-                    
-                    Button {
-                        store.send(.binding(.set(\.sheetItem, nil)))
-                    } label: {
-                        Text("취소")
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.5)
-                    }
-                    .buttonStyle(.nekiCTA(.secondary))
-                    .containerRelativeFrame(.horizontal) { length, _ in
-                        let availableSpace = length - designPadding - designSpacing
-                        return availableSpace * cancelFactor
                     }
                     
-                    Button {
-                        store.send(.onTapStartRandomPoseCarousel)
-                    } label: {
-                        Text("선택하기")
-                    }
-                    .buttonStyle(.nekiCTA(.primary))
-                    .containerRelativeFrame(.horizontal) { length, _ in
-                        let availableSpace = length - designPadding - designSpacing
-                        return availableSpace * selectFactor
+                    HStack(spacing: 12) {
+                        let designTotalWidth: CGFloat = 375.0
+                        let designPadding: CGFloat = 20.0 * 2
+                        let designSpacing: CGFloat = 12.0
+                        let contentWidth = designTotalWidth - designPadding - designSpacing
+                        let cancelFactor = 93.0 / contentWidth
+                        let selectFactor = 230.0 / contentWidth
+                        
+                        Button {
+                            store.send(.binding(.set(\.sheetItem, nil)))
+                        } label: {
+                            Text("취소")
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.5)
+                        }
+                        .buttonStyle(.nekiCTA(.secondary))
+                        .containerRelativeFrame(.horizontal) { length, _ in
+                            let availableSpace = length - designPadding - designSpacing
+                            return availableSpace * cancelFactor
+                        }
+                        
+                        Button {
+                            store.send(.onTapStartRandomPoseCarousel)
+                        } label: {
+                            Text("선택하기")
+                        }
+                        .buttonStyle(.nekiCTA(.primary))
+                        .containerRelativeFrame(.horizontal) { length, _ in
+                            let availableSpace = length - designPadding - designSpacing
+                            return availableSpace * selectFactor
+                        }
                     }
                 }
-                
-                Spacer()
+                .padding()
             }
-            .padding()
+            .ignoresSafeArea(.container, edges: .bottom)
+            .safeAreaPadding(.bottom)
+            .presentationBackground(.white)
         }
-        .background(.white)
-        .presentationDetents([.height(406)])
-        .presentationCornerRadius(20)
-        .presentationDragIndicator(.hidden)
+    }
+}
+
+
+// MARK: - Helpers
+
+extension View {
+    func autoSizingDetent(_ heightBinding: Binding<CGFloat>) -> some View {
+        self
+            .fixedSize(horizontal: false, vertical: true)
+            .onGeometryChange(for: CGFloat.self, of: \.size.height) { newHeight in
+                guard newHeight > .zero, abs(heightBinding.wrappedValue - newHeight) > 1 else { return }
+                heightBinding.wrappedValue = newHeight
+            }
+            .presentationDetents([.height(heightBinding.wrappedValue)])
     }
 }
 

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/RandomPoseCarouselView.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/RandomPoseCarouselView.swift
@@ -38,7 +38,7 @@ struct RandomPoseCarouselView: View {
                         .transition(activeTransition)
                 }
             }
-            .animation(.easeInOut(duration: 0.35), value: store.currentPose)
+            .animation(.spring(response: 0.5, dampingFraction: 0.8, blendDuration: 0), value: store.currentPose)
             
             HStack(spacing: .zero) {
                 Color.clear

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/RandomPoseCarouselView.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/RandomPoseCarouselView.swift
@@ -56,7 +56,6 @@ struct RandomPoseCarouselView: View {
             if store.isTutorialPresented { tutorialOverlay }
         }
         .animation(.easeInOut, value: store.isTutorialPresented)
-        .animation(.easeInOut(duration: 0.4), value: store.currentPose)
         .task { await store.send(.onAppear).finish() }
         .onDisappear {
             guard store.isDismissing == false else { return }

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/RandomPoseCarouselView.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/RandomPoseCarouselView.swift
@@ -10,7 +10,10 @@ import ComposableArchitecture
 import Kingfisher
 
 struct RandomPoseCarouselView: View {
+    enum SlideDirection { case previous, next, none }
+    
     @Bindable var store: StoreOf<RandomPoseCarouselFeature>
+    @State private var slideDirection: SlideDirection = .none
     
     var body: some View {
         ZStack {
@@ -28,21 +31,27 @@ struct RandomPoseCarouselView: View {
             }
             .ignoresSafeArea()
             
-            mainContentView
+            ZStack {
+                if let pose = store.currentPose {
+                    mainContentView(for: pose)
+                        .id(pose.id)
+                        .transition(activeTransition)
+                }
+            }
+            .animation(.easeInOut(duration: 0.35), value: store.currentPose)
             
             HStack(spacing: .zero) {
                 Color.clear
                     .contentShape(.rect)
-                    .onTapGesture { store.send(.tapLeft) }
+                    .onTapGesture { slideDirection = .previous; store.send(.tapLeft) }
                 
                 Color.clear
                     .contentShape(.rect)
-                    .onTapGesture { store.send(.tapRight) }
+                    .onTapGesture { slideDirection = .next; store.send(.tapRight) }
             }
             
             controlButtons
                 .frame(maxHeight: .infinity, alignment: .bottom)
-            // TODO: 하단부 안전영역 패딩 줘야할 수도 있음 / 디자인팀에 문의해보기
             
             if store.isTutorialPresented { tutorialOverlay }
         }
@@ -52,6 +61,17 @@ struct RandomPoseCarouselView: View {
         .onDisappear {
             guard store.isDismissing == false else { return }
             store.send(.onDisappear)
+        }
+    }
+    
+    private var activeTransition: AnyTransition {
+        switch slideDirection {
+        case .previous:
+            return .asymmetric(insertion: .move(edge: .leading), removal: .move(edge: .trailing))
+        case .next:
+            return .asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading))
+        case .none:
+            return .opacity
         }
     }
 }
@@ -100,7 +120,7 @@ private extension RandomPoseCarouselView {
         }
         .padding(8)
         .background {
-            Capsule() // TODO: 이거 디자인 수치 확인해서 다시 그려야함
+            Capsule()
                 .fill(.white.opacity(0.3))
                 .strokeBorder(
                     LinearGradient(colors: [
@@ -188,19 +208,17 @@ private extension RandomPoseCarouselView {
         .zIndex(1)
     }
     
-    var mainContentView: some View {
-        KFImage(store.currentPose?.imageURL)
+    func mainContentView(for pose: Pose) -> some View {
+        KFImage(pose.imageURL)
             .placeholder {
                 ProgressView()
                     .controlSize(.large)
             }
-            .cancelOnDisappear(true)
             .resizable()
             .scaledToFit()
             .clipShape(.rect(cornerRadius: 20))
             .padding()
-            .id(store.currentPose?.id)
-            .transition(.opacity)
+            .compositingGroup()
     }
 }
 


### PR DESCRIPTION
## 🌴 작업한 브랜치
- fix/#97-pose-qa


## ✅ 작업한 내용
1. 포즈 인원수 필터 시트와 랜덤포즈 추천인원 선택 시트에 대하여 시트 내 컨텐츠의 높이에 맞춰 시트의 크기가 동적으로 정해지도록 변경했습니다.
2. 랜덤포즈 화면에서 이전, 다음 포즈사진으로 전환할 때 트랜지션 효과를 디졸브에서 페이징 방식으로 변경했습니다.


## ❗️PR Point
1. iOS 18에서는 `presentationFitted`로 딸깍해서 쓰던게 확실히 예전 방법으로 구현하려니 추억이 새록새록하네요.
단순 뷰빌더 메서드였던 두 시트를 별도의 뷰로 추출했습니다.

2. 랜덤포즈 이전, 다음 포즈 사진으로 전환할 때 애니메이션 duration을 좀 조정하는 것도 괜찮아보입니다. 너무 느리거나 하면 짧게 한다던지? 이런 부분은 어떤 기준에서 정할지는 모르겠네요. 


## 📸 스크린샷
생략합니다.


## 📟 관련 이슈
- Resolved: #97 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 하단 시트가 콘텐츠 높이에 따라 자동으로 조정되어 자연스러운 표시 제공
  * 인원 수 선택 및 랜덤 포즈 선택이 시트별로 분리되어 UI가 더 명확해짐
  * 시트 모서리 반경을 20으로 조정하고 드래그 인디케이터를 숨겨 깔끔한 시각 개선
  * 캐러셀에 좌/우 슬라이드 방향 기반 전환 애니메이션 추가로 직관적인 탐색감
  * 캐러셀 컨트롤 캡슐에 경계선/그라데이션 스타일 적용 및 터치 응답 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->