### PR TITLE
[Fix] QR 스캐너 파싱 문제 해소

### DIFF
--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/HaruFilmStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/HaruFilmStrategy.swift
@@ -46,8 +46,8 @@ struct HaruFilmStrategy: QRCodeParsingStrategy {
             return ParsedQRResult(brand: .harufilm, originalImage: data)
             
         } catch {
-            Logger.domain.notice("이미지 다운로드 연결 실패. 웹뷰 폴백 시도.")
-            throw .fallbackToWebView(url)
+            Logger.network.warning("이미지 없음(404 등). 만료 확인.")
+            throw .imageDownloadFailed
         }
     }
 }

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/Life4CutStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/Life4CutStrategy.swift
@@ -55,8 +55,8 @@ struct Life4CutStrategy: QRCodeParsingStrategy {
             }
             return ParsedQRResult(brand: .life4cut, originalImage: data)
         } catch {
-            Logger.domain.notice("이미지 다운로드 실패. 웹뷰 폴백 시도")
-            throw .fallbackToWebView(url)
+            Logger.network.warning("이미지 없음(404 등). 만료 확인.")
+            throw .imageDownloadFailed
         }
     }
 }

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/PhotograyStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/PhotograyStrategy.swift
@@ -74,8 +74,8 @@ struct PhotograyStrategy: QRCodeParsingStrategy {
             
             return ParsedQRResult(brand: .photogray, originalImage: imageData)
         } catch {
-            Logger.domain.notice("이미지 다운로드 중 에러 발생. 웹뷰 폴백.")
-            throw .fallbackToWebView(url)
+            Logger.network.warning("이미지 없음(404 등). 만료 확인.")
+            throw .imageDownloadFailed
         }
     }
 }

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/PhotosignatureStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/PhotosignatureStrategy.swift
@@ -29,15 +29,15 @@ struct PhotoSignatureStrategy: QRCodeParsingStrategy {
             let (data, response) = try await URLSession.shared.data(from: imageURL)
             
             if let httpResponse = response as? HTTPURLResponse, (200..<300).contains(httpResponse.statusCode) == false {
-                Logger.network.warning("이미지 없음(404 등). 웹뷰 폴백.")
+                Logger.domain.notice("이미지 다운로드 에러. 웹뷰 폴백.")
                 throw QRParseError.fallbackToWebView(url)
             }
             
             return ParsedQRResult(brand: .photosignature, originalImage: data)
             
         } catch {
-            Logger.domain.notice("이미지 다운로드 에러. 웹뷰 폴백.")
-            throw .fallbackToWebView(url)
+            Logger.network.warning("이미지 없음(404 등). 만료 확인.")
+            throw .imageDownloadFailed
         }
     }
 }

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Utilities/ImageDownsamplingProcessor.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Utilities/ImageDownsamplingProcessor.swift
@@ -7,6 +7,7 @@
 
 import ImageIO
 import UniformTypeIdentifiers
+import os
 
 public struct ImageDownsamplingProcessor: Sendable {
     public struct ProcessedImage: Sendable {
@@ -21,22 +22,34 @@ public struct ImageDownsamplingProcessor: Sendable {
     private init() {}
     
     nonisolated public static func process(data: Data) async -> ProcessedImage? {
-        guard let imageSource = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        guard let imageSource = CGImageSourceCreateWithData(data as CFData, nil) else {
+            Logger.domain.error("❌ ImageDownsamplingProcessor: 이미지 소스 생성 실패")
+            return nil
+        }
+        
+        guard CGImageSourceGetCount(imageSource) > .zero else {
+            Logger.domain.error("❌ ImageDownsamplingProcessor: 이미지 소스 내 이미지 개수 0")
+            return nil
+        }
+        
         let properties = CGImageSourceCopyPropertiesAtIndex(imageSource, .zero, nil) as? [CFString: Any]
         let width = properties?[kCGImagePropertyPixelWidth] as? CGFloat ?? .zero
         let height = properties?[kCGImagePropertyPixelHeight] as? CGFloat ?? .zero
         let maxSide = max(width, height)
         
-        let targetPixelSize: CGFloat = maxSide > .zero ? (maxSide > maxDimensionInPixels) ? maxDimensionInPixels : maxSide : maxDimensionInPixels
+        let targetPixelSize: Int = maxSide > .zero ? Int((maxSide > maxDimensionInPixels) ? maxDimensionInPixels : maxSide) : Int(maxDimensionInPixels)
         
         let options: [CFString: Any] = [
-            kCGImageSourceCreateThumbnailFromImageAlways: true,
-            kCGImageSourceShouldCacheImmediately: true,
-            kCGImageSourceCreateThumbnailWithTransform: true,
-            kCGImageSourceThumbnailMaxPixelSize: targetPixelSize
+            kCGImageSourceCreateThumbnailFromImageAlways: kCFBooleanTrue as Any,
+            kCGImageSourceShouldCacheImmediately: kCFBooleanTrue as Any,
+            kCGImageSourceCreateThumbnailWithTransform: kCFBooleanTrue as Any,
+            kCGImageSourceThumbnailMaxPixelSize: targetPixelSize as CFNumber
         ]
         
-        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(imageSource, .zero, options as CFDictionary) else { return nil }
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(imageSource, .zero, options as CFDictionary) else {
+            Logger.domain.error("❌ ImageDownsamplingProcessor: 썸네일 생성 실패")
+            return nil
+        }
         let mutableData = NSMutableData()
         
         guard let destination = CGImageDestinationCreateWithData(mutableData, UTType.jpeg.identifier as CFString, 1, nil) else { return nil }

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Features/QRCodeScanFeature.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Features/QRCodeScanFeature.swift
@@ -151,7 +151,7 @@ struct QRCodeScanFeature {
     }
     
     private func handleError(_ error: Error, state: inout State) -> Effect<Action> {
-        Logger.domain.error("QR 파싱 실패: \(error.localizedDescription)")
+        Logger.domain.error("QR 파싱 실패: \(error)")
         
         guard let qrError = error as? QRParseError else {
             // TODO: 알 수 없는 에러 경우에 토스트

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Features/QRCodeScanFeature.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Features/QRCodeScanFeature.swift
@@ -21,6 +21,7 @@ struct QRCodeScanFeature {
         
         var isManualDownloadNeededAlertPresented: Bool = false
         var isUnsupportedBrandAlertPresented: Bool = false
+        var isExpiredAlertPresented: Bool = false
         var isWebViewPresented: Bool = false
         
         var isCameraActive: Bool {
@@ -35,6 +36,7 @@ struct QRCodeScanFeature {
         case openSuggestBrandPage
         case openWebViewButtonTapped
         case closeWebViewButtonTapped
+        case closeExpiredAlertButtonTapped
         
         // System & Alert Actions
         case codeScanned(String)
@@ -86,6 +88,10 @@ struct QRCodeScanFeature {
                     guard let url = URL(string: "https://tally.so/r/0QekXy") else { return }
                     await openURL(url)
                 }
+                
+            case .closeExpiredAlertButtonTapped:
+                state.isExpiredAlertPresented = false
+                return .none
                 
                 // MARK: - Scanning Flow
             case .codeScanned(let urlString):
@@ -165,18 +171,23 @@ struct QRCodeScanFeature {
         case .invalidURL:
             // TODO: 토스트 또는 로그 등 에러 추적하기
             break
+            
         case .parsingFailed:
             // TODO: 토스트 또는 로그 등 에러 추적하기
             break
+            
         case .urlConstructionFailed:
             // TODO: 토스트 또는 로그 등 에러 추적하기
             break
+            
         case .networkError(_):
             // TODO: 토스트 또는 로그 등 에러 추적하기
             break
+            
         case .imageDownloadFailed:
-            // TODO: 토스트 또는 로그 등 에러 추적하기
-            break
+            Logger.presentation.notice("⚠️ 만료된 QR 코드")
+            state.isExpiredAlertPresented = true
+            
         @unknown default:
             break
         }

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Views/DownloadableWebView.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Views/DownloadableWebView.swift
@@ -111,6 +111,7 @@ extension DownloadableWebView {
                           let data = Data(base64Encoded: String(dataString[dataString.index(after: commaIndex)...]))
                     else {
                         Logger.presentation.error("❌ Blob Error: Base64 문자열 변환 실패")
+                        self.parent.onError(QRParseError.parsingFailed)
                         return
                     }
                     

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Views/DownloadableWebView.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Views/DownloadableWebView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import WebKit
+import os
 
 struct DownloadableWebView: UIViewRepresentable {
     let url: URL
@@ -48,6 +49,86 @@ extension DownloadableWebView {
                 await MainActor.run { parent.onError(error) }
             }
         }
+        
+        func processBlobDownload(url: URL, webView: WKWebView) {
+            Logger.presentation.debug("🌐 Blob 다운로드 시작: \(url.absoluteString)")
+            
+            let script = """
+                const targetUrl = "\(url.absoluteString)";
+
+                // 1. 유효성 검사 (undefined 체크)
+                if (!targetUrl) {
+                    throw new Error("Target URL is empty");
+                }
+
+                // 2. Blob URL이 아닌 경우에만 절대 경로 변환 시도
+                // (blob:http://... 형태는 건드리지 않음)
+                let finalUrl = targetUrl;
+                if (!targetUrl.startsWith('blob:') && !targetUrl.startsWith('http')) {
+                    try {
+                        finalUrl = new URL(targetUrl, document.baseURI).href;
+                    } catch (e) {
+                        console.log("URL parsing failed, using original");
+                    }
+                }
+                
+                // 3. 데이터 Fetch
+                const response = await fetch(finalUrl);
+                
+                if (!response.ok) {
+                    throw new Error("Fetch Failed Status: " + response.status);
+                }
+                
+                const blob = await response.blob();
+                
+                // 4. HTML 에러 페이지인지 이중 체크
+                // (Blob URL인데 내용물이 HTML인 경우 등 방지)
+                if (blob.type.includes("text/html")) {
+                    throw new Error("Downloaded content is HTML, not Image (Type: " + blob.type + ")");
+                }
+
+                // 5. Base64 변환
+                return new Promise((resolve, reject) => {
+                    const reader = new FileReader();
+                    reader.onloadend = () => resolve(reader.result);
+                    reader.onerror = (e) => reject(new Error("FileReader Error: " + e.target.error));
+                    reader.readAsDataURL(blob);
+                });
+            """
+            
+            webView.callAsyncJavaScript(
+                script,
+                arguments: [:],
+                in: nil,
+                in: .page
+            ) { [weak self] (result: Result<Any, Error>) in
+                guard let self = self else { return }
+                
+                switch result {
+                case .success(let dataAny):
+                    guard let dataString = dataAny as? String,
+                          let commaIndex = dataString.firstIndex(of: ","),
+                          let data = Data(base64Encoded: String(dataString[dataString.index(after: commaIndex)...]))
+                    else {
+                        Logger.presentation.error("❌ Blob Error: Base64 문자열 변환 실패")
+                        return
+                    }
+                    
+                    Logger.presentation.debug("✅ 이미지 데이터 최종 확보 성공 (크기: \(ByteCountFormatter.string(fromByteCount: Int64(data.count), countStyle: .file)))")
+                    self.parent.onDownloadCompleted(data)
+                    
+                case .failure(let error):
+                    Logger.presentation.error("❌ Blob 다운로드 실패: \(error.localizedDescription)")
+                    
+                    let nsError = error as NSError
+                    if let jsStack = nsError.userInfo["WKJavaScriptExceptionMessage"] {
+                        print("📝 JS 에러 상세: \(jsStack)")
+                    }
+                    
+                    self.parent.onError(error)
+                }
+            }
+        }
     }
 }
 
@@ -57,12 +138,26 @@ extension DownloadableWebView {
 extension DownloadableWebView.Coordinator: WKNavigationDelegate {
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
         guard let url = navigationAction.request.url else { return .allow }
-        let targetExtensions = ["jpg", "jpeg", "png", "heic", "webp"]
-        let fileExtension = url.pathExtension.lowercased()
         
-        guard targetExtensions.contains(fileExtension) else { return .allow }
-        Task { await downloadImage(from: url) }
-        return .cancel
+        if url.scheme == "blob" {
+            processBlobDownload(url: url, webView: webView)
+            return .cancel
+        }
+        
+        let fileExtension = url.pathExtension.lowercased()
+        let imageExtensions = ["jpg", "jpeg", "png", "heic", "webp"]
+        let videoExtensions = ["mp4", "mov", "avi", "m4v"]
+        
+        if imageExtensions.contains(fileExtension) {
+            Task { await downloadImage(from: url) }
+            return .cancel
+        }
+        
+        if videoExtensions.contains(fileExtension) {
+            return .cancel
+        }
+        
+        return .allow
     }
     
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: any Error) { parent.onError(error) }

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Views/DownloadableWebView.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Views/DownloadableWebView.swift
@@ -54,7 +54,7 @@ extension DownloadableWebView {
             Logger.presentation.debug("🌐 Blob 다운로드 시작: \(url.absoluteString)")
             
             let script = """
-                const targetUrl = "\(url.absoluteString)";
+                const targetUrl = targetUrlArg;
 
                 // 1. 유효성 검사 (undefined 체크)
                 if (!targetUrl) {
@@ -98,7 +98,7 @@ extension DownloadableWebView {
             
             webView.callAsyncJavaScript(
                 script,
-                arguments: [:],
+                arguments: ["targetUrlArg": url.absoluteString],
                 in: nil,
                 in: .page
             ) { [weak self] (result: Result<Any, Error>) in

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Views/QRCodeScannerView.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Views/QRCodeScannerView.swift
@@ -69,6 +69,14 @@ struct QRCodeScannerView: View {
             onConfirm: { store.send(.addPhotoFromGalleryButtonTapped) },
             onSecondary: { store.send(.openSuggestBrandPage) }
         )
+        .nekiAlert(
+            isPresented: $store.isExpiredAlertPresented,
+            style: .plain,
+            title: "만료된 QR 코드예요.",
+            subtitle: "만료되지 않은 네컷사진만 저장할 수 있어요.",
+            confirmText: "확인",
+            onConfirm: { store.send(.closeExpiredAlertButtonTapped) }
+        )
     }
     
     private var header: some View {

--- a/Neki-iOS/Info.plist
+++ b/Neki-iOS/Info.plist
@@ -30,6 +30,13 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
+			<key>photoqr3.kr</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
 			<key>mx2.co.kr</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>


### PR DESCRIPTION
## 🌴 작업한 브랜치
- fix/#112-qr-scanner-debug


## ✅ 작업한 내용
1. 포토시그니처 도메인 ATS 예외 목록에 추가 (HTTP로 시작되는 비보안 URL이라 QR 파싱 간에 무조건 실패함)
2. QR 코드 파싱 및 리디렉션 중 만료, 페이지 없음 등으로 인한 실패일 경우 웹뷰 폴백 대신 만료된 사실을 즉각 얼럿으로 알리도록 로직을 살짝 수정했습니다.
3. 웹뷰 방식으로 다운로드 시 JS 주입 및 실행으로 이미지 Blob을 확보하는 로직을 추가했습니다. 또한 이 과정에서 에러를 추적할 수 있도록 로깅 코드를 작성했습니다.


## ❗️PR Point
1. 이 버그 수정은 포토이즘 한정으로는 성공합니다! 다른 브랜드에서도 비슷한 에러가 발생했을 때 무리없이 적용이 될지는 추후 판단이 필요합니다.


## 📸 스크린샷
영상 공유로 대체합니다.


## 📟 관련 이슈
- Resolved: #112


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 만료된 QR 코드 전용 알림 추가
  * Blob(데이터 URL) 이미지 다운로드 처리 지원 추가

* **버그 수정**
  * 이미지 다운로드 실패 시 명확한 오류 상태 처리 및 만료 알림 표시 개선
  * 이미지 처리 및 썸네일 생성 시 안정성 검사와 실패 로깅 강화
  * QR 스캔 오류 처리 로직 정비로 더 명확한 오류 표출 및 로그 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->