### PR TITLE
[Style] 마이페이지 내 메뉴/섹션 레이아웃 조정

### DIFF
--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/MyPageView.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/MyPageView.swift
@@ -21,11 +21,13 @@ struct MyPageView: View {
             
             divider(isLarge: true)
             
-            section(.authorizationSettings)
-            
-            divider(isLarge: false)
-            
-            section(.support)
+            VStack(spacing: 10) {
+                section(.authorizationSettings)
+                
+                divider(isLarge: false)
+                
+                section(.support)
+            }
             
             Spacer()
         }
@@ -87,10 +89,11 @@ private extension MyPageView {
             Text(item.title)
                 .nekiFont(.body14Medium)
                 .foregroundStyle(.gray400)
-                .padding(.top, 12)
+                .padding(.top, 16)
+                .padding(.bottom, 4)
             
             // Content
-            VStack(spacing: 12) {
+            VStack(spacing: .zero) {
                 ForEach(item.includedItems) { cellItem in
                     sectionCell(cellItem)
                 }


### PR DESCRIPTION
## 🌴 작업한 브랜치
- style/#117-mypage-layout


## ✅ 작업한 내용
메뉴와 Divider 들 레이아웃이 디자인 시안과 다른 부분을 수정했습니다.


## ❗️PR Point
진짜 간단한 수정이라 생략합니다!


## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/d304602e-fe1e-4938-b880-dbddc620b685" width ="350">|


## 📟 관련 이슈
- Resolved: #117


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 마이페이지 설정 섹션의 레이아웃 및 간격을 개선했습니다. 섹션 제목의 패딩을 조정하고 섹션 내부의 항목 간 간격을 최적화하여 시각적 균형을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->