### PR TITLE
[Fix] 지도 내 POI 검색 시점 관련 로직 보완, QR스캐너 접근 전 권한에 따른 얼럿 안내

### DIFF
--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFeature.swift
@@ -33,6 +33,7 @@ struct ArchiveFeature {
         }
         
         var showDropDownMenu: Bool = false
+        var showPermissionAlert: Bool = false
         
         var imagePicker = ImagePickerFeature.State(
             maxCount: 10,
@@ -59,6 +60,8 @@ struct ArchiveFeature {
         case onTapAllPhotos
         case onTapAllAlbums
         case onTapQRScan
+        case closePermissionAlert
+        case openAppSettings
         
         // Add Folder Action
         case onTapCancelAddAlbum
@@ -100,6 +103,7 @@ struct ArchiveFeature {
     
     @Dependency(\.archiveClient) var archiveClient
     @Dependency(\.qrScannerClient) private var qrScannerClient
+    @Dependency(\.openURL) private var openURL
     
     var body: some ReducerOf<Self> {
         BindingReducer()
@@ -384,6 +388,21 @@ struct ArchiveFeature {
                 
             case .loadMorePhotos:
                 return .send(.fetchPhotos(isRefresh: false))
+                
+            case .showPermissionAlert:
+                state.showPermissionAlert = true
+                return .none
+                
+            case .closePermissionAlert:
+                state.showPermissionAlert = false
+                return .none
+                
+            case .openAppSettings:
+                state.showPermissionAlert = false
+                return .run { _ in
+                    guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                    await openURL(url)
+                }
                 
                 
                 // MARK: - Binding Action

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveView.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveView.swift
@@ -115,6 +115,16 @@ struct ArchiveView: View {
         .fullScreenCover(item: $store.scope(state: \.qrScanner, action: \.qrScanner)) { store in
             QRCodeScannerView(store: store)
         }
+        .nekiAlert(
+            isPresented: $store.showPermissionAlert,
+            style: .cancelable,
+            title: "카메라 권한",
+            subtitle: "QR 인식을 위해 카메라 접근이 필요해요",
+            confirmText: "허용",
+            cancelText: "취소",
+            onConfirm: { store.send(.openAppSettings) },
+            onCancel: { store.send(.closePermissionAlert) }
+        )
         .transaction { transaction in
             transaction.disablesAnimations = true
         }

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
@@ -217,7 +217,7 @@ public struct MapFeature {
                 case .notDetermined:
                     return .send(.requestPermission)
                 case .restricted, .denied:
-                    return .send(.openAppSettings)
+                    return .send(.presentPermissionAlert)
                 case .authorizedAlways, .authorizedWhenInUse, .authorized:
                     state.isUserTrackingMode = true
                     if let location = state.userLocation { updateCameraPosition(&state, to: location.coordinate) }

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
@@ -32,6 +32,7 @@ public struct MapFeature {
         var detent: NekiSheetDetent = SheetStage.first.detent
         var isSearchHereButtonVisible: Bool = false
         var isFirstLoad: Bool = true
+        var isPermissionAlertPresented: Bool = false
         
         // Map State
         var cameraPosition: GeographicCoordinate?
@@ -72,6 +73,7 @@ public struct MapFeature {
         case didTapCurrentLocationButton
         case didTapDirectionAppsButton
         case didTapSearchHereButton
+        case dismissPermissionAlert
         
         // Internal Logic Actions
         case updateLocationAuthorization(CLAuthorizationStatus)
@@ -79,6 +81,7 @@ public struct MapFeature {
         case updateUserLocation(Result<CLLocation, Error>)
         case setUserTrackingMode(Bool)
         case didDetectMapInteraction
+        case presentPermissionAlert
         
         // Map Logic Actions
         case mapLoaded(GeographicBoundingBox)
@@ -174,8 +177,16 @@ public struct MapFeature {
                     return .none
                 }
                 
+            case .presentPermissionAlert:
+                state.isPermissionAlertPresented = true
+                return .none
+                
+            case .dismissPermissionAlert:
+                state.isPermissionAlertPresented = false
+                return .none
+                
             case .openAppSettings:
-                // TODO: 설정 앱 동작 전에 안내문구 따위를 보여주도록 해야하는데 디자인 가이드가 없습니다.
+                state.isPermissionAlertPresented = false
                 return .run { _ in
                     guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
                     await openURL(url)

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
@@ -12,6 +12,10 @@ import os
 
 @Reducer
 public struct MapFeature {
+    enum Constants {
+        static let defaultInitialPosition: CLLocation = .init(latitude: 37.498095, longitude: 127.027610)
+    }
+    
     enum SheetStage {
         case first, second, third, photoBoothSelected
         
@@ -172,8 +176,17 @@ public struct MapFeature {
                 case .notDetermined:
                     return state.locationAuthorizationNeeded ? .send(.requestPermission) : .none
                     
-                default:
+                case .denied, .restricted:
                     state.isUserTrackingMode = false
+                    
+                    guard state.isFirstLoad, let bounds = state.currentBounds else { return .none }
+                    state.isFirstLoad = false
+                    return .merge(
+                        .send(.fetchPhotoBooths(bounds: bounds)),
+                        .send(.fetchNearbyPhotoBooths(bounds.center))
+                    )
+                    
+                @unknown default:
                     return .none
                 }
                 
@@ -194,14 +207,9 @@ public struct MapFeature {
                 
                 // MARK: - User Location Interaction
             case let .mapLoaded(bounds):
-                state.isFirstLoad = false
                 state.currentBounds = bounds
                 state.cameraPosition = bounds.center
-                let nearbyTargetCoordinate = state.userGeographicCoordinate ?? bounds.center
-                return .merge(
-                    .send(.fetchPhotoBooths(bounds: bounds)),
-                    .send(.fetchNearbyPhotoBooths(nearbyTargetCoordinate))
-                )
+                return .none
                 
             case .didTapCurrentLocationButton:
                 resetToMapMode(&state, for: .first)
@@ -221,9 +229,11 @@ public struct MapFeature {
             case let .updateUserLocation(.success(location)):
                 state.userLocation = location
                 
-                guard state.isUserTrackingMode else { return .none }
-                updateCameraPosition(&state, to: location.coordinate)
-                state.isSearchHereButtonVisible = false
+                if state.isFirstLoad || state.isUserTrackingMode {
+                    updateCameraPosition(&state, to: location.coordinate)
+                    guard state.isFirstLoad else { return .none }
+                    state.isSearchHereButtonVisible = false
+                }
                 return .none
                 
             case .updateUserLocation(.failure):
@@ -248,7 +258,25 @@ public struct MapFeature {
             case let .cameraMotionEnded(bounds):
                 state.currentBounds = bounds
                 state.cameraPosition = bounds.center
-                return .none
+                
+                guard state.isFirstLoad else { return .none }
+                guard state.locationAuthorizationStatus != .notDetermined else { return .none }
+                let targetCoordinate: CLLocation
+                if state.isLocationAuthorized {
+                    guard let userLocation = state.userLocation else { return .none }
+                    targetCoordinate = userLocation
+                } else {
+                    targetCoordinate = Constants.defaultInitialPosition
+                }
+                
+                let currentCameraLocation = CLLocation(latitude: bounds.center.latitude, longitude: bounds.center.longitude)
+                guard currentCameraLocation.distance(from: targetCoordinate) <= 200 else { return .none }
+                state.isFirstLoad = false
+                let nearbyTargetCoordinate = state.userGeographicCoordinate ?? bounds.center
+                return .merge(
+                    .send(.fetchPhotoBooths(bounds: bounds)),
+                    .send(.fetchNearbyPhotoBooths(nearbyTargetCoordinate))
+                )
                 
             case let .updateSearchButtonVisibility(isVisible):
                 state.isSearchHereButtonVisible = isVisible

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
@@ -41,16 +41,9 @@ struct NaverMapRepresentable: UIViewRepresentable {
         configureMapView(view)
         
         // 초기 카메라 이동
-        let startPosition = {
-            if isLocationAuthorized, let current = NMFLocationManager.sharedInstance().currentLatLng() {
-                return current
-            } else {
-                return Constants.defaultInitialPosition
-            }
-        }()
+        let startPosition = Constants.defaultInitialPosition
         let cameraUpdate = NMFCameraUpdate(scrollTo: startPosition, zoomTo: Constants.initialZoomLevel)
         cameraUpdate.animation = .none
-        cameraUpdate.animationDuration = 0.3
         view.mapView.moveCamera(cameraUpdate)
         
         // 델리게이트 연결

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
@@ -344,6 +344,16 @@ public struct NaverMapView: View {
         }
         .animation(.easeInOut, value: store.detent)
         .animation(.easeInOut, value: store.selectedBooth?.id)
+        .nekiAlert(
+            isPresented: $store.isPermissionAlertPresented,
+            style: .cancelable,
+            title: "위치 권한",
+            subtitle: "주변 포토부스를 찾기 위해 위치 사용 권한이 필요해요",
+            confirmText: "허용",
+            cancelText: "취소",
+            onConfirm: { store.send(.openAppSettings) },
+            onCancel: { store.send(.dismissPermissionAlert) }
+        )
     }
 }
 

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Views/QRCodeScannerView.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Views/QRCodeScannerView.swift
@@ -65,7 +65,7 @@ struct QRCodeScannerView: View {
             title: "지원하지 않는 브랜드예요.",
             subtitle: "갤러리에서 사진을 추가해 바로 저장할 수 있어요.\n원하는 브랜드가 있다면 제안해주세요!",
             confirmText: "갤러리에서 추가하기",
-            secondaryText: "텍스트 버튼",
+            secondaryText: "브랜드 제안하기",
             onConfirm: { store.send(.addPhotoFromGalleryButtonTapped) },
             onSecondary: { store.send(.openSuggestBrandPage) }
         )


### PR DESCRIPTION
## 🌴 작업한 브랜치
- fix/#119-map-debug


## ✅ 작업한 내용
1. 미지원 브랜드에 대해 QR 스캔 시 나타나는 얼럿에서 '브랜드 제안하기' 문구로 수정했습니다.
2. 미확보 권한 안내 및 설정 앱으로 유도하는 얼럿을 추가했습니다. (지도, QR스캐너)
3. 위치 권한이 있음에도 기본좌표(강남역) 기준으로 POI 검색이 이루어지던 문제를 해결했습니다.


## ❗️PR Point

지도는 최초 로드 시 강남역 기준으로 로드됩니다. 이때 즉시 검색이 발생되어 강남역 근처에 마커가 찍히고 시트 목록이 채워졌습니다.
이제 지도가 로드됐을 때에서 검색을 수행하지 않고, 오로지 카메라 이동이 멈췄을 시점의 상태만으로 검색을 트리거링 하도록 만들었습니다.

예를 들어, 가장 처음 지도 탭으로 진입할 경우 지도가 로드되고, `최초 좌표: 강남역`,  `목표 좌표, 홍대역 (사용자의 실제 위치)` 케이스가 됩니다. 이때 카메라 이동은 2번 이루어집니다. 따라서 위치 정확성, 이동거리 등을 고려하여 '200' 정도의 threshold를 주며 얼마나 차이나는지 계산합니다. 첫 번째 이동인 `강남역-홍대역`은 먼 거리이므로 검색을 시도하지 않습니다. 만약 카메라가 사용자의 현 위치로 이동하면, `최초 좌표: 홍대역`, `목표 좌표: 홍대역`이 되고 이 두 번째 이동에서는 검색을 시도합니다.

1. threshold 값은 임시, 변경해야할 수도 있어요.

---




## 📸 스크린샷
생략합니다!


## 📟 관련 이슈
- Resolved: #119


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 권한 요청 시 안내 알림이 추가되고, 안내에서 앱 설정으로 바로 이동할 수 있습니다.
  * 권한 관련 알림을 통해 위치/카메라 권한을 명확히 안내합니다.

* **개선사항**
  * 지도의 초기 위치가 고정되어 일관된 시작점을 제공합니다.
  * 지도 카메라 동작 및 애니메이션 처리가 변경되어 동작이 더 일관되게 동작합니다.
  * 첫 로드 시 위치 근접성에 따라 주변 데이터 로드가 보다 신뢰성 있게 트리거됩니다.

* **버그 수정**
  * QR코드 스캐너의 비지원 브랜드 알림 버튼 레이블이 '브랜드 제안하기'로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->