### PR TITLE
[Fix] 이용약관 동의없이 온보딩 플로우를 끝내는 문제 해결

### DIFF
--- a/Neki-iOS/Core/Sources/Auth/Sources/Presentation/Sources/View/TermsAgreementView.swift
+++ b/Neki-iOS/Core/Sources/Auth/Sources/Presentation/Sources/View/TermsAgreementView.swift
@@ -25,7 +25,7 @@ public struct TermsAgreementView: View {
             Spacer()
             
             Button {
-                store.send(.didFinishOnboarding)
+                store.send(.confirmButtonTapped)
             } label: {
                 Text("다음으로")
             }


### PR DESCRIPTION
## 🌴 작업한 브랜치
- fix/#122-skip-onboarding


## ✅ 작업한 내용
약관동의 과정에서 온보딩을 끝내는 델리게이트 액션을 직접 호출하는 것을 제거하고 '다음으로' 버튼이 약관동의 및 서버 응답을 받아 판단하는 액션을 호출하도록 변경했습니다.


## ❗️PR Point
액션 열거형을 private으로 묶어 뷰에서 직접 호출하지 못하도록 개선하는 것도 방법이겠습니다!


## 📸 스크린샷
생략합니다.


## 📟 관련 이슈
- Resolved: #122


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 약관 동의 화면의 다음 버튼 동작을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->