### PR TITLE
[Style] '이 지역 재검색' 버튼 변경

### DIFF
--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
@@ -442,19 +442,20 @@ private extension NaverMapView {
         Button {
             store.send(.didTapSearchHereButton)
         } label: {
-            HStack(spacing: 8) {
+            HStack(spacing: 7) {
                 Image(.iconRotate)
                 
-                Text("현 위치에서 탐색")
+                Text("이 지역 재검색")
                     .nekiFont(.body14SemiBold)
                     .foregroundStyle(.gray800)
             }
-            .padding(.horizontal, 12)
+            .padding(.horizontal, 13)
             .padding(.vertical, 10)
             .background(
                 Capsule()
                     .fill(.white)
-                    .strokeBorder(.gray100)
+                    .strokeBorder(.primary400)
+                    .shadow(radius: 2)
             )
         }
         .safeAreaPadding(.top)


### PR DESCRIPTION
## 🌴 작업한 브랜치
- style/#125-search-button


## ✅ 작업한 내용

'지도 내 '이 지역 재검색' 버튼 리디자인 요구사항에 대응합니다.
1. 그림자 추가
2. Inner Stroke - primary400 변경
3. 라벨 문구 변경


## ❗️PR Point
간단 수정이라 생략합니다.


## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|스크린샷|
|:--:|:--:|
|ScreenShot|<img src = "https://github.com/user-attachments/assets/dfea2784-33f1-48aa-98c1-7fc298eacc41" width ="350">|


## 📟 관련 이슈
- Resolved: #125


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **스타일 및 UI 개선**
  * 지도 화면의 검색 컨트롤을 개선했습니다. 버튼 텍스트를 "이 지역 재검색"으로 업데이트하고, 간격과 패딩을 조정하며, 테두리 색상과 그림자 효과를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->