### PR TITLE
[Refactor] #121 - Archive Client-Repository 리팩토링 및 데이터 관리 로직 전면 개편

### DIFF
--- a/Neki-iOS/Features/Archive/Sources/Data/Sources/DefaultArchiveRepository.swift
+++ b/Neki-iOS/Features/Archive/Sources/Data/Sources/DefaultArchiveRepository.swift
@@ -14,16 +14,19 @@ actor DefaultArchiveRepository: ArchiveRepository {
     
     // MARK: - Cache
     
-    private var photoCache: [Int?: [PhotoEntity]] = [:]
-    private var albumCache: [AlbumEntity] = []
-    private var favoritePhotoCache: [PhotoEntity] = []
-    private var favoriteAlbumInfoCache: FavoriteAlbumEntity?
+    private var photoCache: [Int?: [PhotoEntity]] = [:] // 사진들 캐시(앨범별), 앨범을 nil로 줄 경우 전체 사진
+    private var currentSortOrder: [Int?: String] = [:]  // 앨범별 정렬 (최신순, 오래된 순)
+
+    private var albumCache: [AlbumEntity] = []  // 앨범들 정보 캐시
+    private var favoritePhotoCache: [PhotoEntity] = []  // 즐겨찾기 사진들 캐시
+    private var favoriteAlbumInfoCache: FavoriteAlbumEntity?    // 즐겨찾기 앨범 정보 캐시
+    
     
     // Dirty Flags (데이터 유효성 검사)
-    private var isPhotoCacheDirty: [Int?: Bool] = [:]
-    private var isAlbumCacheDirty: Bool = true
-    private var isFavoriteCacheDirty: Bool = true
-    private var isFavoriteAlbumInfoDirty: Bool = true
+    private var isPhotoCacheDirty: [Int?: Bool] = [:]   // 사진 변경사항 플래그
+    private var isAlbumCacheDirty: Bool = true  // 앨범 변경사항 플래그
+    private var isFavoriteCacheDirty: Bool = true   // 즐겨찾는 사진 변경사항 플래그
+    private var isFavoriteAlbumInfoDirty: Bool = true   // 즐겨찾기 앨범 정보 변경사항 플래그
     
     
     // MARK: - Pagination State
@@ -74,11 +77,19 @@ extension DefaultArchiveRepository {
         let isDirty = isPhotoCacheDirty[folderID] ?? true
         let currentCache = photoCache[folderID] ?? []
         
-        if isDirty || currentCache.isEmpty {
+        // 요청한 정렬 순서 (기본값 DESC)
+        let requestSortOrder = sortOrder ?? "DESC"
+        // 기존에 저장된 정렬 순서
+        let cachedSortOrder = currentSortOrder[folderID]
+        // 정렬이 바뀌었으면 무조건 Dirty로 간주하여 초기화
+        let isSortChanged = (cachedSortOrder != nil) && (cachedSortOrder != requestSortOrder)
+        
+        if isDirty || currentCache.isEmpty || isSortChanged {
             currentPhotoPage[folderID] = 0
             hasNextPhoto[folderID] = true
             photoCache[folderID] = []
             isPhotoCacheDirty[folderID] = false
+            currentSortOrder[folderID] = requestSortOrder
         }
         
         // 마지막 페이지면 실행

--- a/Neki-iOS/Features/Archive/Sources/Data/Sources/DefaultArchiveRepository.swift
+++ b/Neki-iOS/Features/Archive/Sources/Data/Sources/DefaultArchiveRepository.swift
@@ -8,108 +8,269 @@
 import Foundation
 import Dependencies
 
-struct DefaultArchiveRepository: ArchiveRepository {
+actor DefaultArchiveRepository: ArchiveRepository {
+    
     @Dependency(\.networkProvider) var networkProvider
     
-    func fetchPhotoList(folderID: Int?, page: Int?, size: Int?, sortOrder: String?) async throws -> (photos: [PhotoEntity], hasNext: Bool) {
-        let request = PhotoListDTO.Request(folderId: folderID, page: page, size: size, sortOrder: sortOrder)
-        let endpoint = ArchiveEndpoint.getPhotoList(request: request)
-        let response: BaseResponseDTO<PhotoListDTO.PhotoListData> = try await networkProvider.request(endpoint: endpoint)
-        
-        guard let data = response.data else { throw NetworkError.responseDecodingError }
-        
-        let entities = data.toEntity()
-        
-        return (entities, data.hasNext)
-    }
+    // MARK: - Cache
     
-    func deletePhotoList(photoIDs: [Int]) async throws {
-        let request = DeletePhotoRequestDTO(photoIds: photoIDs)
-        let endpoint = ArchiveEndpoint.deletePhoto(request: request)
-        let _ = try await networkProvider.request(endpoint: endpoint)
-    }
+    private var photoCache: [Int?: [PhotoEntity]] = [:]
+    private var albumCache: [AlbumEntity] = []
+    private var favoritePhotoCache: [PhotoEntity] = []
+    private var favoriteAlbumInfoCache: FavoriteAlbumEntity?
     
+    // Dirty Flags (데이터 유효성 검사)
+    private var isPhotoCacheDirty: [Int?: Bool] = [:]
+    private var isAlbumCacheDirty: Bool = true
+    private var isFavoriteCacheDirty: Bool = true
+    private var isFavoriteAlbumInfoDirty: Bool = true
+    
+    
+    // MARK: - Pagination State
+    
+    private var currentPhotoPage: [Int?: Int] = [:]
+    private var hasNextPhoto: [Int?: Bool] = [:]
+    private var currentFavoritePage: Int = 0
+    private var hasNextFavorite: Bool = true
+}
+
+
+// MARK: - Create Logic
+
+extension DefaultArchiveRepository {
     func registerPhoto(folderID: Int?, uploads: [(mediaID: Int, memo: String?)]) async throws {
-        let uploadData: [RegisterPhotoDTO.RegisterPhotoData] = uploads.map {
-                    RegisterPhotoDTO.RegisterPhotoData(
-                        mediaID: $0.mediaID,
-                        memo: $0.memo
-                    )
-                }
-        
+        let uploadData = uploads.map { RegisterPhotoDTO.RegisterPhotoData(mediaID: $0.mediaID, memo: $0.memo) }
         let request = RegisterPhotoDTO.Request(folderID: folderID, uploads: uploadData)
         let endpoint = ArchiveEndpoint.registerPhoto(request: request)
         let _ = try await networkProvider.request(endpoint: endpoint)
         
-    }
-    
-    func getFavoriteAlbumInfo() async throws -> FavoriteAlbumEntity {
-        let result: BaseResponseDTO<FavoriteAlbumInfoDTO> = try await networkProvider.request(endpoint: ArchiveEndpoint.getFavoriteAlbumInfo)
         
-        guard let data = result.data else {
-            throw NetworkError.responseDecodingError
+        self.isPhotoCacheDirty[nil] = true  // 전체 사진 캐시에 변경 신호
+        if let folderID = folderID {        // 앨범을 선택해 업로드 했다면 해당 앨범내 사진 캐시와 전체 앨범 캐시에도 변경 신호
+            self.isPhotoCacheDirty[folderID] = true
+            self.isAlbumCacheDirty = true
         }
-        
-        let entity: FavoriteAlbumEntity = FavoriteAlbumEntity(latestImageURL: data.latestImageURL ?? "", totalCount: data.totalCount)
-        
-        
-        
-        return entity
-    }
-    
-    func getAlbumList() async throws -> [AlbumEntity] {
-        let result: BaseResponseDTO<AlbumInfoDTO> = try await networkProvider.request(endpoint: ArchiveEndpoint.getAlbumList)
-        
-        guard let data = result.data else {
-            throw NetworkError.responseDecodingError
-        }
-        
-        let entities: [AlbumEntity] = data.items.map {
-            AlbumEntity(id: $0.folderID, name: $0.name, photoCount: $0.totalCount, coverImageURLString: $0.latestImageURL ?? "")
-        }
-        
-        return entities
     }
     
     func addFolder(name: String) async throws -> Int {
         let request = AddFolderDTO.Request(name: name)
         let result: BaseResponseDTO<AddFolderDTO.Response> = try await networkProvider.request(endpoint: ArchiveEndpoint.addFolder(request: request))
-        
         guard let data = result.data else { throw NetworkError.responseDecodingError }
         
+        self.isAlbumCacheDirty = true
         return data.folderId
     }
+}
+
+
+// MARK: - Read Logic
+
+extension DefaultArchiveRepository {
     
-    func deleteFolders(folderIDs: [Int], deletePhotos: Bool) async throws {
-        let request = DeleteFoldersRequestDTO(folderIds: folderIDs)
-        let endpoint = ArchiveEndpoint.deleteFolders(request: request, deletePhotos: deletePhotos)
-        let _ = try await networkProvider.request(endpoint: endpoint)
+    func fetchPhotoList(folderID: Int?, size: Int?, sortOrder: String?) async throws -> [PhotoEntity] {
+        
+        /// 캐시가 더렵혀졌거나(변경사항이 있거나) 비어있으면 실행
+        /// 첫 페이지부터 다시 불러오고 기존에 저장되어 있던 캐시들 삭제
+        let isDirty = isPhotoCacheDirty[folderID] ?? true
+        let currentCache = photoCache[folderID] ?? []
+        
+        if isDirty || currentCache.isEmpty {
+            currentPhotoPage[folderID] = 0
+            hasNextPhoto[folderID] = true
+            photoCache[folderID] = []
+            isPhotoCacheDirty[folderID] = false
+        }
+        
+        // 마지막 페이지면 실행
+        if let hasNext = hasNextPhoto[folderID], !hasNext {
+            return photoCache[folderID] ?? []
+        }
+        
+        let page = currentPhotoPage[folderID] ?? 0
+        let request = PhotoListDTO.Request(folderId: folderID, page: page, size: size ?? 20, sortOrder: sortOrder)
+        let endpoint = ArchiveEndpoint.getPhotoList(request: request)
+        let response: BaseResponseDTO<PhotoListDTO.PhotoListData> = try await networkProvider.request(endpoint: endpoint)
+        
+        guard let data = response.data else { throw NetworkError.responseDecodingError }
+        
+        let newEntities = data.toEntity()
+        
+        /// 캐시 업데이트 (해당 폴더 Key에 추가)
+        /// 테스트해보니 라이프사이클 시점 문제인지 같은 아이디의 사진을 받고 있어서 앱이 꺼지는 현상 발견
+        /// 따라서 캐시에 존재하는 값들을 set으로 만든 후 새로운 데이터와 비교해 없는 값만 캐시에 추가
+        var currentList = photoCache[folderID] ?? []
+        let existingIDs = Set(currentList.map { $0.photoID })
+        
+        // 새로운 데이터 중 기존에 없는 것만 필터링
+        let uniqueNewEntities = newEntities.filter { !existingIDs.contains($0.photoID) }
+        
+        // 중복 없는 데이터만 추가
+        currentList.append(contentsOf: uniqueNewEntities)
+        
+        photoCache[folderID] = currentList
+        
+        // 페이지 상태 업데이트
+        hasNextPhoto[folderID] = data.hasNext
+        if data.hasNext {
+            currentPhotoPage[folderID] = page + 1
+        }
+        
+        return currentList
     }
     
-    func fetchFavoritePhotoList(page: Int?, size: Int?, sortOrder: String?) async throws -> (photos: [PhotoEntity], hasNext: Bool) {
-        let request = PhotoListDTO.Request(folderId: nil, page: page, size: size, sortOrder: sortOrder)
+    func getAlbumList() async throws -> [AlbumEntity] {
+        // 캐시에 변경사항이 없고, 비어있지도 않으면 캐시된 값 리턴
+        if !isAlbumCacheDirty, !albumCache.isEmpty {
+            return albumCache
+        }
+        
+        let result: BaseResponseDTO<AlbumInfoDTO> = try await networkProvider.request(endpoint: ArchiveEndpoint.getAlbumList)
+        guard let data = result.data else { throw NetworkError.responseDecodingError }
+        
+        let entities: [AlbumEntity] = data.items.map {
+            AlbumEntity(id: $0.folderID, name: $0.name, photoCount: $0.totalCount, coverImageURLString: $0.latestImageURL ?? "")
+        }
+        
+        self.albumCache = entities
+        self.isAlbumCacheDirty = false
+        
+        return entities
+    }
+    
+    func getFavoriteAlbumInfo() async throws -> FavoriteAlbumEntity {
+        if !isFavoriteAlbumInfoDirty, let cache = favoriteAlbumInfoCache {
+            return cache
+        }
+        
+        let result: BaseResponseDTO<FavoriteAlbumInfoDTO> = try await networkProvider.request(endpoint: ArchiveEndpoint.getFavoriteAlbumInfo)
+        guard let data = result.data else { throw NetworkError.responseDecodingError }
+        
+        let entity = FavoriteAlbumEntity(latestImageURL: data.latestImageURL ?? "", totalCount: data.totalCount)
+        
+        self.favoriteAlbumInfoCache = entity
+        self.isFavoriteAlbumInfoDirty = false
+        
+        return entity
+    }
+    
+    func fetchFavoritePhotoList(size: Int?, sortOrder: String?) async throws -> [PhotoEntity] {
+        
+        if isFavoriteCacheDirty || favoritePhotoCache.isEmpty {
+            currentFavoritePage = 0
+            hasNextFavorite = true
+            favoritePhotoCache.removeAll()
+            isFavoriteCacheDirty = false
+        }
+        
+        if !hasNextFavorite { return favoritePhotoCache }
+        
+        let request = PhotoListDTO.Request(folderId: nil, page: currentFavoritePage, size: size ?? 20, sortOrder: sortOrder)
         let endpoint = ArchiveEndpoint.getFavoritePhotoList(request: request)
         let response: BaseResponseDTO<PhotoListDTO.PhotoListData> = try await networkProvider.request(endpoint: endpoint)
         
         guard let data = response.data else { throw NetworkError.responseDecodingError }
         
-        let entities = data.toEntity()
+        let newEntities = data.toEntity()
+        let existingIDs = Set(self.favoritePhotoCache.map { $0.photoID })
+        let uniqueNewEntities = newEntities.filter { !existingIDs.contains($0.photoID) }
         
-        return (entities, data.hasNext)
+        self.favoritePhotoCache.append(contentsOf: uniqueNewEntities)
+        
+        self.hasNextFavorite = data.hasNext
+        if data.hasNext { self.currentFavoritePage += 1 }
+        
+        return self.favoritePhotoCache
     }
+}
+
+
+// MARK: - Update Logic
+
+extension DefaultArchiveRepository {
     
     func toggleFavorite(photoID: Int, request: Bool) async throws {
-        let request = ToggleFavoriteDTO(favorite: request)
-        let endpoint = ArchiveEndpoint.toggleFavorite(photoID: photoID, request: request)
-        let _ = try await networkProvider.request(endpoint: endpoint)
+        let dto = ToggleFavoriteDTO(favorite: request)
+        let endpoint = ArchiveEndpoint.toggleFavorite(photoID: photoID, request: dto)
+        
+        do {
+            let _ = try await networkProvider.request(endpoint: endpoint)
+            
+            for (key, var list) in photoCache {
+                if let index = list.firstIndex(where: { $0.photoID == photoID }) {
+                    let oldItem = list[index]
+                    let newItem = PhotoEntity(
+                        photoID: oldItem.photoID,
+                        imageURL: oldItem.imageURL,
+                        folderID: oldItem.folderID,
+                        isfavorite: request,
+                        contentType: oldItem.contentType,
+                        createdAt: oldItem.createdAt
+                    )
+                    list[index] = newItem
+                    photoCache[key] = list
+                }
+            }
+            
+            self.isFavoriteCacheDirty = true
+            self.isFavoriteAlbumInfoDirty = true
+        } catch {
+            throw error
+        }
     }
     
     func excludePhotosInAlbum(albumID: Int, photoIDs: [Int]) async throws {
         let request = DeletePhotoRequestDTO(photoIds: photoIDs)
         let endpoint = ArchiveEndpoint.excludePhotosInAlbum(albumID: albumID, request: request)
         let _ = try await networkProvider.request(endpoint: endpoint)
+        
+        self.isAlbumCacheDirty = true
+        self.isPhotoCacheDirty[albumID] = true
     }
 }
+
+
+// MARK: - Delete Logic
+
+extension DefaultArchiveRepository {
+    func deletePhotoList(photoIDs: [Int]) async throws {
+        let request = DeletePhotoRequestDTO(photoIds: photoIDs)
+        let endpoint = ArchiveEndpoint.deletePhoto(request: request)
+        let _ = try await networkProvider.request(endpoint: endpoint)
+        
+        for (key, var list) in photoCache {
+            list.removeAll { photoIDs.contains($0.photoID) }
+            photoCache[key] = list
+        }
+        
+        self.isAlbumCacheDirty = true
+        self.isFavoriteCacheDirty = true
+        self.isFavoriteAlbumInfoDirty = true
+    }
+    
+    func deleteFolders(folderIDs: [Int], deletePhotos: Bool) async throws {
+        let request = DeleteFoldersRequestDTO(folderIds: folderIDs)
+        let endpoint = ArchiveEndpoint.deleteFolders(request: request, deletePhotos: deletePhotos)
+        let _ = try await networkProvider.request(endpoint: endpoint)
+        
+        self.isAlbumCacheDirty = true
+        
+        for folderID in folderIDs {
+            self.photoCache.removeValue(forKey: folderID)
+            self.currentPhotoPage.removeValue(forKey: folderID)
+            self.hasNextPhoto.removeValue(forKey: folderID)
+            self.isPhotoCacheDirty.removeValue(forKey: folderID)
+        }
+        
+        if deletePhotos {
+            self.isPhotoCacheDirty[nil] = true
+            self.isFavoriteCacheDirty = true
+            self.isFavoriteAlbumInfoDirty = true
+        }
+    }
+}
+
+
+// MARK: - Dependency
 
 private enum ArchiveRepositoryKey: DependencyKey {
     static let liveValue: ArchiveRepository = DefaultArchiveRepository()

--- a/Neki-iOS/Features/Archive/Sources/Data/Sources/DefaultArchiveRepository.swift
+++ b/Neki-iOS/Features/Archive/Sources/Data/Sources/DefaultArchiveRepository.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Dependencies
 
-actor DefaultArchiveRepository: ArchiveRepository {
+final actor DefaultArchiveRepository: ArchiveRepository {
     
     @Dependency(\.networkProvider) var networkProvider
     

--- a/Neki-iOS/Features/Archive/Sources/Data/Sources/DefaultArchiveRepository.swift
+++ b/Neki-iOS/Features/Archive/Sources/Data/Sources/DefaultArchiveRepository.swift
@@ -70,7 +70,7 @@ extension DefaultArchiveRepository {
 
 extension DefaultArchiveRepository {
     
-    func fetchPhotoList(folderID: Int?, size: Int?, sortOrder: String?) async throws -> [PhotoEntity] {
+    func fetchPhotoList(folderID: Int?, size: Int? = 20, sortOrder: String? = "DESC") async throws -> [PhotoEntity] {
         
         /// 캐시가 더렵혀졌거나(변경사항이 있거나) 비어있으면 실행
         /// 첫 페이지부터 다시 불러오고 기존에 저장되어 있던 캐시들 삭제
@@ -78,7 +78,7 @@ extension DefaultArchiveRepository {
         let currentCache = photoCache[folderID] ?? []
         
         // 요청한 정렬 순서 (기본값 DESC)
-        let requestSortOrder = sortOrder ?? "DESC"
+        let requestSortOrder = sortOrder
         // 기존에 저장된 정렬 순서
         let cachedSortOrder = currentSortOrder[folderID]
         // 정렬이 바뀌었으면 무조건 Dirty로 간주하여 초기화
@@ -98,7 +98,7 @@ extension DefaultArchiveRepository {
         }
         
         let page = currentPhotoPage[folderID] ?? 0
-        let request = PhotoListDTO.Request(folderId: folderID, page: page, size: size ?? 20, sortOrder: sortOrder)
+        let request = PhotoListDTO.Request(folderId: folderID, page: page, size: size, sortOrder: sortOrder)
         let endpoint = ArchiveEndpoint.getPhotoList(request: request)
         let response: BaseResponseDTO<PhotoListDTO.PhotoListData> = try await networkProvider.request(endpoint: endpoint)
         
@@ -164,7 +164,7 @@ extension DefaultArchiveRepository {
         return entity
     }
     
-    func fetchFavoritePhotoList(size: Int?, sortOrder: String?) async throws -> [PhotoEntity] {
+    func fetchFavoritePhotoList(size: Int? = 20, sortOrder: String?) async throws -> [PhotoEntity] {
         
         if isFavoriteCacheDirty || favoritePhotoCache.isEmpty {
             currentFavoritePage = 0
@@ -175,7 +175,7 @@ extension DefaultArchiveRepository {
         
         if !hasNextFavorite { return favoritePhotoCache }
         
-        let request = PhotoListDTO.Request(folderId: nil, page: currentFavoritePage, size: size ?? 20, sortOrder: sortOrder)
+        let request = PhotoListDTO.Request(folderId: nil, page: currentFavoritePage, size: size, sortOrder: sortOrder)
         let endpoint = ArchiveEndpoint.getFavoritePhotoList(request: request)
         let response: BaseResponseDTO<PhotoListDTO.PhotoListData> = try await networkProvider.request(endpoint: endpoint)
         

--- a/Neki-iOS/Features/Archive/Sources/Domain/Sources/Client/ArchiveClient.swift
+++ b/Neki-iOS/Features/Archive/Sources/Domain/Sources/Client/ArchiveClient.swift
@@ -11,14 +11,14 @@ import DependenciesMacros
 
 @DependencyClient
 struct ArchiveClient {
-    public var fetchPhotoList: (_ folderId: Int?, _ page: Int?, _ size: Int?, _ sortOrder: String?) async throws -> (photos: [PhotoEntity], hasNext: Bool)
+    public var fetchPhotoList: (_ folderId: Int?, _ size: Int?, _ sortOrder: String?) async throws -> [PhotoEntity]
+    public var getAlbumList: () async throws -> [AlbumEntity]
     public var deletePhotoList: (_ photoIds: [Int]) async throws -> Void
     public var registerPhotos: (_ folderId: Int?, _ uploads: [(mediaID: Int, memo: String?)]) async throws -> Void
     public var getFavoriteAlbumInfo: () async throws -> FavoriteAlbumEntity
-    public var getAlbumList: () async throws -> [AlbumEntity]
     public var addFolder: (_ name: String) async throws -> Int
     public var deleteFolders: (_ folderIDs: [Int], _ deletePhotos: Bool) async throws -> Void
-    public var fetchFavoritePhotoList: (_ page: Int?, _ size: Int?, _ sortOrder: String?) async throws -> (photos: [PhotoEntity], hasNext: Bool)
+    public var fetchFavoritePhotoList: (_ size: Int?, _ sortOrder: String?) async throws -> [PhotoEntity]
     public var toggleFavorite: (_ photoID: Int, _ request: Bool) async throws -> Void
     public var excludePhotosInAlbum: (_ albumID: Int, _ photoIDs: [Int]) async throws -> Void
 }
@@ -27,61 +27,37 @@ extension ArchiveClient: DependencyKey {
     static var liveValue: ArchiveClient {
         @Dependency(\.archiveRepository) var archiveRepository
         
-        func fetchPhotoList(_ folderId: Int?, _ page: Int?, _ size: Int?, _ sortOrder: String?) async throws -> (photos: [PhotoEntity], hasNext: Bool) {
-            let result = try await archiveRepository.fetchPhotoList(folderID: folderId, page: page, size: size, sortOrder: sortOrder)
-            
-            return result
-        }
-        
-        func deletePhotoList(_ photoIds: [Int]) async throws {
-            try await archiveRepository.deletePhotoList(photoIDs: photoIds)
-        }
-        
-        func registerPhotos(_ folderId: Int?, _ uploads: [(mediaID: Int, memo: String?)]) async throws {
-            try await archiveRepository.registerPhoto(folderID: folderId, uploads: uploads)
-        }
-        
-        func getFavoriteAlbumInfo() async throws -> FavoriteAlbumEntity {
-            return try await archiveRepository.getFavoriteAlbumInfo()
-        }
-        
-        func getAlbumList() async throws -> [AlbumEntity] {
-            return try await archiveRepository.getAlbumList()
-        }
-
-        func addFolder(name: String) async throws -> Int {
-            return try await archiveRepository.addFolder(name: name)
-        }
-        
-        func deleteFolders(folderIDs: [Int], deletePhotos: Bool) async throws -> Void {
-            return try await archiveRepository.deleteFolders(folderIDs: folderIDs, deletePhotos: deletePhotos)
-        }
-
-        func fetchFavoritePhotoList(_ page: Int?, _ size: Int?, _ sortOrder: String?) async throws -> (photos: [PhotoEntity], hasNext: Bool) {
-            let result = try await archiveRepository.fetchFavoritePhotoList(page: page, size: size, sortOrder: sortOrder)
-            
-            return result
-        }
-        
-        func toggleFavorite(photoID: Int, request: Bool) async throws -> Void {
-            return try await archiveRepository.toggleFavorite(photoID: photoID, request: request)
-        }
-        
-        func excludePhotosInAlbum(albumID: Int, photoIDs: [Int]) async throws -> Void {
-            try await archiveRepository.excludePhotosInAlbum(albumID: albumID, photoIDs: photoIDs)
-        }
-        
         return ArchiveClient(
-            fetchPhotoList: fetchPhotoList,
-            deletePhotoList: deletePhotoList,
-            registerPhotos: registerPhotos,
-            getFavoriteAlbumInfo: getFavoriteAlbumInfo,
-            getAlbumList: getAlbumList,
-            addFolder: addFolder,
-            deleteFolders: deleteFolders,
-            fetchFavoritePhotoList: fetchFavoritePhotoList,
-            toggleFavorite: toggleFavorite,
-            excludePhotosInAlbum: excludePhotosInAlbum
+            fetchPhotoList: { folderId, size, sortOrder in
+                try await archiveRepository.fetchPhotoList(folderID: folderId, size: size, sortOrder: sortOrder)
+            },
+            getAlbumList: {
+                try await archiveRepository.getAlbumList()
+            },
+            deletePhotoList: { photoIds in
+                try await archiveRepository.deletePhotoList(photoIDs: photoIds)
+            },
+            registerPhotos: { folderId, uploads in
+                try await archiveRepository.registerPhoto(folderID: folderId, uploads: uploads)
+            },
+            getFavoriteAlbumInfo: {
+                try await archiveRepository.getFavoriteAlbumInfo()
+            },
+            addFolder: { name in
+                try await archiveRepository.addFolder(name: name)
+            },
+            deleteFolders: { folderIDs, deletePhotos in
+                try await archiveRepository.deleteFolders(folderIDs: folderIDs, deletePhotos: deletePhotos)
+            },
+            fetchFavoritePhotoList: { size, sortOrder in
+                try await archiveRepository.fetchFavoritePhotoList(size: size, sortOrder: sortOrder)
+            },
+            toggleFavorite: { photoID, request in
+                try await archiveRepository.toggleFavorite(photoID: photoID, request: request)
+            },
+            excludePhotosInAlbum: { albumID, photoIDs in
+                try await archiveRepository.excludePhotosInAlbum(albumID: albumID, photoIDs: photoIDs)
+            }
         )
     }
 }

--- a/Neki-iOS/Features/Archive/Sources/Domain/Sources/Interfaces/Repositories/ArchiveRepository.swift
+++ b/Neki-iOS/Features/Archive/Sources/Domain/Sources/Interfaces/Repositories/ArchiveRepository.swift
@@ -7,15 +7,22 @@
 
 import Foundation
 
-protocol ArchiveRepository {
-    func fetchPhotoList(folderID: Int?, page: Int?, size: Int?, sortOrder: String?) async throws -> (photos: [PhotoEntity], hasNext: Bool)
-    func deletePhotoList(photoIDs: [Int]) async throws
-    func registerPhoto(folderID: Int?, uploads: [(mediaID: Int, memo: String?)]) async throws
-    func getFavoriteAlbumInfo() async throws -> FavoriteAlbumEntity
-    func getAlbumList() async throws -> [AlbumEntity]
+protocol ArchiveRepository: Sendable {
+    // Create
     func addFolder(name: String) async throws -> Int
-    func deleteFolders(folderIDs: [Int], deletePhotos: Bool) async throws
-    func fetchFavoritePhotoList(page: Int?, size: Int?, sortOrder: String?) async throws -> (photos: [PhotoEntity], hasNext: Bool)
+    func registerPhoto(folderID: Int?, uploads: [(mediaID: Int, memo: String?)]) async throws
+    
+    // Read
+    func fetchPhotoList(folderID: Int?, size: Int?, sortOrder: String?) async throws -> [PhotoEntity]
+    func getAlbumList() async throws -> [AlbumEntity]
+    func getFavoriteAlbumInfo() async throws -> FavoriteAlbumEntity
+    func fetchFavoritePhotoList(size: Int?, sortOrder: String?) async throws -> [PhotoEntity]
+    
+    // Update
     func toggleFavorite(photoID: Int, request: Bool) async throws
     func excludePhotosInAlbum(albumID: Int, photoIDs: [Int]) async throws
+    
+    // Delete
+    func deletePhotoList(photoIDs: [Int]) async throws
+    func deleteFolders(folderIDs: [Int], deletePhotos: Bool) async throws
 }

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Coordinator/ArchiveCoordinator.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Coordinator/ArchiveCoordinator.swift
@@ -48,7 +48,7 @@ struct ArchiveCoordinator {
             case let .root(.imageTapped(item)):
                 state.path.append(.detail(
                     ArchivePhotoDetailFeature.State(
-                        photos: state.root.$photos,
+                        photos: state.root.photos,
                         currentItemID: item.id,
                         folderId: nil
                     )
@@ -56,28 +56,20 @@ struct ArchiveCoordinator {
                 return .none
                 
             case .root(.onTapAllPhotos):
-                state.path.append(.allPhotos(
-                    ArchiveAllPhotosFeature.State(photos: state.root.$photos)
-                ))
+                state.path.append(.allPhotos(ArchiveAllPhotosFeature.State()))
                 return .none
                 
             case .root(.onTapAllAlbums):
-                state.path.append(.allAlbums(
-                    ArchiveAllAlbumsFeature.State(albums: state.root.$albums, photos: state.root.$photos)
-                ))
+                state.path.append(.allAlbums(ArchiveAllAlbumsFeature.State()))
                 return .none
                 
             case let .root(.albumTapped(album)):
                 let isFirstAlbum = state.root.albums.first?.id == album.id
                 
                 if isFirstAlbum {
-                    state.path.append(.favoriteAlbum(
-                        ArchiveFavoriteAlbumFeature.State(photos: state.root.$photos, album: album)
-                    ))
+                    state.path.append(.favoriteAlbum(ArchiveFavoriteAlbumFeature.State(album: album)))
                 } else {
-                    state.path.append(.albumDetail(
-                        ArchiveAlbumDetailFeature.State(photos: state.root.$photos, sharedAlbums: state.root.$albums, album: album)
-                    ))
+                    state.path.append(.albumDetail(ArchiveAlbumDetailFeature.State(album: album)))
                 }
                 return .none
                 
@@ -85,13 +77,9 @@ struct ArchiveCoordinator {
                 let isFirstAlbum = state.root.albums.first?.id == album.id
                 
                 if isFirstAlbum {
-                    state.path.append(.favoriteAlbum(
-                        ArchiveFavoriteAlbumFeature.State(photos: state.root.$photos, album: album)
-                    ))
+                    state.path.append(.favoriteAlbum(ArchiveFavoriteAlbumFeature.State(album: album)))
                 } else {
-                    state.path.append(.albumDetail(
-                        ArchiveAlbumDetailFeature.State(photos: state.root.$photos, sharedAlbums: state.root.$albums, album: album)
-                    ))
+                    state.path.append(.albumDetail(ArchiveAlbumDetailFeature.State(album: album)))
                 }
                 return .none
                 
@@ -104,7 +92,7 @@ struct ArchiveCoordinator {
                 if !allPhotosState.isSelectionMode {
                     state.path.append(.detail(
                         ArchivePhotoDetailFeature.State(
-                            photos: state.root.$photos,
+                            photos: state.root.photos,
                             currentItemID: item.id,
                             folderId: nil
                         )
@@ -117,12 +105,11 @@ struct ArchiveCoordinator {
                 
                 if isFirstAlbum {
                     state.path.append(.favoriteAlbum(
-                        ArchiveFavoriteAlbumFeature.State(photos: state.root.$photos, album: album)
+                        ArchiveFavoriteAlbumFeature.State(album: album)
                     ))
                 } else {
                     state.path.append(.albumDetail(
-                        ArchiveAlbumDetailFeature.State(photos: state.root.$photos, sharedAlbums: state.root.$albums, album: album)
-                    ))
+                        ArchiveAlbumDetailFeature.State(album: album)))
                 }
                 return .none
                 
@@ -132,7 +119,7 @@ struct ArchiveCoordinator {
                 if !albumDetailState.isSelectionMode {
                     state.path.append(.detail(
                         ArchivePhotoDetailFeature.State(
-                            photos: state.root.$photos,
+                            photos: state.root.photos,
                             currentItemID: item.id,
                             folderId: albumDetailState.album.id
                         )
@@ -146,7 +133,7 @@ struct ArchiveCoordinator {
                 if !albumDetailState.isSelectionMode {
                     state.path.append(.detail(
                         ArchivePhotoDetailFeature.State(
-                            photos: state.root.$photos,
+                            photos: state.root.photos,
                             currentItemID: item.id,
                             folderId: albumDetailState.album.id
                         )

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveAlbumDetailFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveAlbumDetailFeature.swift
@@ -13,8 +13,7 @@ struct ArchiveAlbumDetailFeature {
     
     @ObservableState
     struct State {
-        @Shared var photos: IdentifiedArrayOf<ArchiveImageItem>
-        @Shared var sharedAlbums: IdentifiedArrayOf<AlbumItem>
+        var photos: IdentifiedArrayOf<ArchiveImageItem> = []
         
         let album: AlbumItem
         
@@ -23,12 +22,9 @@ struct ArchiveAlbumDetailFeature {
         var isSelectionMode: Bool = false
         
         var filteredAlbumPhotos: IdentifiedArrayOf<ArchiveImageItem> {
-            let items = photos.filter { $0.folderId == album.id }
-            return IdentifiedArray(uniqueElements: items)
+            return photos
         }
         
-        var currentPage: Int = 0
-        var hasNext: Bool = true
         var isFetchingPhotos: Bool = false
         
         var isLoading: Bool = false
@@ -50,13 +46,10 @@ struct ArchiveAlbumDetailFeature {
         case downloadImagesResponse(successCount: Int)
         
         case onTapDeleteButton(option: ArchivePhotoDeleteOption)
-        case deletePhotosResponse(ArchivePhotoDeleteOption, Result<Void, Error>)
+        case deletePhotosResponse(Result<Void, Error>)
         
-        case fetchAlbums
-        case albumListResponse(Result<[AlbumItem], Error>)
-        
-        case fetchPhotos(isRefresh: Bool)
-        case photoListResponse(Result<(photos: [PhotoEntity], hasNext: Bool), Error>)
+        case fetchPhotos
+        case photoListResponse(Result<[PhotoEntity], Error>)
         case loadMorePhotos
         
         // 네비게이션
@@ -81,23 +74,16 @@ struct ArchiveAlbumDetailFeature {
                 return .run { _ in await dismiss() }
                 
             case .onAppear:
-                return .send(.fetchPhotos(isRefresh: true))
+                return .send(.fetchPhotos)
                 
-            case let .fetchPhotos(isRefresh):
-                if isRefresh {
-                    state.currentPage = 0
-                    state.hasNext = true
-                }
-                
-                guard state.hasNext, !state.isFetchingPhotos else { return .none }
+            case .fetchPhotos:
                 state.isFetchingPhotos = true
                 
-                return .run { [page = state.currentPage, albumId = state.album.id] send in
+                return .run { [albumId = state.album.id] send in
                     await send(.photoListResponse(
                         Result {
                             try await archiveClient.fetchPhotoList(
                                 folderId: albumId,
-                                page: page,
                                 size: 20,
                                 sortOrder: nil
                             )
@@ -105,13 +91,12 @@ struct ArchiveAlbumDetailFeature {
                     ))
                 }
                 
-            case let .photoListResponse(.success(result)):
+            case let .photoListResponse(.success(entities)):
                 state.isFetchingPhotos = false
-                state.hasNext = result.hasNext
                 
                 let currentAlbumId = state.album.id
                 
-                let newItems = result.photos.map { entity in
+                let newItems = entities.map { entity in
                     ArchiveImageItem(
                         id: entity.photoID,
                         imageURLString: entity.imageURL,
@@ -121,21 +106,15 @@ struct ArchiveAlbumDetailFeature {
                     )
                 }
                 
-                state.$photos.withLock { sharedPhotos in
-                    for item in newItems {
-                        sharedPhotos.updateOrAppend(item)
-                    }
-                }
-                
-                state.currentPage += 1
+                state.photos = IdentifiedArray(uniqueElements: newItems)
                 return .none
                 
-            case .photoListResponse:
+            case .photoListResponse(.failure):
                 state.isFetchingPhotos = false
                 return .send(.delegate(.showToast(NekiToastItem("사진을 불러오지 못했어요", style: .error))))
                 
             case .loadMorePhotos:
-                return .send(.fetchPhotos(isRefresh: false))
+                return .send(.fetchPhotos)
                 
             case .onTapSelectButton:
                 state.isSelectionMode = true
@@ -159,18 +138,11 @@ struct ArchiveAlbumDetailFeature {
             case .onTapDownloadButton:
                 guard !state.selectedIDs.isEmpty else { return .none }
                 state.isLoading = true
-
-                let selectedURLs: [URL] = state.selectedIDs.compactMap { id in
-                        return state.photos[id: id]?.imageURL
-                    }
                 
-                guard !selectedURLs.isEmpty else {
-                    state.isLoading = false
-                    return .none
-                }
+                let urls = state.selectedIDs.compactMap { state.photos[id: $0]?.imageURL }
                 
                 return .run { send in
-                    let count = try await imageDownloadClient.downloadImages(urls: selectedURLs)
+                    let count = try await imageDownloadClient.downloadImages(urls: urls)
                     await send(.downloadImagesResponse(successCount: count))
                 }
                 
@@ -188,82 +160,32 @@ struct ArchiveAlbumDetailFeature {
             case let .onTapDeleteButton(option):
                 guard !state.selectedIDs.isEmpty else { return .none }
                 
-                return .run { [ids = state.selectedIDs, albumId = state.album.id] send in
+                let selectedIDs = Array(state.selectedIDs)
+                let albumID = state.album.id
+                
+                return .run { send in
                     await send(.deletePhotosResponse(
-                        option,
                         Result {
                             if option == .fromAlbumOnly {
-                                try await archiveClient.excludePhotosInAlbum(albumID: albumId, photoIDs: Array(ids))
+                                try await archiveClient.excludePhotosInAlbum(albumID, selectedIDs)
                             } else {
-                                try await archiveClient.deletePhotoList(photoIds: Array(ids))
+                                try await archiveClient.deletePhotoList(selectedIDs)
                             }
                         }
                     ))
                 }
                 
-            case let .deletePhotosResponse(option, .success):
-                
-                state.$photos.withLock { photos in
-                    if option == .fromAlbumOnly {
-                        for id in state.selectedIDs {
-                            photos[id: id]?.folderId = nil
-                        }
-                    } else {
-                        photos.removeAll { state.selectedIDs.contains($0.id) }
-                    }
-                }
+            case .deletePhotosResponse(.success):
+                let idsToDelete = state.selectedIDs
+                state.photos.removeAll { idsToDelete.contains($0.id) }
                 
                 state.isSelectionMode = false
                 state.selectedIDs.removeAll()
                 
-                let toastItem = NekiToastItem("사진을 삭제했어요", style: .success)
+                return .send(.delegate(.showToast(NekiToastItem("사진을 삭제했어요", style: .success))))
                 
-                return .merge(
-                    .send(.delegate(.showToast(toastItem))),
-                    .send(.fetchPhotos(isRefresh: true)),
-                    .send(.fetchAlbums)
-                )
-                
-            case .deletePhotosResponse(_, .failure):
+            case .deletePhotosResponse(.failure):
                 return .send(.delegate(.showToast(NekiToastItem("사진을 삭제하지 못했어요", style: .error))))
-                
-            case .fetchAlbums:
-                return .run { send in
-                    await send(.albumListResponse(Result {
-                        let entities = try await archiveClient.getAlbumList()
-                        return entities.map {
-                            AlbumItem(
-                                id: $0.id,
-                                title: $0.name,
-                                count: $0.photoCount,
-                                coverImageURL: URL(string: $0.coverImageURLString),
-                                isFavorite: false
-                            )
-                        }
-                    }))
-                }
-                
-            case let .albumListResponse(.success(newAlbums)):
-                state.$sharedAlbums.withLock { existing in
-                    var favoriteAlbum: AlbumItem?
-                    if let first = existing.first, first.isFavorite {
-                        favoriteAlbum = first
-                    }
-                    
-                    var mergedAlbums: [AlbumItem] = []
-                    
-                    if let fav = favoriteAlbum {
-                        mergedAlbums.append(fav)
-                    }
-                    
-                    mergedAlbums.append(contentsOf: newAlbums)
-                    
-                    existing = IdentifiedArray(uniqueElements: mergedAlbums)
-                }
-                return .none
-                
-            case .albumListResponse(.failure):
-                return .none
                 
             default:
                 return .none

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveAllAlbumsFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveAllAlbumsFeature.swift
@@ -13,8 +13,7 @@ struct ArchiveAllAlbumsFeature {
     
     @ObservableState
     struct State {
-        @Shared var albums: IdentifiedArrayOf<AlbumItem>
-        @Shared var photos: IdentifiedArrayOf<ArchiveImageItem>
+        var albums: IdentifiedArrayOf<AlbumItem> = []
         
         var isSelectMode: Bool = false
         var selectedAlbumIDs: Set<Int> = []
@@ -30,6 +29,7 @@ struct ArchiveAllAlbumsFeature {
     enum Action: BindableAction {
         case binding(BindingAction<State>)
         
+        case onAppear
         case onTapBackButton
         
         case onTapAlbum(AlbumItem)
@@ -41,9 +41,6 @@ struct ArchiveAllAlbumsFeature {
         // 앨범 삭제 액션
         case onTapExecuteDelete(option: ArchiveAlbumDeleteOption)
         case deleteFoldersResponse(Result<Void, Error>)
-        
-        case fetchPhotos
-        case photoListResponse(Result<[ArchiveImageItem], Error>)
         
         // 앨범 생성 액션
         case onTapCancelAddAlbum
@@ -67,10 +64,12 @@ struct ArchiveAllAlbumsFeature {
     var body: some ReducerOf<Self> {
         BindingReducer()
         
-        Reduce {
-            state,
-            action in
+        Reduce { state, action in
             switch action {
+                
+            case .onAppear:
+                return .send(.fetchAlbums)
+                
             case .onTapBackButton:
                 if state.isSelectMode {
                     return .send(.onTapExitDeleteMode)
@@ -104,17 +103,18 @@ struct ArchiveAllAlbumsFeature {
                 }
                 
                 let shouldDeletePhotos = (option == .withPhotos)
+                let idsToDelete = Array(state.selectedAlbumIDs)
                 
-                return .run { [ids = state.selectedAlbumIDs] send in
+                return .run { send in
                     await send(.deleteFoldersResponse(Result {
-                        try await archiveClient.deleteFolders(folderIDs: Array(ids), deletePhotos: shouldDeletePhotos)
+                        try await archiveClient.deleteFolders(idsToDelete, shouldDeletePhotos)
                     }))
                 }
                 
             case .deleteFoldersResponse(.success):
-                state.$albums.withLock { albums in
-                    albums.removeAll { state.selectedAlbumIDs.contains($0.id) }
-                }
+                let idsToRemove = state.selectedAlbumIDs
+                state.albums.removeAll { idsToRemove.contains($0.id) }
+                
                 state.isSelectMode = false
                 state.selectedAlbumIDs.removeAll()
                 
@@ -122,41 +122,12 @@ struct ArchiveAllAlbumsFeature {
                 
                 return .merge(
                     .send(.delegate(.showToast(toastItem))),
-                    .send(.fetchAlbums),
-                    .send(.fetchPhotos)
+                    .send(.fetchAlbums)
                 )
                 
             case .deleteFoldersResponse(.failure):
                 let toastItem = NekiToastItem("앨범을 삭제하지 못했어요", style: .error)
                 return .send(.delegate(.showToast(toastItem)))
-                
-            case .fetchPhotos:
-                return .run { send in
-                    await send(.photoListResponse(Result {
-                        let result = try await archiveClient.fetchPhotoList(folderId: nil, page: 0, size: 20, sortOrder: nil)
-                        
-                        let isoFormatter = ISO8601DateFormatter()
-                        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-                        
-                        return result.photos.map { entity in
-                            ArchiveImageItem(
-                                id: entity.photoID,
-                                imageURLString: entity.imageURL,
-                                isFavorite: entity.isfavorite,
-                                date: isoFormatter.date(from: entity.createdAt) ?? Date()
-                            )
-                        }
-                    }))
-                }
-                
-            case let .photoListResponse(.success(newPhotos)):
-                state.$photos.withLock { sharedPhotos in
-                    sharedPhotos = IdentifiedArray(uniqueElements: newPhotos)
-                }
-                return .none
-                
-            case .photoListResponse(.failure):
-                return .none
                 
             case .onTapCancelAddAlbum:
                 state.newAlbumTitle = ""
@@ -208,20 +179,14 @@ struct ArchiveAllAlbumsFeature {
                 }
                 
             case let .albumListResponse(.success(newAlbums)):
-                state.$albums.withLock { existing in
-                    var favoriteAlbum: AlbumItem?
-                    if let first = existing.first,
-                       first.isFavorite {
-                        favoriteAlbum = first
-                    }
-                    
-                    var mergedAlbums: [AlbumItem] = []
-                    if let fav = favoriteAlbum {
-                        mergedAlbums.append(fav)
-                    }
-                    mergedAlbums.append(contentsOf: newAlbums)
-                    existing = IdentifiedArray(uniqueElements: mergedAlbums)
+                let favoriteAlbum = state.albums.first(where: { $0.isFavorite })
+                
+                var mergedAlbums: [AlbumItem] = []
+                if let fav = favoriteAlbum {
+                    mergedAlbums.append(fav)
                 }
+                mergedAlbums.append(contentsOf: newAlbums)
+                state.albums = IdentifiedArray(uniqueElements: mergedAlbums)
                 return .none
                 
             case .albumListResponse(.failure):

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveAllPhotosFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveAllPhotosFeature.swift
@@ -7,23 +7,19 @@
 
 import ComposableArchitecture
 import Foundation
-//import Core
 
 @Reducer
 struct ArchiveAllPhotosFeature {
     
     @ObservableState
     struct State {
-        @Shared var photos: IdentifiedArrayOf<ArchiveImageItem>
+        var photos: IdentifiedArrayOf<ArchiveImageItem> = []
         var selectedIDs: Set<Int> = []
         
         var selectedSortedTime: String = "최신순" // "최신순" == DESC, "오래된순" == ASC
         var isSelectedFavorite: Bool = false
         var isSelectionMode: Bool = false
         
-        // 페이징 관리
-        var currentPage: Int = 0
-        var hasNext: Bool = true
         var isFetchingPhotos: Bool = false
         
         // 선택된 사진이 있는지 여부
@@ -59,8 +55,8 @@ struct ArchiveAllPhotosFeature {
         case onTapFavoriteButton
         
         // Fetch Photo Action
-        case fetchPhotos(isRefresh: Bool)
-        case photoListResponse(Result<(photos: [PhotoEntity], hasNext: Bool), Error>)
+        case fetchPhotos
+        case photoListResponse(Result<[PhotoEntity], Error>)
         case loadMorePhotos
         
         case imageTapped(ArchiveImageItem)
@@ -83,11 +79,7 @@ struct ArchiveAllPhotosFeature {
                 // MARK: - View Life Cycle Action
                 
             case .onAppear:
-                if state.photos.isEmpty {
-                    return .send(.fetchPhotos(isRefresh: true))
-                }
-                return .none
-                
+                return .send(.fetchPhotos)
                 
                 // MARK: - User Action
                 
@@ -100,7 +92,6 @@ struct ArchiveAllPhotosFeature {
                 
             case .onTapCancelSelectButton:
                 state.isSelectionMode = false
-                // 선택 모드 해제 시 모든 선택 상태 초기화
                 state.selectedIDs.removeAll()
                 return .none
                 
@@ -115,18 +106,15 @@ struct ArchiveAllPhotosFeature {
                 
                 
                 // MARK: - Delete Action
-
+                
             case .onTapDeleteButton:
                 return .run { [selectedIDs = state.selectedIDs] send in
                     try await archiveClient.deletePhotoList(photoIds: Array(selectedIDs))
-
                     await send(.deletePhotosLocally(ids: Array(selectedIDs)))
                 }
-
+                
             case let .deletePhotosLocally(ids):
-                state.$photos.withLock {
-                    $0.removeAll { ids.contains($0.id) }
-                }
+                state.photos.removeAll { ids.contains($0.id) }
                 
                 state.isSelectionMode = false
                 state.selectedIDs.removeAll()
@@ -139,12 +127,14 @@ struct ArchiveAllPhotosFeature {
             case .onTapFilterNewest:
                 if state.selectedSortedTime == "최신순" { return .none }
                 state.selectedSortedTime = "최신순"
-                return .send(.fetchPhotos(isRefresh: true))
+                state.photos.removeAll()
+                return .send(.fetchPhotos)
                 
             case .onTapFilterOldest:
                 if state.selectedSortedTime == "오래된순" { return .none }
                 state.selectedSortedTime = "오래된순"
-                return .send(.fetchPhotos(isRefresh: true))
+                state.photos.removeAll()
+                return .send(.fetchPhotos)
                 
             case .onTapFavoriteButton:
                 state.isSelectedFavorite.toggle()
@@ -153,55 +143,35 @@ struct ArchiveAllPhotosFeature {
                 
                 // MARK: - Fetch Photo Action
                 
-            case let .fetchPhotos(isRefresh):
-                if isRefresh {
-                    state.currentPage = 0
-                    state.hasNext = true
-                }
-                
-                guard state.hasNext, !state.isFetchingPhotos else { return .none }
+            case .fetchPhotos:
+                guard !state.isFetchingPhotos else { return .none }
                 state.isFetchingPhotos = true
                 
                 // "최신순" -> "DESC", "오래된순" -> "ASC" 변환
                 let sortOrder = state.selectedSortedTime == "최신순" ? "DESC" : "ASC"
                 
-                return .run { [page = state.currentPage, sort = sortOrder] send in
+                return .run { send in
                     await send(.photoListResponse(
                         Result {
-                            try await archiveClient.fetchPhotoList(
-                                folderId: nil,
-                                page: page,
-                                size: 20,
-                                sortOrder: sort
-                            )
+                            try await archiveClient.fetchPhotoList(folderId: nil, size: 20, sortOrder: sortOrder)
                         }
                     ))
                 }
                 
-            case let .photoListResponse(.success(result)):
+            case let .photoListResponse(.success(entities)):
                 state.isFetchingPhotos = false
-                state.hasNext = result.hasNext
-                
-                let isoFormatter = ISO8601DateFormatter()
-                isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-                
-                let newItems = result.photos.map { entity in
+    
+                let newItems = entities.map { entity in
                     ArchiveImageItem(
                         id: entity.photoID,
                         imageURLString: entity.imageURL,
                         isFavorite: entity.isfavorite,
-                        date: isoFormatter.date(from: entity.createdAt) ?? Date(),
+                        date: entity.createdAt.toISO8601Date(),
                         folderId: entity.folderID
                     )
                 }
                 
-                if state.currentPage == 0 {
-                    state.$photos.withLock { $0 = IdentifiedArray(uniqueElements: newItems) }
-                } else {
-                    state.$photos.withLock { $0.append(contentsOf: newItems) }
-                }
-                
-                state.currentPage += 1
+                state.photos = IdentifiedArray(uniqueElements: newItems)
                 return .none
                 
             case .photoListResponse(.failure):
@@ -209,7 +179,7 @@ struct ArchiveAllPhotosFeature {
                 return .send(.delegate(.showToast(NekiToastItem("사진을 불러오지 못했어요", style: .error))))
                 
             case .loadMorePhotos:
-                return .send(.fetchPhotos(isRefresh: false))
+                return .send(.fetchPhotos)
                 
             case let .imageTapped(item):
                 if state.isSelectionMode {

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFavoriteAlbumFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFavoriteAlbumFeature.swift
@@ -12,30 +12,23 @@ import SwiftUI
 struct ArchiveFavoriteAlbumFeature {
     @ObservableState
     struct State {
-        @Shared var photos: IdentifiedArrayOf<ArchiveImageItem>
+        var photos: IdentifiedArrayOf<ArchiveImageItem> = []
         let album: AlbumItem
         
         var selectedIDs: Set<Int> = []
         var isSelectionMode: Bool = false
         
-        var currentPage: Int = 0
-        var hasNext: Bool = true
         var isFetchingPhotos: Bool = false
         
         var hasSelectedItems: Bool { !selectedIDs.isEmpty }
-        
-        var filteredItems: IdentifiedArrayOf<ArchiveImageItem> {
-            let items = photos.filter { $0.isFavorite == true }
-            return IdentifiedArray(uniqueElements: items)
-        }
     }
     
     enum Action: BindableAction {
         case binding(BindingAction<State>)
         
         case onAppear
-        case fetchFavoritePhotos(isRefresh: Bool)
-        case favoritePhotoListResponse(Result<(photos: [PhotoEntity], hasNext: Bool), Error>)
+        case fetchFavoritePhotos
+        case favoritePhotoListResponse(Result<[PhotoEntity], Error>)
         case loadMorePhotos
         
         case onTapBackButton
@@ -70,36 +63,26 @@ struct ArchiveFavoriteAlbumFeature {
                 return .run { _ in await dismiss() }
                 
             case .onAppear:
-                return .send(.fetchFavoritePhotos(isRefresh: true))
+                return .send(.fetchFavoritePhotos)
                 
-            case let .fetchFavoritePhotos(isRefresh):
-                if isRefresh {
-                    state.currentPage = 0
-                    state.hasNext = true
-                }
+            case .fetchFavoritePhotos:
                 
-                guard state.hasNext, !state.isFetchingPhotos else { return .none }
                 state.isFetchingPhotos = true
                 
-                return .run { [page = state.currentPage] send in
+                return .run { send in
                     await send(.favoritePhotoListResponse(
                         Result {
-                            try await archiveClient.fetchFavoritePhotoList(
-                                page: page,
-                                size: 20,
-                                sortOrder: "DESC"
-                            )
+                            try await archiveClient.fetchFavoritePhotoList(20, "DESC")
                         }
                     ))
                 }
                 
             case let .favoritePhotoListResponse(.success(result)):
                 state.isFetchingPhotos = false
-                state.hasNext = result.hasNext
                 
                 let currentAlbumId = state.album.id
                 
-                let newItems = result.photos.map { entity in
+                let newItems = result.map { entity in
                     ArchiveImageItem(
                         id: entity.photoID,
                         imageURLString: entity.imageURL,
@@ -109,13 +92,7 @@ struct ArchiveFavoriteAlbumFeature {
                     )
                 }
                 
-                state.$photos.withLock { sharedPhotos in
-                    for item in newItems {
-                        sharedPhotos.updateOrAppend(item)
-                    }
-                }
-                
-                state.currentPage += 1
+                state.photos = IdentifiedArray(uniqueElements: newItems)
                 return .none
                 
             case .favoritePhotoListResponse(.failure):
@@ -123,7 +100,7 @@ struct ArchiveFavoriteAlbumFeature {
                 return .send(.delegate(.showToast(NekiToastItem("사진을 불러오지 못했어요", style: .error))))
                 
             case .loadMorePhotos:
-                return .send(.fetchFavoritePhotos(isRefresh: false))
+                return .send(.fetchFavoritePhotos)
                 
             case .onTapSelectButton:
                 state.isSelectionMode = true
@@ -154,16 +131,16 @@ struct ArchiveFavoriteAlbumFeature {
                 return .send(.deletePhotos)
                 
             case .deletePhotos:
-                return .run { [ids = state.selectedIDs] send in
+                let idsToDelete = Array(state.selectedIDs)
+                return .run { send in
                     await send(.deletePhotosResponse(Result {
-                        try await archiveClient.deletePhotoList(photoIds: Array(ids))
+                        try await archiveClient.deletePhotoList(idsToDelete)
                     }))
                 }
                 
             case .deletePhotosResponse(.success):
-                state.$photos.withLock { photos in
-                    photos.removeAll { state.selectedIDs.contains($0.id) }
-                }
+                let idsToRemove = state.selectedIDs
+                state.photos.removeAll { idsToRemove.contains($0.id) }
                 
                 state.isSelectionMode = false
                 state.selectedIDs.removeAll()

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFavoriteAlbumFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFavoriteAlbumFeature.swift
@@ -66,7 +66,7 @@ struct ArchiveFavoriteAlbumFeature {
                 return .send(.fetchFavoritePhotos)
                 
             case .fetchFavoritePhotos:
-                
+                guard !state.isFetchingPhotos else { return .none }
                 state.isFetchingPhotos = true
                 
                 return .run { send in

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFeature.swift
@@ -8,22 +8,19 @@
 import SwiftUI
 import ComposableArchitecture
 import os
-//import Core
 
 @Reducer
 struct ArchiveFeature {
     
     @ObservableState
     struct State {
-        @Shared(.inMemory("archive-photos")) var photos: IdentifiedArrayOf<ArchiveImageItem> = []
-        @Shared(.inMemory("archive-albums")) var albums: IdentifiedArrayOf<AlbumItem> = []
+        var photos: IdentifiedArrayOf<ArchiveImageItem> = []
+        var albums: IdentifiedArrayOf<AlbumItem> = []
         
         @Shared(.appStorage("showTooltip")) var showTooltip: Bool = true
-        
         @Presents var selectUploadAlbum: SelectUploadAlbumFeature.State?
         
         var newAlbumTitle: String = ""
-        
         var albumTitleErrorMessage: String? = nil
         
         var isConfirmButtonEnabled: Bool {
@@ -31,16 +28,10 @@ struct ArchiveFeature {
         }
         
         var showDropDownMenu: Bool = false
+        var imagePicker = ImagePickerFeature.State(maxCount: 10, mediaType: .photoBooth)
+        var isLoading: Bool = false
         
-        var imagePicker = ImagePickerFeature.State(
-            maxCount: 10,
-            mediaType: .photoBooth // 테스트를 위한 temp, .photoBooth로 변경 예정
-        )
-        var isLoading: Bool = false // 업로드 시 로딩
-        
-        var currentPage: Int = 0
-        var hasNext: Bool = true
-        var isFetchingPhotos: Bool = false // 사진 fetch시 로딩
+        var isFetchingPhotos: Bool = false
     }
     
     enum Action: BindableAction {
@@ -66,18 +57,20 @@ struct ArchiveFeature {
         // QR Scanner Action
         case onTapQRScan
         
-        // Fetch Album(Folder) Action
+        // Fetch Actions
         case fetchAlbums
-        case favoriteAlbumResponse(Result<AlbumItem, Error>)      // 즐겨찾기
-        case normalAlbumsResponse(Result<[AlbumItem], Error>)
+        case fetchPhotos
+        
+        // Responses
+        case albumsResponse(Result<[AlbumItem], Error>)
+        case favoriteAlbumResponse(Result<AlbumItem, Error>)
+        case photoListResponse(Result<[PhotoEntity], Error>)
         
         // Image Upload Action
         case imagePicker(ImagePickerFeature.Action)
         case selectUploadAlbum(PresentationAction<SelectUploadAlbumFeature.Action>)
         
-        // Fetch Photo Action
-        case fetchPhotos(isRefresh: Bool)
-        case photoListResponse(Result<(photos: [PhotoEntity], hasNext: Bool), Error>)
+        // Pagination
         case loadMorePhotos
         
         // Navigation Action
@@ -107,23 +100,19 @@ struct ArchiveFeature {
         }
         
         Reduce { (state: inout State, action: Action) -> Effect<Action> in
-            /// 화면전환과 관련된 액션은 default를 이용해 무시하고 나머지 case만 사용
             switch action {
                 
             case .clearData:
-                state.$photos.withLock { $0.removeAll() }
-                state.$albums.withLock { $0.removeAll() }
+                state.photos.removeAll()
+                state.albums.removeAll()
                 return .none
                 
                 // MARK: - View Life Cycle Action
                 
             case .onAppear:
                 return .merge(
-                    /// TODO: - 사진상세에서 즐겨찾기 호출 시 앨범 갱신 로직을 델리게이트 해야하지만, 현재 시간이 없으므로
-                    /// 임시로 onappear 마다 갱신하도록 수정
-//                    state.albums.isEmpty ? .send(.fetchAlbums) : .none,
                     .send(.fetchAlbums),
-                    state.photos.isEmpty ? .send(.fetchPhotos(isRefresh: true)) : .none
+                    .send(.fetchPhotos)
                 )
                 
                 // MARK: - User Action
@@ -136,7 +125,6 @@ struct ArchiveFeature {
                 state.showDropDownMenu = false
                 return .none
                 
-                
                 // MARK: - Add Folder Action
                 
             case .onTapCancelAddAlbum:
@@ -147,37 +135,122 @@ struct ArchiveFeature {
                 
             case .onTapConfirmAddAlbum:
                 guard state.isConfirmButtonEnabled else { return .none }
-                
                 let title = state.newAlbumTitle.trimmingCharacters(in: .whitespaces)
                 state.newAlbumTitle = ""
                 state.albumTitleErrorMessage = nil
                 
                 return .run { send in
                     await send(.addFolderResponse(Result {
-                        try await archiveClient.addFolder(name: title)
+                        try await archiveClient.addFolder(title)
                     }))
                 }
                 
             case .addFolderResponse(.success):
-                let toastItem = NekiToastItem("새로운 앨범을 추가했어요", style: .success)
-                
                 return .run { send in
-                    await send(.delegate(.showToast(toastItem)))
+                    await send(.delegate(.showToast(NekiToastItem("새로운 앨범을 추가했어요", style: .success))))
                     await send(.fetchAlbums)
                 }
                 
             case .addFolderResponse(.failure):
-                let toastItem = NekiToastItem("앨범을 만들지 못했어요", style: .error)
-                return .send(.delegate(.showToast(toastItem)))
-                
+                return .send(.delegate(.showToast(NekiToastItem("앨범을 만들지 못했어요", style: .error))))
                 
                 // MARK: - QR Scanner Action
                 
             case .onTapQRScan:
                 return .send(.delegate(.requestQRScan))
                 
+                // MARK: - Fetch Logic
                 
-                // MARK: - Image Upload Action
+            case .fetchAlbums:
+                return .merge(
+                    .run { send in
+                        do {
+                            let entity = try await archiveClient.getFavoriteAlbumInfo()
+                            let favoriteAlbum = AlbumItem(
+                                id: 0,
+                                title: "즐겨찾기",
+                                count: entity.totalCount,
+                                coverImageURL: URL(string: entity.latestImageURL),
+                                isFavorite: true
+                            )
+                            await send(.favoriteAlbumResponse(.success(favoriteAlbum)))
+                        } catch {
+                            await send(.favoriteAlbumResponse(.failure(error)))
+                        }
+                    },
+                    .run { send in
+                        await send(.albumsResponse(Result {
+                            let entities = try await archiveClient.getAlbumList()
+                            return entities.map {
+                                AlbumItem(
+                                    id: $0.id,
+                                    title: $0.name,
+                                    count: $0.photoCount,
+                                    coverImageURL: URL(string: $0.coverImageURLString),
+                                    isFavorite: false
+                                )
+                            }
+                        }))
+                    }
+                )
+                
+            case let .favoriteAlbumResponse(.success(album)):
+                state.albums.removeAll(where: { $0.isFavorite })
+                state.albums.insert(album, at: 0)
+                return .none
+                
+            case .favoriteAlbumResponse(.failure):
+                return .send(.delegate(.showToast(NekiToastItem("즐겨찾기 앨범을 불러오지 못했어요", style: .error))))
+                
+            case let .albumsResponse(.success(fetchedAlbums)):
+                let favorite = state.albums.first(where: { $0.isFavorite })
+                var newAlbums: [AlbumItem] = []
+                if let fav = favorite { newAlbums.append(fav) }
+                newAlbums.append(contentsOf: fetchedAlbums)
+                
+                state.albums = IdentifiedArray(uniqueElements: newAlbums)
+                return .none
+                
+            case .albumsResponse(.failure):
+                return .send(.delegate(.showToast(NekiToastItem("앨범을 불러오지 못했어요", style: .error))))
+                
+                
+                // MARK: - Fetch Photos
+                
+            case .fetchPhotos:
+                guard !state.isFetchingPhotos else { return .none }
+                state.isFetchingPhotos = true
+                
+                return .run { send in
+                    await send(.photoListResponse(Result {
+                        let photos = try await archiveClient.fetchPhotoList(nil, nil, nil)
+                        return photos
+                    }))
+                }
+                
+            case let .photoListResponse(.success(entities)):
+                state.isFetchingPhotos = false
+                
+                let items = entities.map { entity in
+                    ArchiveImageItem(
+                        id: entity.photoID,
+                        imageURLString: entity.imageURL,
+                        isFavorite: entity.isfavorite,
+                        date: entity.createdAt.toISO8601Date()
+                    )
+                }
+                
+                state.photos = IdentifiedArray(uniqueElements: items)
+                return .none
+                
+            case .photoListResponse(.failure):
+                state.isFetchingPhotos = false
+                return .send(.delegate(.showToast(NekiToastItem("사진을 불러오지 못했어요", style: .error))))
+                
+            case .loadMorePhotos:
+                return .send(.fetchPhotos)
+                
+                // MARK: - Image Upload
                 
             case .imagePicker(.uploadStarted):
                 state.isLoading = true
@@ -189,205 +262,60 @@ struct ArchiveFeature {
                 
             case let .processUploadImages(imageIDs):
                 state.isLoading = false
-                guard imageIDs.isEmpty == false else { return .none }
+                guard !imageIDs.isEmpty else { return .none }
                 state.selectUploadAlbum = SelectUploadAlbumFeature.State(uploadedImageIds: imageIDs, albums: state.albums)
                 return .none
                 
             case let .selectUploadAlbum(.presented(.delegate(delegateAction))):
                 switch delegateAction {
                 case let .uploadDidSuccess(albumId):
-                    state.selectUploadAlbum = nil // 팝업 닫기
-                    let toast = NekiToastItem("이미지를 추가했어요", style: .success)
+                    state.selectUploadAlbum = nil
                     
-                    // 앨범 선택했다면 해당 앨범으로 이동 요청
-                    if let albumId = albumId,
-                       let album = state.albums.first(where: { $0.id == albumId }) {
+                    if let albumId = albumId, let album = state.albums.first(where: { $0.id == albumId }) {
                         return .run { send in
-                            await send(.delegate(.showToast(toast)))
-                            await send(.fetchPhotos(isRefresh: true))
+                            await send(.delegate(.showToast(NekiToastItem("이미지를 추가했어요", style: .success))))
+                            await send(.fetchPhotos)
                             await send(.fetchAlbums)
-                            
-                            /// fullScreenCover가 내려가고 전환해야 사진이 잘 불러와짐
-                            /// fullScreenCover가 내려가는 0.35초보다 빨리 전환 시 사진이 fetch가 안 돼서 빈 화면만 보임
                             try? await Task.sleep(for: .milliseconds(400))
-                            
                             await send(.afterUploadNavigateToAlbumDetail(album))
                         }
                     }
                     
                     return .run { send in
-                        await send(.delegate(.showToast(toast)))
+                        await send(.delegate(.showToast(NekiToastItem("이미지를 추가했어요", style: .success))))
+                        await send(.fetchPhotos)
                         await send(.fetchAlbums)
-                        await send(.fetchPhotos(isRefresh: true))
                     }
                     
                 case .uploadDidFail:
-                    state.selectUploadAlbum = nil // 팝업 닫기
-                    let toast = NekiToastItem("업로드에 실패했어요", style: .error)
-                    return .send(.delegate(.showToast(toast)))
-                    
+                    state.selectUploadAlbum = nil
+                    return .send(.delegate(.showToast(NekiToastItem("업로드에 실패했어요", style: .error))))
                 }
                 
             case .imagePicker(.uploadFailed):
                 state.isLoading = false
-                let toast = NekiToastItem("업로드에 실패했어요", style: .error)
-                return .send(.delegate(.showToast(toast)))
+                return .send(.delegate(.showToast(NekiToastItem("업로드에 실패했어요", style: .error))))
                 
-                
-                // MARK: - Fetch Album Action
-                
-            case .fetchAlbums:
-                return .merge(
-                    .run { send in
-                        do {
-                            let entity = try await archiveClient.getFavoriteAlbumInfo()
-                            
-                            let favoriteAlbum = AlbumItem(
-                                id: 0,
-                                title: "즐겨찾기",
-                                count: entity.totalCount,
-                                // TODO: - 없을 시 브랜딩 이미지로 변경
-                                coverImageURL: URL(string: entity.latestImageURL.isEmpty ? "" : entity.latestImageURL),
-                                isFavorite: true
-                            )
-                            
-                            await send(.favoriteAlbumResponse(.success(favoriteAlbum)))
-                            
-                        } catch {
-                            await send(.favoriteAlbumResponse(.failure(error)))
-                        }
-                    },
-                    .run { send in
-                        do {
-                            let entities = try await archiveClient.getAlbumList()
-                            
-                            let folders: [AlbumItem] = entities.map {
-                                AlbumItem(
-                                    id: $0.id,
-                                    title: $0.name,
-                                    count: $0.photoCount,
-                                    coverImageURL: URL(string: $0.coverImageURLString), // TODO: - 없으면 브랜딩 이미지
-                                    isFavorite: false
-                                )
-                            }
-                            
-                            await send(.normalAlbumsResponse(.success(folders)))
-                            
-                        } catch {
-                            await send(.normalAlbumsResponse(.failure(error)))
-                        }
-                    }
-                )
-                
-            case let .favoriteAlbumResponse(.success(result)):
-                state.$albums.withLock { existing in
-                    existing.removeAll(where: { $0.isFavorite })
-                    existing.insert(result, at: 0)
-                }
-                return .none
-                
-            case .favoriteAlbumResponse(.failure):
-                let toast = NekiToastItem("즐겨찾기 앨범을 불러오지 못했어요", style: .error)
-                return .send(.delegate(.showToast(toast)))
-                
-            case let .normalAlbumsResponse(.success(result)):
-                state.$albums.withLock { existing in
-                    var favoriteAlbum: AlbumItem?
-                    if let first = existing.first, first.isFavorite {
-                        favoriteAlbum = first
-                    }
-                    
-                    var newAlbums: [AlbumItem] = []
-                    if let fav = favoriteAlbum {
-                        newAlbums.append(fav)
-                    }
-                    newAlbums.append(contentsOf: result)
-                    
-                    existing = IdentifiedArray(uniqueElements: newAlbums)
-                }
-                return .none
-                
-                
-            case .normalAlbumsResponse(.failure):
-                let toast = NekiToastItem("앨범을 불러오지 못했어요", style: .error)
-                return .send(.delegate(.showToast(toast)))
-                
-                
-                // MARK: - Fetch Photo Action
-                
-            case let .fetchPhotos(isRefresh):
-                if isRefresh {
-                    state.currentPage = 0
-                    state.hasNext = true
+            case let .addPhotoFromQRScanner(imageID):
+                return .run { send in
+                    try await archiveClient.registerPhotos(nil, [(imageID, nil)])
+                    await send(.delegate(.showToast(NekiToastItem("이미지를 추가했어요", style: .success))))
+                    await send(.fetchPhotos)
+                } catch: { error, send in
+                    Logger.presentation.error("사진 등록 실패: \(error)")
+                    await send(.delegate(.showToast(NekiToastItem("사진 등록에 실패했어요", style: .error))))
                 }
                 
-                guard state.hasNext,
-                      !state.isFetchingPhotos else { return .none }
-                
-                state.isFetchingPhotos = true
-                
-                return .run { [page = state.currentPage] send in
-                    await send(.photoListResponse(
-                        Result {
-                            try await archiveClient.fetchPhotoList(folderId: nil, page: page, size: 20, sortOrder: nil)
-                        }
-                    ))
-                }
-                
-            case let .photoListResponse(.success(result)):
-                state.isFetchingPhotos = false
-                state.hasNext = result.hasNext
-                
-                let newItems = result.photos.map { entity in
-                    ArchiveImageItem(
-                        id: entity.photoID,
-                        imageURLString: entity.imageURL,
-                        isFavorite: entity.isfavorite,
-                        date: entity.createdAt.toISO8601Date()
-                    )
-                }
-                
-                if state.currentPage == 0 {
-                    state.$photos.withLock { $0 = IdentifiedArray(uniqueElements: newItems) }
-                } else {
-                    state.$photos.withLock { $0.append(contentsOf: newItems) }
-                }
-                
-                state.currentPage += 1
-                return .none
-                
-            case .photoListResponse(.failure):
-                state.isFetchingPhotos = false
-                let toast = NekiToastItem("사진을 불러오지 못했어요", style: .error)
-                return .send(.delegate(.showToast(toast)))
-                
-            case .loadMorePhotos:
-                return .send(.fetchPhotos(isRefresh: false))
-                
-                
-                // MARK: - Binding Action
+                // MARK: - Binding
                 
             case .binding(\.newAlbumTitle):
                 let inputTitle = state.newAlbumTitle.trimmingCharacters(in: .whitespaces)
-                
                 if state.albums.contains(where: { $0.title == inputTitle }) {
                     state.albumTitleErrorMessage = "이미 사용 중인 앨범명이에요."
                 } else {
                     state.albumTitleErrorMessage = nil
                 }
                 return .none
-                
-            case let .addPhotoFromQRScanner(imageID):
-                return .run { send in
-                    try await archiveClient.registerPhotos(folderId: nil, uploads: [(mediaID: imageID, memo: nil)])
-                    let toast = NekiToastItem("이미지를 추가했어요", style: .success)
-                    await send(.delegate(.showToast(toast)))
-                    await send(.fetchPhotos(isRefresh: true))
-                } catch: { error, send in
-                    Logger.presentation.error("사진 등록 실패: \(error)")
-                    let toast = NekiToastItem("사진 등록에 실패했어요", style: .error)
-                    await send(.delegate(.showToast(toast)))
-                }
                 
             default:
                 return .none
@@ -398,4 +326,3 @@ struct ArchiveFeature {
         }
     }
 }
-

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFeature.swift
@@ -135,7 +135,7 @@ struct ArchiveFeature {
                 
             case .onTapConfirmAddAlbum:
                 guard state.isConfirmButtonEnabled else { return .none }
-                let title = state.newAlbumTitle.trimmingCharacters(in: .whitespaces)
+                let title = state.newAlbumTitle.trimmingCharacters(in: .whitespacesAndNewlines)
                 state.newAlbumTitle = ""
                 state.albumTitleErrorMessage = nil
                 
@@ -309,7 +309,7 @@ struct ArchiveFeature {
                 // MARK: - Binding
                 
             case .binding(\.newAlbumTitle):
-                let inputTitle = state.newAlbumTitle.trimmingCharacters(in: .whitespaces)
+                let inputTitle = state.newAlbumTitle.trimmingCharacters(in: .whitespacesAndNewlines)
                 if state.albums.contains(where: { $0.title == inputTitle }) {
                     state.albumTitleErrorMessage = "이미 사용 중인 앨범명이에요."
                 } else {

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchivePhotoDetailFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchivePhotoDetailFeature.swift
@@ -12,19 +12,10 @@ import ComposableArchitecture
 struct ArchivePhotoDetailFeature {
     @ObservableState
     struct State {
-        @Shared var photos: IdentifiedArrayOf<ArchiveImageItem>
+        var photos: IdentifiedArrayOf<ArchiveImageItem>
         
         var currentItemID: Int
         let folderId: Int?
-        
-        var slidingPhotos: IdentifiedArrayOf<ArchiveImageItem> {
-            if let folderId = folderId {
-                let filteredItems = photos.filter { $0.folderId == folderId }
-                return IdentifiedArray(uniqueElements: filteredItems)
-            } else {
-                return photos
-            }
-        }
         
         var currentItem: ArchiveImageItem? {
             photos[id: currentItemID]
@@ -76,7 +67,7 @@ struct ArchivePhotoDetailFeature {
                 guard let item = state.currentItem else { return .none }
                 let newStatus = !item.isFavorite
                 
-                state.$photos.withLock { $0[id: item.id]?.isFavorite = newStatus }
+                state.photos[id: item.id]?.isFavorite = newStatus
                 
                 return .run { [id = item.id, isFavorite = newStatus] send in
                     do {
@@ -91,8 +82,7 @@ struct ArchivePhotoDetailFeature {
                 return .none
                 
             case let .toggleFavoriteResponse(photoID, .failure):
-                state.$photos.withLock { $0[id: photoID]?.isFavorite.toggle() }
-                
+                state.photos[id: photoID]?.isFavorite.toggle()
                 return .send(.delegate(.showToast(NekiToastItem("즐겨찾기 변경에 실패했어요", style: .error))))
                 
             case .onTapDownload:
@@ -130,20 +120,20 @@ struct ArchivePhotoDetailFeature {
             case .deletePhotoResponse(.success):
                 guard let deletedID = state.currentItem?.id else { return .none }
                 
-                let deletedIndex = state.slidingPhotos.index(id: deletedID)
+                let deletedIndex = state.photos.index(id: deletedID)
                 
-                state.$photos.withLock { _ = $0.remove(id: deletedID) }
+                state.photos.remove(id: deletedID)
                 
-                if state.slidingPhotos.isEmpty {
+                if state.photos.isEmpty {
                     return .run { send in
                         await send(.delegate(.showToast(NekiToastItem("사진을 삭제했어요", style: .success))))
                         await dismiss()
                     }
                 }
                 
-                if let index = deletedIndex, index < state.slidingPhotos.count {
-                    state.currentItemID = state.slidingPhotos[index].id
-                } else if let last = state.slidingPhotos.last {
+                if let index = deletedIndex, index < state.photos.count {
+                    state.currentItemID = state.photos[index].id
+                } else if let last = state.photos.last {
                     state.currentItemID = last.id
                 }
                 

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveAlbumDetailView.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveAlbumDetailView.swift
@@ -36,6 +36,7 @@ struct ArchiveAlbumDetailView: View {
                 }
             }
         }
+        .task { await store.send(.onAppear).finish() }
         .nekiToolbar(
             left: { NekiToolBar.back { store.send(.onTapBackButton) } },
             center: { NekiToolBar.textCenter(store.album.title) },
@@ -47,7 +48,6 @@ struct ArchiveAlbumDetailView: View {
                 }
             }
         )
-        
         .sheet(isPresented: $deleteAlbumSheetPresented) {
             ArchiveDeleteSheet<ArchivePhotoDeleteOption>(
                 initialOption: .fromAlbumOnly,

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveAlbumDetailView.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveAlbumDetailView.swift
@@ -65,9 +65,6 @@ struct ArchiveAlbumDetailView: View {
             .presentationDetents([.height(280)])
             .presentationCornerRadius(20)
         }
-        .task {
-            await store.send(.onAppear).finish()
-        }
         .background(.white)
         
     }

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveAllAlbumsView.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveAllAlbumsView.swift
@@ -59,6 +59,7 @@ struct ArchiveAllAlbumsView: View {
             }
             
         }
+        .task { await store.send(.onAppear).finish() }
         .sheet(isPresented: $addAlbumSheetPresented) {
             ArchiveAddAlbumSheet(
                 text: $store.newAlbumTitle,

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveFavoriteAlbumView.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveFavoriteAlbumView.swift
@@ -15,7 +15,7 @@ struct ArchiveFavoriteAlbumView: View {
     
     var body: some View {
         ZStack(alignment: .top) {
-            if store.filteredItems.count == 0 {
+            if store.photos.count == 0 {
                 ArchiveEmptyView(description: "아직 등록된 사진이 없어요\n새로운 사진을 등록하고 앨범에 추가해보세요!")
                     .padding(.bottom, 54)
             } else {
@@ -38,7 +38,7 @@ struct ArchiveFavoriteAlbumView: View {
             left: { NekiToolBar.back(action: { store.send(.onTapBackButton) }) },
             center: { NekiToolBar.textCenter(store.album.title) },
             right: {
-                if store.filteredItems.isEmpty == false {
+                if store.photos.isEmpty == false {
                     store.isSelectionMode ? NekiToolBar.textRight("취소", action: { store.send(.onTapCancelSelectButton) }) : NekiToolBar.textRight("선택", action: { store.send(.onTapSelectButton) })
                 }
             }
@@ -68,7 +68,7 @@ private extension ArchiveFavoriteAlbumView {
     var masonryView: some View {
         ScrollView {
             MasonryGridView(
-                items: Array(store.filteredItems),
+                items: Array(store.photos),
                 columns: 2
             ) { item in
                 ArchiveImageCard(
@@ -80,7 +80,7 @@ private extension ArchiveFavoriteAlbumView {
                     store.send(.imageTapped(item))
                 }
                 .onAppear {
-                    if item == store.filteredItems.last {
+                    if item == store.photos.last {
                         store.send(.loadMorePhotos)
                     }
                 }

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchivePhotoDetailView.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchivePhotoDetailView.swift
@@ -17,7 +17,7 @@ struct ArchivePhotoDetailView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             TabView(selection: $store.currentItemID) {
-                ForEach(store.slidingPhotos) { item in
+                ForEach(store.photos) { item in
                     KFImage(item.imageURL)
                         .resizable()
                         .placeholder {

--- a/Neki-iOS/Shared/DesignSystem/Resources/Assets.xcassets/Common/icon_checkmark.imageset/Contents.json
+++ b/Neki-iOS/Shared/DesignSystem/Resources/Assets.xcassets/Common/icon_checkmark.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "checkmark.svg",
+      "filename" : "Checkmark.svg",
       "idiom" : "universal"
     }
   ],


### PR DESCRIPTION
## 🌴 작업한 브랜치
- `refactor#121-archive-client-repository`


## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->

기존의 @Shared를 이용한 상태 공유 방식에서 발생하던 동기화 문제와 복잡성을 해결하기 위해, Repository Pattern을 도입하여 데이터 관리 책임을 Repository 계층으로 이관했습니다.
이제 뷰(Feature)는 UI 상태만 관리하며, 실제 데이터의 캐싱, 페이지네이션, 정렬, 동기화는 DefaultArchiveRepository가 전담합니다.

[Repository 아키텍처 개편 (DefaultArchiveRepository)]

**폴더별 캐싱 구조 도입**
처음에는 단일 리스트 캐싱 구조로 구현하려고 시도했습니다. 
하지만 구현 결과, 폴더별 아이템을 정제해서 보여주기에 여러 난관이 있었고, [Int?: [PhotoEntity]] 딕셔너리 구조로 변경하여, 앨범(폴더)별로 사진 데이터를 격리하고 페이지네이션 상태를 독립적으로 관리하도록 수정했습니다.

**Dirty Flag** 
데이터 변경(추가/삭제/좋아요) 시 관련 캐시를 즉시 업데이트하거나 Dirty 상태로 마킹하여, 불필요한 네트워크 호출을 줄이고 데이터 무결성을 보장했습니다.

**중복 방지 및 정렬 보장**
API 응답 병합 시 Set을 이용해 중복 데이터를 필터링(Crash 방지)하고, sortOrder 변경을 감지하여 캐시를 초기화하고 재요청하도록 로직을 설계했습니다.


[Presentation - Feature Reducer]

**Shared State 제거**
ArchiveFeature, AllPhotos, AlbumDetail, Favorite 등 모든 아카이브 관련 Feature에서 @Shared를 제거하고 로컬 State로 변경했습니다. 

**로직 위임**
페이지네이션(currentPage, hasNext) 로직을 Repository 내부로 숨기고, Feature는 단순히 fetch 액션만 호출하도록 단순화했습니다.



## ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

- 폴더별 캐싱 구조를 도입하며 즐겨찾기나 삭제 등 해당 사진이 어떤 폴더에 속해있는지 여부를 알 수 없는 액션의 경우 모든 폴더를 순회하며 처리하게 구현했습니다. 이 경우 시간복잡도가 폴더 개수에 비례하게 높아질 것 같아 굉장히 찝찝했지만... 뭔가 뚜렷한 해결방안이 보이지 않기도 하고, 현재 우리 서비스는 전체 폴더 개수를 10개로 제한하고 있기에 과도하게 시간복잡도가 높아질 일은 없을 것이라 판단했습니다.

- Archive에 해당하는 모든 리듀서와 뷰에는 onAppear 액션을 넣어서 매번 캐시 혹은 네트워크 요청을 보내게 해뒀습니다. 확인한다고 확인해보긴 했는데 혹시 뭔가 이상하게 작동하거나 빼먹은 부분은 없는지 살짝 걱정이 됩니다! 

- 탭바에서 사진 추가할 때 뭔가 굉장히 앱이 버벅이며 더럽게 되고 있는데, 해당 이슈에서는 리팩토링과 관련된 작업만 포함하기 위해 이건 일단 흐린눈 했습니다. 

## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|
생략합니다.

## 📟 관련 이슈
- Resolved: #121 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **개선 사항**
  * 아카이브에 광범위한 인메모리 캐시 도입으로 목록 로드와 반복 요청 성능이 향상되었습니다.
  * 사진·즐겨찾기·앨범 리스트의 페이징 및 필터 흐름을 단순화해 일관된 로드 동작을 제공합니다.
  * 업로드·삭제·즐겨찾기 토글 시 캐시 동기화로 UI 반영 속도가 빨라졌습니다.
  * 상태 관리 및 내비게이션 초기화 로직을 정리해 뷰 동작이 간소화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->