### PR TITLE
[Feat] 앱 버전 정보

### DIFF
--- a/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
+++ b/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
@@ -10,6 +10,9 @@ import ComposableArchitecture
 
 @Reducer
 struct AppCoordinator {
+    enum Constants {
+        static let versionCheckInterval: TimeInterval = 60 *  60 * 24 // 1일
+    }
     
     @ObservableState
     struct State {
@@ -30,6 +33,7 @@ struct AppCoordinator {
             }
         }
         var pendingSessionStatus: UserSessionStatus?
+        var lastVersionCheckedTime: Date?
         
         init() {
             self.route = .splash
@@ -50,6 +54,8 @@ struct AppCoordinator {
         // Internal Actions
         case splashSequenceCompleted(UserSessionStatus, AppVersionClient.VersionResult)
         case userSessionStatusChanged(UserSessionStatus)
+        case scenePhaseChanged(ScenePhase)
+        case backgroundVersionCheckResult(Result<AppVersionClient.VersionResult, Error>)
         
         // Binding Actions
         case binding(BindingAction<State>)
@@ -62,6 +68,7 @@ struct AppCoordinator {
     @Dependency(\.appVersionClient) private var appVersionClient
     @Dependency(\.continuousClock) var clock
     @Dependency(\.openURL) private var openURL
+    @Dependency(\.date.now) private var now
     
     var body: some ReducerOf<Self> {
         BindingReducer()
@@ -71,6 +78,8 @@ struct AppCoordinator {
         Reduce { (state: inout State, action: Action) -> Effect<Action> in
             switch action {
             case .onAppLaunched:
+                state.lastVersionCheckedTime = now
+                
                 return .run { [currentStatus = state.userSessionStatus] send in
                     async let timer: Void = clock.sleep(for: .milliseconds(1500))
                     
@@ -97,6 +106,37 @@ struct AppCoordinator {
                     let (_, finalStatus, finalVersionResult) = try await (timer, nextStatus, versionResult)
                     
                     await send(.splashSequenceCompleted(finalStatus, finalVersionResult))
+                }
+                
+            case let .scenePhaseChanged(phase):
+                guard phase == .active else { return .none }
+                if state.versionAlert == .updateNeeded { return .none }
+                if let lastTime = state.lastVersionCheckedTime, now.timeIntervalSince(lastTime) < Constants.versionCheckInterval { return .none }
+                return .run { send in
+                    do {
+                        let result = try await appVersionClient.checkVersion()
+                        await send(.backgroundVersionCheckResult(.success(result)))
+                    } catch {
+                        await send(.backgroundVersionCheckResult(.failure(error)))
+                    }
+                }
+                
+            case let .backgroundVersionCheckResult(result):
+                guard case let .success(version) = result else { return .none }
+                state.lastVersionCheckedTime = now
+                
+                switch version.status {
+                case .mustUpdate:
+                    state.versionAlert = .updateNeeded
+                    return .none
+                    
+                case .optionalUpdate:
+                    guard state.versionAlert == nil else { return .none }
+                    state.versionAlert = .updateAvailable
+                    return .none
+                    
+                case .upToDate:
+                    return .none
                 }
                 
             case let .splashSequenceCompleted(finalStatus, finalVersionResult):

--- a/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
+++ b/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
@@ -19,8 +19,17 @@ struct AppCoordinator {
         @Shared(.appStorage("hasSeenOnboarding")) var hasSeenOnboarding: Bool = false
         
         var toastItem: NekiToastItem?
-        
         var route: Route.State
+        var versionAlert: VersionUpdateAlertType?
+        var isAlertPresented: Bool {
+            get { versionAlert != nil }
+            set {
+                guard newValue == false else { return }
+                guard versionAlert != .updateNeeded else { return }
+                versionAlert = nil
+            }
+        }
+        var pendingSessionStatus: UserSessionStatus?
         
         init() {
             self.route = .splash
@@ -35,9 +44,11 @@ struct AppCoordinator {
     enum Action: BindableAction {
         // View Actions
         case onAppLaunched
+        case didTapUpdateAlert
+        case didTapLaterAlert
         
-        case splashSequenceCompleted(UserSessionStatus)
-        
+        // Internal Actions
+        case splashSequenceCompleted(UserSessionStatus, AppVersionClient.VersionResult)
         case userSessionStatusChanged(UserSessionStatus)
         
         // Binding Actions
@@ -48,7 +59,9 @@ struct AppCoordinator {
     }
     
     @Dependency(\.authClient) private var authClient
+    @Dependency(\.appVersionClient) private var appVersionClient
     @Dependency(\.continuousClock) var clock
+    @Dependency(\.openURL) private var openURL
     
     var body: some ReducerOf<Self> {
         BindingReducer()
@@ -72,35 +85,53 @@ struct AppCoordinator {
                         }
                     }()
                     
-                    let (_, finalStatus) = try await (timer, nextStatus)
+                    async let versionResult: AppVersionClient.VersionResult = {
+                        do {
+                            return try await appVersionClient.checkVersion()
+                        } catch {
+                            // TODO: 네트워크 에러 등으로 버전 정보를 확보하지 못했을 때는 최신 상태로 간주하여 앱 진입 할 수 있도록 함, 추후 개선 필요
+                            return (.init(value: "0.0.0"), .init(value: "0.0.0"), .upToDate)
+                        }
+                    }()
                     
-                    await send(.splashSequenceCompleted(finalStatus))
+                    let (_, finalStatus, finalVersionResult) = try await (timer, nextStatus, versionResult)
+                    
+                    await send(.splashSequenceCompleted(finalStatus, finalVersionResult))
                 }
                 
-            case let .splashSequenceCompleted(finalStatus):
+            case let .splashSequenceCompleted(finalStatus, finalVersionResult):
                 state.$userSessionStatus.withLock { $0 = finalStatus }
                 
-                switch finalStatus {
-                case let .signedIn(user):
-                    state.route = .mainTab(.init(user: user))
-                    
-                case .signedOut, .expired:
-                    if state.hasSeenOnboarding {
-                        state.route = .auth(.init())
-                        
-                        if case .expired = finalStatus {
-                            state.toastItem = .init("다시 로그인 해주세요.")
-                        }
-                    } else {
-                        state.route = .onboarding(.init())
-                    }
+                guard finalVersionResult.status != .mustUpdate else {
+                    state.versionAlert = .updateNeeded
+                    return .none
                 }
-                return .none
+                
+                guard finalVersionResult.status != .optionalUpdate else {
+                    state.versionAlert = .updateAvailable
+                    state.pendingSessionStatus = finalStatus
+                    return .none
+                }
+                
+                return navigateToNextScreen(state: &state, sessionStatus: finalStatus)
+                
+            case .didTapUpdateAlert:
+                // TODO: 앱스토어 URL 필요
+                return .run { _ in
+                    let appStoreURL = URL(string: "https://itunes.apple.com/kr/app/neki")!
+                    await openURL(appStoreURL)
+                }
+                
+            case .didTapLaterAlert:
+                state.versionAlert = nil
+                guard let pendingSessionStatus = state.pendingSessionStatus else { return .none }
+                state.pendingSessionStatus = nil
+                return navigateToNextScreen(state: &state, sessionStatus: pendingSessionStatus)
                 
             case let .userSessionStatusChanged(newStatus):
                 if state.userSessionStatus != newStatus { state.$userSessionStatus.withLock { $0 = newStatus } }
                 
-                if case .splash = state.route { return .none }
+                if case .splash = state.route, state.versionAlert != nil { return .none }
                 
                 switch newStatus {
                 case let .signedIn(user):
@@ -150,9 +181,32 @@ struct AppCoordinator {
                 state.$userSessionStatus.withLock { $0 = .signedIn(user) }
                 return .none
                 
+            case .binding(\.isAlertPresented):
+                guard state.isAlertPresented == false else { return .none }
+                guard let pendingSessionStatus = state.pendingSessionStatus else { return .none }
+                state.pendingSessionStatus = nil
+                return navigateToNextScreen(state: &state, sessionStatus: pendingSessionStatus)
+                
             default:
                 return .none
             }
+        }
+    }
+    
+    private func navigateToNextScreen(state: inout State, sessionStatus: UserSessionStatus) -> Effect<Action> {
+        switch sessionStatus {
+        case .signedIn(let user):
+            state.route = .mainTab(.init(user: user))
+            return .none
+            
+        case .signedOut, .expired:
+            if state.hasSeenOnboarding {
+                state.route = .auth(.init())
+                if case .expired = sessionStatus { state.toastItem = .init("다시 로그인 해주세요.") }
+            } else {
+                state.route = .onboarding(.init())
+            }
+            return .none
         }
     }
 }
@@ -194,5 +248,50 @@ private extension AppCoordinator.State {
         UserDefaults.standard.removeObject(forKey: "hasSeenOnboarding") // 최초 온보딩
         UserDefaults.standard.removeObject(forKey: "showTooltip")       // 아카이빙 홈 툴팁
         UserDefaults.standard.removeObject(forKey: "isTutorialPresented")   // 랜덤포즈 튜토리얼
+    }
+}
+
+
+// MARK: - Nested Types
+
+extension AppCoordinator {
+    enum VersionUpdateAlertType {
+        case updateNeeded // 필수 업데이트 안내
+        case updateAvailable // 새로운 버전 안내
+        
+        var style: NekiAlertStyle {
+            switch self {
+            case .updateNeeded: .plain
+            case .updateAvailable: .cancelable
+            }
+        }
+        
+        var title: String {
+            switch self {
+            case .updateNeeded: return "필수 업데이트 안내"
+            case .updateAvailable: return "새로운 버전 업데이트"
+            }
+        }
+        
+        var subtitle: String {
+            switch self {
+            case .updateNeeded: return "더 안정적인 서비스 이용을 위해\n필수 업데이트가 필요해요"
+            case .updateAvailable: return "새로운 기능이 추가되었어요!\n더 나은 이용을 위해 업데이트 해보세요"
+            }
+        }
+        
+        var confirmText: String {
+            switch self {
+            case .updateNeeded: return "업데이트 하러 가기"
+            case .updateAvailable: return "업데이트"
+            }
+        }
+        
+        var cancelText: String? {
+            switch self {
+            case .updateNeeded: return nil
+            case .updateAvailable: return "다음에 할래요"
+            }
+        }
     }
 }

--- a/Neki-iOS/APP/Sources/Application/AppCoordinatorView.swift
+++ b/Neki-iOS/APP/Sources/Application/AppCoordinatorView.swift
@@ -38,5 +38,16 @@ struct AppCoordinatorView: View {
             store.send(.userSessionStatusChanged(newValue))
         }
         .nekiToast(item: $store.toastItem)
+        .nekiAlert(
+            isPresented: $store.isAlertPresented,
+            style: store.versionAlert?.style ?? .cancelable,
+            title: store.versionAlert?.title ?? "",
+            subtitle: store.versionAlert?.subtitle ?? "",
+            confirmText: store.versionAlert?.confirmText ?? "",
+            cancelText: store.versionAlert?.cancelText ?? "",
+            hasIcon: true,
+            onConfirm: { store.send(.didTapUpdateAlert) },
+            onCancel: { store.send(.didTapLaterAlert) }
+        )
     }
 }

--- a/Neki-iOS/APP/Sources/Application/AppCoordinatorView.swift
+++ b/Neki-iOS/APP/Sources/Application/AppCoordinatorView.swift
@@ -44,7 +44,7 @@ struct AppCoordinatorView: View {
             title: store.versionAlert?.title ?? "",
             subtitle: store.versionAlert?.subtitle ?? "",
             confirmText: store.versionAlert?.confirmText ?? "",
-            cancelText: store.versionAlert?.cancelText ?? "",
+            cancelText: store.versionAlert?.cancelText,
             hasIcon: true,
             onConfirm: { store.send(.didTapUpdateAlert) },
             onCancel: { store.send(.didTapLaterAlert) }

--- a/Neki-iOS/Features/MyPage/Sources/Data/Sources/DTOs/FetchAppVersionDTO.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Data/Sources/DTOs/FetchAppVersionDTO.swift
@@ -1,0 +1,20 @@
+//
+//  FetchAppVersionDTO.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 2/17/26.
+//
+
+import Foundation
+
+enum FetchAppVersionDTO {
+    struct Response: Decodable {
+        let minimumVersion: String
+        let currentVersion: String
+        
+        enum CodingKeys: String, CodingKey {
+            case minimumVersion = "minVersion"
+            case currentVersion
+        }
+    }
+}

--- a/Neki-iOS/Features/MyPage/Sources/Data/Sources/DefaultAppVersionRepository.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Data/Sources/DefaultAppVersionRepository.swift
@@ -1,0 +1,53 @@
+//
+//  DefaultAppVersionRepository.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 2/17/26.
+//
+
+import Foundation
+import Dependencies
+import DependenciesMacros
+
+final actor DefaultAppVersionRepository {
+    private var minimumVersion: AppVersion?
+    private var latestVersion: AppVersion?
+    
+    @Dependency(\.networkProvider) private var networkProvider
+    
+    init() {}
+}
+
+
+// MARK: - DefaultAppVersionRepository + AppVersionRepository
+
+extension DefaultAppVersionRepository: AppVersionRepository {
+    func fetchVersionInfo() async throws -> (minimumVersion: AppVersion, latestVersion: AppVersion) {
+        if let minimumVersion, let latestVersion { return (minimumVersion, latestVersion) }
+        
+        let platform: String = "ios"
+        let endpoint = MyPageEndpoint.fetchAppVersion(platform: platform)
+        let responseDTO: BaseResponseDTO<FetchAppVersionDTO.Response> = try await networkProvider.request(endpoint: endpoint)
+        
+        guard let data = responseDTO.data else { throw NetworkError.responseDecodingError }
+        let minimumVersionEntity = AppVersion(value: data.minimumVersion)
+        let latestVersionEntity = AppVersion(value: data.currentVersion)
+        
+        self.minimumVersion = minimumVersionEntity
+        self.latestVersion = latestVersionEntity
+        
+        return (minimumVersionEntity, latestVersionEntity)
+    }
+}
+
+
+private enum AppVersionRepositoryKey: DependencyKey {
+    static var liveValue: AppVersionRepository = DefaultAppVersionRepository()
+}
+
+extension DependencyValues {
+    var appVersionRepository: AppVersionRepository {
+        get { self[AppVersionRepositoryKey.self] }
+        set { self[AppVersionRepositoryKey.self] = newValue }
+    }
+}

--- a/Neki-iOS/Features/MyPage/Sources/Data/Sources/MyPageEndpoint.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Data/Sources/MyPageEndpoint.swift
@@ -1,0 +1,31 @@
+//
+//  MyPageEndpoint.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 2/17/26.
+//
+
+import Foundation
+
+enum MyPageEndpoint {
+    case fetchAppVersion(platform: String)
+}
+
+
+// MARK: - MyPageEndpoint + Endpoint
+
+extension MyPageEndpoint: Endpoint {
+    var authorizationType: AuthorizationType { .none }
+    
+    var contentType: HTTPContentType { .json }
+    
+    var path: String {
+        switch self {
+        case let .fetchAppVersion(platform): return "versions/\(platform)"
+        }
+    }
+    
+    var method: HTTPMethodType { .get }
+    
+    var body: (any Encodable)? { nil }
+}

--- a/Neki-iOS/Features/MyPage/Sources/Domain/Sources/Clients/AppVersionClient.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Domain/Sources/Clients/AppVersionClient.swift
@@ -1,0 +1,47 @@
+//
+//  AppVersionClient.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 2/17/26.
+//
+
+import Foundation
+import Dependencies
+import DependenciesMacros
+
+@DependencyClient
+struct AppVersionClient {
+    typealias VersionResult = (current: AppVersion, latest: AppVersion, status: AppUpdateStatus)
+    
+    var checkVersion: @Sendable () async throws -> VersionResult
+    var currentVersion: @Sendable () -> AppVersion = { .init(major: .zero, minor: .zero, revision: .zero) }
+}
+
+extension AppVersionClient: DependencyKey {
+    static var liveValue: AppVersionClient = {
+        @Dependency(\.appVersionRepository) var appVersionRepository
+        
+        let fetchLocalVersion: @Sendable () -> AppVersion = {
+            let localVersionString = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+            return AppVersion(value: localVersionString)
+        }
+        
+        return AppVersionClient {
+            let (minimumVersion, latestVersion) = try await appVersionRepository.fetchVersionInfo()
+            let currentVersion = fetchLocalVersion()
+            
+            guard currentVersion >= minimumVersion else { return (currentVersion, latestVersion, .mustUpdate) }
+            guard currentVersion >= latestVersion else { return (currentVersion, latestVersion, .optionalUpdate) }
+            return (currentVersion, latestVersion, .upToDate)
+        } currentVersion: {
+            return fetchLocalVersion()
+        }
+    }()
+}
+
+extension DependencyValues {
+    var appVersionClient: AppVersionClient {
+        get { self[AppVersionClient.self] }
+        set { self[AppVersionClient.self] = newValue }
+    }
+}

--- a/Neki-iOS/Features/MyPage/Sources/Domain/Sources/Entities/AppVersion.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Domain/Sources/Entities/AppVersion.swift
@@ -1,0 +1,48 @@
+//
+//  AppVersion.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 2/17/26.
+//
+
+import Foundation
+
+struct AppVersion: Equatable, Sendable {
+    let value: String
+    
+    init(value: String) { self.value = value }
+    init(major: Int, minor: Int, revision: Int) { self.value = "\(major).\(minor).\(revision)" }
+}
+
+
+// MARK: - AppVersion + Comparable
+
+extension AppVersion: Comparable {
+    private var versionComponents: [Int] { value.split(separator: ".").compactMap { Int($0) } }
+    
+    static func < (lhs: AppVersion, rhs: AppVersion) -> Bool {
+        let lhsComponents = lhs.versionComponents
+        let rhsComponents = rhs.versionComponents
+        let maxLength = max(lhsComponents.count, rhsComponents.count)
+        
+        for i in 0..<maxLength {
+            let lhsValue = i < lhsComponents.count ? lhsComponents[i] : 0
+            let rhsValue = i < rhsComponents.count ? rhsComponents[i] : 0
+            
+            guard lhsValue != rhsValue else { continue }
+            return lhsValue < rhsValue
+        }
+        
+        return false
+    }
+}
+
+/// 업데이트가 요구되는 상태를 의미합니다.
+enum AppUpdateStatus: Equatable, Sendable {
+    /// 업데이트 필요
+    case mustUpdate
+    /// 업데이트 권장
+    case optionalUpdate
+    /// 업데이트 불필요(최신)
+    case upToDate
+}

--- a/Neki-iOS/Features/MyPage/Sources/Domain/Sources/Entities/AppVersion.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Domain/Sources/Entities/AppVersion.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct AppVersion: Equatable, Sendable {
+struct AppVersion: Sendable {
     let value: String
     
     init(value: String) { self.value = value }
@@ -15,10 +15,14 @@ struct AppVersion: Equatable, Sendable {
 }
 
 
-// MARK: - AppVersion + Comparable
+// MARK: - AppVersion + Comparable & Equatable
 
-extension AppVersion: Comparable {
+extension AppVersion: Comparable, Equatable {
     private var versionComponents: [Int] { value.split(separator: ".").compactMap { Int($0) } }
+    
+    static func == (lhs: AppVersion, rhs: AppVersion) -> Bool {
+        lhs.versionComponents == rhs.versionComponents
+    }
     
     static func < (lhs: AppVersion, rhs: AppVersion) -> Bool {
         let lhsComponents = lhs.versionComponents

--- a/Neki-iOS/Features/MyPage/Sources/Domain/Sources/Interfaces/AppVersionRepository.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Domain/Sources/Interfaces/AppVersionRepository.swift
@@ -1,0 +1,12 @@
+//
+//  AppVersionRepository.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 2/17/26.
+//
+
+import Foundation
+
+protocol AppVersionRepository: Sendable {
+    func fetchVersionInfo() async throws -> (minimumVersion: AppVersion, latestVersion: AppVersion)
+}

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/MyPageFeature.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/MyPageFeature.swift
@@ -5,7 +5,7 @@
 //  Created by SwainYun on 1/20/26.
 //
 
-import Foundation
+import UIKit
 import ComposableArchitecture
 
 @Reducer
@@ -13,16 +13,43 @@ struct MyPageFeature {
     @ObservableState
     struct State {
         var user: User
+        var appVersion: AppVersion = AppVersion(major: 0, minor: 0, revision: 0)
     }
     
     enum Action {
+        case onAppear
         case cellTapped(SectionCellItem)
         case profileTapped
     }
     
+    @Dependency(\.appVersionClient) private var appVersionClient
+    @Dependency(\.openURL) private var openURL
+    
     var body: some ReducerOf<Self> {
         Reduce { (state: inout State, action: Action) -> Effect<Action> in
             switch action {
+            case .onAppear:
+                state.appVersion = appVersionClient.currentVersion()
+                return .none
+                
+            case let .cellTapped(item):
+                switch item {
+                case .deviceAuthorization:
+                    let url = URL(string: UIApplication.openSettingsURLString)!
+                    return .run { _ in await openURL(url) }
+                case .support:
+                    let url = URL(string: "https://tally.so/r/obGpRX")!
+                    return .run { _ in await openURL(url) }
+                case .termsOfService:
+                    let url = URL(string: "https://lydian-tip-26b.notion.site/2ee0d9441db0807c8684ce3e2d4b8aca?source=copy_link")!
+                    return .run { _ in await openURL(url) }
+                case .privacyPolicy:
+                    let url = URL(string: "https://lydian-tip-26b.notion.site/2ee0d9441db0807cb850f78145db6dd3?pvs=74")!
+                    return .run { _ in await openURL(url) }
+                case .version:
+                    return .none
+                }
+                
             default:
                 return .none
             }

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/MyPageView.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/MyPageView.swift
@@ -38,6 +38,7 @@ struct MyPageView: View {
                 // NekiToolBar.icon(.iconBellFill)
             }
         )
+        .task { await store.send(.onAppear).finish() }
     }
 }
 
@@ -113,7 +114,7 @@ private extension MyPageView {
             if item.hasLink {
                 Image(.iconChevronRight)
             } else {
-                Text("v.1.3.1") // TODO: 실제 버전정보 표시하도록 해야함
+                Text("v.\(store.appVersion.value)")
                     .nekiFont(.body14Medium)
                     .foregroundStyle(.gray500)
             }


### PR DESCRIPTION
## 🌴 작업한 브랜치
- feat/#136-app-version


## ✅ 작업한 내용
1. 앱 진입 시점에 스플래시 카운트, 자동 로그인 시도와 함께 버전 정보를 병렬적으로 확인하고 업데이트 필요 여부에 따라 얼럿을 띄우도록 했습니다.
2. Todo로 남겨두었던 마이페이지 내 앱 버전 정보 표시와 문의하기, 이용약관 등 외부 페이지로 이동시키는 로직을 마저 구현했습니다.


## ❗️PR Point
네트워크 에러 등으로 앱 버전 정보를 확인하지 못했을 경우의 에러 핸들링이 필요합니다. Todo 주석으로 남겨두었습니다.
가장 신경 쓴 부분은 다음과 같습니다.
1. 앱 버전 정보를 모를 경우, "0.0.0" 기본값으로 일단 채운 뒤, 앱 플로우는 이어갈 수 있도록 함. (특정 플로우에 갇히는 상황 예방)
2. 배경 탭 등으로 버전 업데이트 얼럿을 닫게 될 경우에 플로우가 끊기지 않도록 바인딩 처리에서 방어 로직 작성


## 📸 스크린샷
아이콘 대격변 PR이 머지되지 않아 이미지 에셋 불일치로 인해 빌드가 어렵습니다. 따라서 스크린샷을 찍을 수가 없어서 생략합니다!


## 📟 관련 이슈
- Resolved: #136


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 앱 실행 및 백그라운드에서 자동으로 버전 업데이트를 확인합니다.
  * 필수 업데이트 시 앱 사용을 차단하는 안내 알림을 표시합니다.
  * 선택적 업데이트는 “나중에”로 미루는 기능을 제공합니다.
  * 내정보(MyPage)에 현재 앱 버전이 동적으로 표시됩니다.
  * 설정·고객지원·약관·개인정보 등 관련 링크를 바로 열 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->