### PR TITLE
[Feat] 인앱 라우팅용 유니버셜링크 추가

### DIFF
--- a/Neki-iOS.xcodeproj/project.pbxproj
+++ b/Neki-iOS.xcodeproj/project.pbxproj
@@ -311,7 +311,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 586LZSS32L;
 				ENABLE_PREVIEWS = YES;
@@ -362,7 +362,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 586LZSS32L;
 				ENABLE_PREVIEWS = YES;

--- a/Neki-iOS.xcodeproj/project.pbxproj
+++ b/Neki-iOS.xcodeproj/project.pbxproj
@@ -318,7 +318,9 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Neki-iOS/Info.plist";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
+				INFOPLIST_KEY_NSCameraUsageDescription = "$(CAMERA_USAGE_DESCRIPTION)";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "$(LOCATION_USAGE_DESCRIPTION)";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "$(PHOTO_LIBRARY_USAGE_DESCRIPTION)";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -367,7 +369,9 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Neki-iOS/Info.plist";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
+				INFOPLIST_KEY_NSCameraUsageDescription = "$(CAMERA_USAGE_DESCRIPTION)";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "$(LOCATION_USAGE_DESCRIPTION)";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "$(PHOTO_LIBRARY_USAGE_DESCRIPTION)";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Neki-iOS/APP/Sources/Application/Neki_iOSApp.swift
+++ b/Neki-iOS/APP/Sources/Application/Neki_iOSApp.swift
@@ -22,6 +22,11 @@ struct Neki_iOSApp: App {
     }
     
     private func handleIncomingURL(_ url: URL) {
-        guard let host = url.host(), host == "neki.suitestudy.com" else { return }
+        if url.scheme == "neki" { return }
+        
+        if url.scheme == "https" || url.scheme == "http" {
+            guard let host = url.host(), host == "neki.suitestudy.com" else { return }
+            return
+        }
     }
 }

--- a/Neki-iOS/APP/Sources/Application/Neki_iOSApp.swift
+++ b/Neki-iOS/APP/Sources/Application/Neki_iOSApp.swift
@@ -17,6 +17,11 @@ struct Neki_iOSApp: App {
     var body: some Scene {
         WindowGroup {
             AppCoordinatorView(store: store)
+                .onOpenURL { handleIncomingURL($0) }
         }
+    }
+    
+    private func handleIncomingURL(_ url: URL) {
+        guard let host = url.host(), host == "neki.suitestudy.com" else { return }
     }
 }

--- a/Neki-iOS/Info.plist
+++ b/Neki-iOS/Info.plist
@@ -14,6 +14,16 @@
 				<string>kakao${KAKAO_LOGIN_NATIVE_APP_KEY}</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.OneTen.Neki-iOS</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>neki</string>
+			</array>
+		</dict>
 	</array>
 	<key>KAKAO_LOGIN_NATIVE_APP_KEY</key>
 	<string>$(KAKAO_LOGIN_NATIVE_APP_KEY)</string>
@@ -57,11 +67,5 @@
 	</array>
 	<key>UIDesignRequiresCompatibility</key>
 	<true/>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>$(LOCATION_USAGE_DESCRIPTION)</string>
-	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>$(PHOTO_LIBRARY_USAGE_DESCRIPTION)</string>
-	<key>NSCameraUsageDescription</key>
-	<string>$(CAMERA_USAGE_DESCRIPTION)</string>
 </dict>
 </plist>

--- a/Neki-iOS/Neki-iOS.entitlements
+++ b/Neki-iOS/Neki-iOS.entitlements
@@ -6,5 +6,9 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:neki.suitestudy.com</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## 🌴 작업한 브랜치
- feat/#74-app-scheme


## ✅ 작업한 내용
유니버셜링크를 통해 앱이 동작할 수 있도록 `onOpenURL` 수정자를 간단하게 작성했습니다.


## ❗️PR Point
지금 개발기만 만들 수 있어서 상용기에서 동작하는지 테스트가 필요합니다.


## 📸 스크린샷
생략합니다.


## 📟 관련 이슈
- Resolved: #74


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 카메라 및 사진 라이브러리 접근 권한 설명 추가(앱 권한 요청 표시)
  * 딥링크 지원 추가 — 앱 URL 스킴(neki) 및 웹사이트 연동(applinks:neki.suitestudy.com)
  * 특정 도메인으로 들어오는 링크를 앱에서 수신해 처리가능(지정 호스트에 대한 링크 라우팅)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->