### PR TITLE
[Style] 탭바 레이아웃 재조정

### DIFF
--- a/Neki-iOS/APP/Sources/MainTab/NekiTabBar.swift
+++ b/Neki-iOS/APP/Sources/MainTab/NekiTabBar.swift
@@ -37,19 +37,19 @@ struct NekiTabBar: View {
     let onAddTap: () -> Void
     
     var body: some View {
-        HStack {
+        HStack(spacing: .zero) {
             ForEach(NekiTab.allCases, id: \.self) { tab in
                 Button {
                     guard case .add = tab else { return selectedTab = tab }
                     onAddTap()
                 } label: {
-                    VStack(alignment: .center, spacing: 4) {
+                    VStack(alignment: .center, spacing: 2) {
                         ZStack {
                             if case .add = tab {
                                 Color.clear.frame(width: 26, height: 26)
                                     .overlay {
                                         Image(tab.icon(isSelected: true))
-                                            .offset(y: -8)
+                                            .offset(y: -10)
                                     }
                             } else {
                                 Image(tab.icon(isSelected: selectedTab == tab))
@@ -62,10 +62,12 @@ struct NekiTabBar: View {
                             .foregroundColor(selectedTab == tab ? .gray800 : .gray500)
                     }
                     .frame(maxWidth: .infinity)
+                    .padding(.vertical, 2)
                 }
             }
         }
+        .frame(height: 52, alignment: .center)
         .background(.white)
-        .shadow(color: .black.opacity(0.05), radius: 2, y: -2)
+        .shadow(color: .black.opacity(0.04), radius: 5, y: -2)
     }
 }


### PR DESCRIPTION
## 🌴 작업한 브랜치
- style/#151-tabbar-layout


## ✅ 작업한 내용
탭바 레이아웃을 재조정했습니다.
* 탭바 전체 높이를 고정하면서도 내부 아이템의 패딩과 간격 값을 변경해 디자인 시안과 같게 수정했습니다.


## ❗️PR Point
내부 요소에 대한 Geometry 크기를 일일이 재면서 재조정했습니다. 계산결과, 피그마 dev모드로 나타난 수치와 같아졌습니다.


## 📸 스크린샷
생략합니다.


## 📟 관련 이슈
- Resolved: #151


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 탭 바의 간격과 정렬이 조정되었습니다.
  * 탭 아이콘의 크기 및 패딩이 최적화되었습니다.
  * 탭 바의 그림자 효과가 미세하게 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->