### PR TITLE
Fix/#162 qr parsing photosignature

### DIFF
--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/PhotosignatureStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/PhotosignatureStrategy.swift
@@ -17,8 +17,14 @@ struct PhotoSignatureStrategy: QRCodeParsingStrategy {
         Logger.data.debug("포토시그니처 파싱 시도: \(url.absoluteString)")
         
         let urlString = url.absoluteString
-        let cleanString = urlString.hasSuffix("/") ? String(urlString.dropLast()) : urlString
-        let imageURLString = cleanString + "/a.jpg"
+        var imageURLString = String()
+        
+        if urlString.hasSuffix("index.html") {
+            imageURLString = urlString.replacingOccurrences(of: "index.html", with: "a.jpg")
+        } else {
+            let cleanString = urlString.hasSuffix("/") ? String(urlString.dropLast()) : urlString
+            imageURLString = cleanString + "/a.jpg"
+        }
         
         guard let imageURL = URL(string: imageURLString) else {
             Logger.domain.error("이미지 URL 생성 실패.")
@@ -35,6 +41,8 @@ struct PhotoSignatureStrategy: QRCodeParsingStrategy {
             
             return ParsedQRResult(brand: .photosignature, originalImage: data)
             
+        } catch let error as QRParseError {
+            throw error
         } catch {
             Logger.network.warning("이미지 없음(404 등). 만료 확인.")
             throw .imageDownloadFailed

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Features/QRCodeScanFeature.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Features/QRCodeScanFeature.swift
@@ -109,6 +109,7 @@ struct QRCodeScanFeature {
                 
             case let .parseQRResult(.failure(error)):
                 state.isLoading = false
+                Logger.domain.info("QR 파싱 실패: \(error)")
                 return handleError(error, state: &state)
                 
                 // MARK: - WebView Download Flow


### PR DESCRIPTION
## 🌴 작업한 브랜치
- fix/#162-parsing-photosignature


## ✅ 작업한 내용
Photo Signature - **Code**에 대하여 기존 로직으로는 이미지를 파싱할 수 없던 문제를 해소하고 파싱 로직을 보완했습니다.


## ❗️PR Point
이건 ㄹㅇ 네컷사진을 주기적으로 찍던지, 사용자 피드백을 받던지 해서 노가다식 대응을 할 수 밖에 없는 문제인 것 같습니다...


## 📸 스크린샷
관련없으므로 생략합니다.


## 📟 관련 이슈
- Resolved: #162


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* **QR 코드 스캔 안정성 개선**
  * 이미지 URL 처리 로직을 개선하여 더욱 안정적인 스캔 환경 제공
  * QR 파싱 실패 시 상세한 진단 로그 추가로 문제 파악 및 해결 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->