### PR TITLE
[Refactor] #176 - 지도 내 바텀시트 인터랙션 UX 개선

### DIFF
--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NearPhotoBoothListSheet.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NearPhotoBoothListSheet.swift
@@ -39,6 +39,7 @@ private extension NearPhotoBoothListSheet {
             }
             .scrollIndicators(.never)
             .contentMargins(.horizontal, 20, for: .scrollContent)
+            .scrollDisabled(false)
         } header: {
             Text("네컷 사진 브랜드")
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NekiSheet/NekiSheet.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NekiSheet/NekiSheet.swift
@@ -83,10 +83,15 @@ public struct NekiSheet<Content: View, Controllers: View>: View {
 
 private extension NekiSheet {
     var indicator: some View {
-        RoundedRectangle(cornerRadius: configuration.indicatorSize.height / 2)
-            .fill(configuration.indicatorColor)
-            .frame(width: configuration.indicatorSize.width, height: configuration.indicatorSize.height)
-            .padding(.vertical, 10)
+        VStack {
+            RoundedRectangle(cornerRadius: configuration.indicatorSize.height / 2)
+                .fill(configuration.indicatorColor)
+                .frame(width: configuration.indicatorSize.width, height: configuration.indicatorSize.height)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 24)
+        .contentShape(.rect)
+        .onTapGesture { withAnimation(configuration.animation) { selection = .large } }
     }
 }
 


### PR DESCRIPTION
## 🌴 작업한 브랜치
- refactor/#176-sheet-interaction


## ✅ 작업한 내용
1. 바텀시트 인디케이터 영역을 확대했습니다.
   * 기존: 인디케이터 도형 한정
   * 변경: 인디케이터 도형 영역의 전체 VStack (빈 영역 포함)
2. 바텀시트 인디케이터 터치 액션 이벤트를 추가했습니다.
   * 네이버지도 like한 UX로, 바텀시트 인디케이터를 터치하면 시트가 최대 크기가 됩니다. (Third-stage)


## ❗️PR Point
시트 축소 상태에서 내부 스크롤뷰의 스크롤 이벤트 감지를 막아(`.scrollDisabled`) 인디케이터가 아닌, 시트 내부 컨텐츠를 잡고 끄는 것으로 시트 높이를 변경할 수 있도록 해두었으나, -저는 잘되지만- 데모데이 일부 유저들은 그것이 안되는 것으로 확인되었습니다. 하지만 그 원인은 못찾았습니다. 따라서 현행 유지하되, 브랜드 필터칩은 좌,우로 스크롤 할 수 있어야 하므로 모든 스크롤 이벤트가 막히지 않도록 보완하는데 그쳤습니다.


## 📸 스크린샷
생략합니다.


## 📟 관련 이슈
- Resolved: #176


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 시트 표시기를 탭하여 빠르게 상세 보기로 확장할 수 있는 인터랙티브 기능이 추가되었습니다.

* **버그 수정**
  * 포토부스 브랜드 필터 섹션에서 가로 스크롤이 정상적으로 작동하도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->