### PR TITLE
[Feat] #178 - 사진 상세보기 스크롤 목록 필터링

### DIFF
--- a/Neki-iOS.xcodeproj/project.pbxproj
+++ b/Neki-iOS.xcodeproj/project.pbxproj
@@ -317,6 +317,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Neki-iOS/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Neki-Dev";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "$(CAMERA_USAGE_DESCRIPTION)";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "$(LOCATION_USAGE_DESCRIPTION)";
@@ -368,6 +369,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Neki-iOS/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = Neki;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "$(CAMERA_USAGE_DESCRIPTION)";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "$(LOCATION_USAGE_DESCRIPTION)";

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Coordinator/ArchiveCoordinator.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Coordinator/ArchiveCoordinator.swift
@@ -119,7 +119,7 @@ struct ArchiveCoordinator {
                 if !albumDetailState.isSelectionMode {
                     state.path.append(.detail(
                         ArchivePhotoDetailFeature.State(
-                            photos: state.root.photos,
+                            photos: albumDetailState.photos,
                             currentItemID: item.id,
                             folderId: albumDetailState.album.id
                         )
@@ -133,7 +133,7 @@ struct ArchiveCoordinator {
                 if !albumDetailState.isSelectionMode {
                     state.path.append(.detail(
                         ArchivePhotoDetailFeature.State(
-                            photos: state.root.photos,
+                            photos: albumDetailState.photos,
                             currentItemID: item.id,
                             folderId: albumDetailState.album.id
                         )


### PR DESCRIPTION
## 🌴 작업한 브랜치
- `feat/#178-photo-scroll-filter`

## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->

QA 항목 중 하나인 사진 상세보기 스크롤 목록 필터링 작업을 했습니다. 
코드를 뜯어보니 `ArchiveCoordinator`에서 이미지 상세로 전환 액션을 보낼 때 각 폴더에 속하는 이미지 목록이 아닌 root의 목록을 보내고 있는 것을 확인했습니다. 
해당 부분을 각 폴더 및 즐겨찾기에 맞게 수정한 결과 정상적으로 잘 작동하는 것을 확인했습니다.

## ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

표기되는 앱 이름을 수정했습니다!
Debug Scheme의 경우 Neki-Dev로, Release Scheme의 경우 Neki로 설정해뒀습니다.


## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

생략

## 📟 관련 이슈
- Resolved: #178 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 앱 디스플레이 이름 설정 추가 (개발: "Neki-Dev", 릴리스: "Neki")

* **Bug Fixes**
  * 앨범 상세 뷰에서 사진 선택 시 올바른 사진 목록을 표시하도록 수정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->