### PR TITLE
[Feat] QR 스캔 미지원 브랜드, 신속한 파싱 전략 수립을 위한 디스코드 웹훅 설정 #188

### DIFF
--- a/Neki-iOS/APP/Sources/MainTab/MainTabCoordinator.swift
+++ b/Neki-iOS/APP/Sources/MainTab/MainTabCoordinator.swift
@@ -153,7 +153,7 @@ struct MainTabCoordinator {
                 }
                 
             case .qrScannerPresented:
-                state.destination = .qrScan(QRCodeScanFeature.State())
+                state.destination = .qrScan(QRCodeScanFeature.State(user: state.user))
                 return .none
                 
             case .presentPermissionAlert:

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Repositories/DTOs/DiscordWebhookDTO.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Repositories/DTOs/DiscordWebhookDTO.swift
@@ -31,9 +31,10 @@ public enum DiscordWebhookDTO {
                 description: "새로운 포토부스 브랜드이거나 파싱에 실패한 URL입니다.",
                 color: 16711680, // 빨강색 (Hex: FF0000)
                 fields: [
+                    Field(name: "🍎 Platform", value: "iOS", inline: true),
                     Field(name: "👤 User", value: "\(user.nickname) (ID: \(user.id))", inline: true),
                     Field(name: "🌐 Host", value: host, inline: true),
-                    Field(name: "🔗 Full URL", value: unsupportedURL.absoluteString, inline: false)
+                    Field(name: "🔗 Full URL", value: unsupportedURL.absoluteString, inline: false),
                 ]
             )
             

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Repositories/DTOs/DiscordWebhookDTO.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Repositories/DTOs/DiscordWebhookDTO.swift
@@ -1,0 +1,43 @@
+//
+//  DiscordWebhookDTO.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 3/24/26.
+//
+
+import Foundation
+
+public enum DiscordWebhookDTO {
+    public struct Request: Encodable {
+        struct Embed: Encodable {
+            let title: String
+            let description: String
+            let color: Int
+            let fields: [Field]
+        }
+        
+        struct Field: Encodable {
+            let name: String
+            let value: String
+            let inline: Bool
+        }
+        
+        let embeds: [Embed]
+        
+        init(unsupportedURL: URL, user: User) {
+            let host = unsupportedURL.host() ?? "Unknown Host"
+            let embed = Embed(
+                title: "🚨 미지원 QR 코드 스캔 감지",
+                description: "새로운 포토부스 브랜드이거나 파싱에 실패한 URL입니다.",
+                color: 16711680, // 빨강색 (Hex: FF0000)
+                fields: [
+                    Field(name: "👤 User", value: "\(user.nickname) (ID: \(user.id))", inline: true),
+                    Field(name: "🌐 Host", value: host, inline: true),
+                    Field(name: "🔗 Full URL", value: unsupportedURL.absoluteString, inline: false)
+                ]
+            )
+            
+            self.embeds = [embed]
+        }
+    }
+}

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Repositories/DefaultQRCodeScanRepository.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Repositories/DefaultQRCodeScanRepository.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Dependencies
+import os
 
 struct DefaultQRCodeScanRepository: QRCodeScanRepository {
     private let strategies: [QRCodeParsingStrategy] = [
@@ -19,12 +20,21 @@ struct DefaultQRCodeScanRepository: QRCodeScanRepository {
     
     @Dependency(\.networkProvider) private var networkProvider
     
-    func parse(_ url: URL) async throws(QRParseError) -> ParsedQRResult {
+    func parse(_ url: URL, user: User) async throws(QRParseError) -> ParsedQRResult {
         guard let host = url.host() else { throw .invalidURL }
         
         for strategy in strategies {
             guard strategy.canHandle(host: host) else { continue }
             return try await strategy.parse(url, networkProvider: networkProvider)
+        }
+        
+        Task.detached(priority: .background) {
+            do {
+                let endpoint = QRCodeScannerEndpoint.notifyUnsupportedBrand(url: url, user: user)
+                try await networkProvider.requestVoid(endpoint: endpoint)
+            } catch {
+                Logger.network.error("미지원 브랜드 디스코드 웹훅 발송 실패: \(error)")
+            }
         }
         
         throw .unsupportedBrand

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Repositories/QRCodeScannerEndpoint.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Repositories/QRCodeScannerEndpoint.swift
@@ -1,0 +1,51 @@
+//
+//  QRCodeScannerEndpoint.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 3/24/26.
+//
+
+import Foundation
+import os
+
+public enum QRCodeScannerEndpoint {
+    case notifyUnsupportedBrand(url: URL, user: User)
+}
+
+
+// MARK: - QRCodeScannerEndpoint + Endpoint
+
+extension QRCodeScannerEndpoint: Endpoint {
+    public var baseURL: String {
+        switch self {
+        case .notifyUnsupportedBrand:
+            guard let webhookURLString = Bundle.main.infoDictionary?["QR_WEBHOOK_URL"] as? String else {
+                Logger.data.fault("QR_WEBHOOK_URL을 번들에서 찾을 수 없음.")
+                return ""
+            }
+            return webhookURLString
+        }
+    }
+    
+    public var path: String {
+        switch self {
+        case .notifyUnsupportedBrand: return ""
+        }
+    }
+    
+    public var method: HTTPMethodType {
+        switch self {
+        case .notifyUnsupportedBrand: return .post
+        }
+    }
+    
+    public var authorizationType: AuthorizationType { return .none }
+    
+    public var contentType: HTTPContentType { return .json }
+    
+    public var body: (any Encodable)? {
+        switch self {
+        case let .notifyUnsupportedBrand(url, user): return DiscordWebhookDTO.Request(unsupportedURL: url, user: user)
+        }
+    }
+}

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Clients/QRCodeScannerClient.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Clients/QRCodeScannerClient.swift
@@ -12,7 +12,7 @@ import ComposableArchitecture
 struct QRScannerClient {
     var checkAuthorizationStatus: @Sendable () -> AVAuthorizationStatus
     var requestAccess: @Sendable () async -> Bool
-    var parse: @Sendable (_ urlString: String) async throws -> ParsedQRResult
+    var parse: @Sendable (_ urlString: String, User) async throws -> ParsedQRResult
     var processImage: @Sendable (_ data: Data) async throws -> [Int]
 }
 
@@ -25,9 +25,9 @@ extension QRScannerClient: DependencyKey {
             AVCaptureDevice.authorizationStatus(for: .video)
         } requestAccess: {
             await AVCaptureDevice.requestAccess(for: .video)
-        } parse: { urlString in
+        } parse: { urlString, user in
             guard let url = URL(string: urlString) else { throw QRParseError.invalidURL }
-            return try await qrCodeScanRepository.parse(url)
+            return try await qrCodeScanRepository.parse(url, user: user)
         } processImage: { data in
             let processed = await ImageDownsamplingProcessor.process(data: data)
             guard let imageData = processed?.data else { throw QRParseError.parsingFailed }

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Interfaces/QRCodeScanRepository.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Interfaces/QRCodeScanRepository.swift
@@ -20,7 +20,7 @@ public enum QRParseError: Error {
 }
 
 public protocol QRCodeScanRepository {
-    func parse(_ url: URL) async throws(QRParseError) -> ParsedQRResult
+    func parse(_ url: URL, user: User) async throws(QRParseError) -> ParsedQRResult
 }
 
 private enum QRCodeScanRepositoryKey: DependencyKey {

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Features/QRCodeScanFeature.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Features/QRCodeScanFeature.swift
@@ -14,6 +14,8 @@ import os
 struct QRCodeScanFeature {
     @ObservableState
     struct State {
+        let user: User
+        
         var isLightOn: Bool = false
         var isLoading: Bool = false
         
@@ -105,11 +107,12 @@ struct QRCodeScanFeature {
                 // MARK: - Scanning Flow
             case .codeScanned(let urlString):
                 guard state.isLoading == false, state.isCameraActive else { return .none }
+                let user = state.user
                 state.isLoading = true
                 Logger.presentation.debug("QR 스캔 감지: \(urlString)")
                 
                 return .run { send in
-                    await send(.parseQRResult(Result { try await qrScannerClient.parse(urlString) }))
+                    await send(.parseQRResult(Result { try await qrScannerClient.parse(urlString, user) }))
                 }
                 
             case let .parseQRResult(.success(parsed)):

--- a/Neki-iOS/Info.plist
+++ b/Neki-iOS/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>QR_WEBHOOK_URL</key>
+	<string>$(QR_WEBHOOK_URL)</string>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
 	<key>CFBundleURLTypes</key>


### PR DESCRIPTION
## 🌴 작업한 브랜치
- feat/#188-qr-parsing-webhook


## ✅ 작업한 내용
미지원 브랜드에 대한 QR 스캔 시도 시, 파싱 전략 수립을 위해 디스코드 웹훅을 이용해 알림을 띄우고 QR URL을 확보할 수 있도록 했습니다.
1. 디스코드 웹훅 주소 따와서 XCConfig 및 번들에 기록했습니다.
2. QRScanner 모듈쪽에 Endpoint 정의해서 디스코드 웹훅을 트리거링 할 수 있습니다.
3. 미지원 브랜드 스캔 감지 시, 미지원 브랜드를 안내하는 얼럿과 구글폼을 제공함과 동시에 Fire&Forget으로 디스코드 웹훅을 전송합니다.

그리고 자잘하게 UI 컴포넌트 디자인적 변경점이 있는 것 같아서 이참에 하려고 했는데 막상 살펴보니 바꿀게 딱히 없어서 태스크에서 제외했습니다.

## ❗️PR Point
간단한 구현이므로 생략합니다!

디스코드 스레드에서 해당 기능을 프론트에서 할지, 백엔드에서 할지 의논하다가 프론트에서 하는 걸로 잠정 결론나서 구현했는데, 나중에 백엔드에서 하게될 수도 있다는 점만 인지해두시면 될 듯합니다.


## 📸 스크린샷
디스코드 웹훅 테스트로 대체합니다!


## 📟 관련 이슈
- Resolved: #188


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * QR 코드 스캔 시 현재 사용자 정보가 스캔 흐름에 포함되어 전달됩니다.
  * 지원되지 않는 QR 코드 형식이 감지되면 외부에 자동으로 알림을 전송하는 보고 기능이 추가됩니다.
  * 외부 알림 대상 URL을 설정에서 지정할 수 있도록 앱 설정 키가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->