### PR TITLE
[Chore] 짤막 QA 처리

### DIFF
--- a/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Features/QRCodeScanFeature.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Features/QRCodeScanFeature.swift
@@ -102,7 +102,7 @@ struct QRCodeScanFeature {
                 
             case .closeExpiredAlertButtonTapped:
                 state.isExpiredAlertPresented = false
-                return .none
+                return .send(.addPhotoFromGalleryButtonTapped)
                 
                 // MARK: - Scanning Flow
             case .codeScanned(let urlString):

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Views/QRCodeScannerView.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Presentation/Sources/Views/QRCodeScannerView.swift
@@ -81,9 +81,9 @@ struct QRCodeScannerView: View {
         .nekiAlert(
             isPresented: $store.isExpiredAlertPresented,
             style: .plain,
-            title: "만료된 QR 코드예요.",
-            subtitle: "만료되지 않은 네컷사진만 저장할 수 있어요.",
-            confirmText: "확인",
+            title: "QR이 만료되었어요.",
+            subtitle: "일정 시간이 지나면 QR로는 더 이상 불러올 수 없어요. 이미 저장된 사진이 있다면 갤러리에서 추가해보세요.",
+            confirmText: "갤러리에서 추가하기",
             onConfirm: { store.send(.closeExpiredAlertButtonTapped) }
         )
         .fullScreenCover(isPresented: $store.isLoading) { LoadingView() }

--- a/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiAlertModifier.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiAlertModifier.swift
@@ -23,9 +23,9 @@ struct NekiAlertModifier: ViewModifier {
     let hasIcon: Bool
     
     // 액션 클로저
-    let onConfirm: () -> Void
-    let onCancel: () -> Void
-    let onSecondary: () -> Void
+    let onConfirm: (() -> Void)?
+    let onCancel: (() -> Void)?
+    let onSecondary: (() -> Void)?
     
     func body(content: Content) -> some View {
         ZStack {
@@ -37,7 +37,13 @@ struct NekiAlertModifier: ViewModifier {
                     .ignoresSafeArea()
                     .zIndex(1)
                     .transition(.opacity)
-                    .onTapGesture { isPresented.toggle() }
+                    .onTapGesture {
+                        if let onCancel = onCancel {
+                            onCancel()
+                        } else {
+                            isPresented.toggle()
+                        }
+                    }
                 
                 NekiAlertModal(hasIcon: hasIcon) {
                     VStack(spacing: 4) {
@@ -86,7 +92,7 @@ struct NekiAlertModifier: ViewModifier {
     // 개별 버튼 컴포넌트
     private var confirmButton: some View {
         Button {
-            onConfirm()
+            onConfirm?()
         } label: {
             Text(confirmText)
                 .frame(maxWidth: .infinity)
@@ -97,7 +103,7 @@ struct NekiAlertModifier: ViewModifier {
     
     private var cancelButton: some View {
         Button {
-            onCancel()
+            onCancel?()
         } label: {
             Text(cancelText ?? "취소")
                 .frame(maxWidth: .infinity)
@@ -108,7 +114,7 @@ struct NekiAlertModifier: ViewModifier {
     
     private var secondaryButton: some View {
         Button {
-            onSecondary()
+            onSecondary?()
         } label: {
             Text(secondaryText ?? "선택")
                 .padding(.horizontal, 32)
@@ -133,9 +139,9 @@ public extension View {
         secondaryText: String? = nil,
         isProcessing: Bool = false,
         hasIcon: Bool = true,
-        onConfirm: @escaping () -> Void = {},
-        onCancel: @escaping () -> Void = {},
-        onSecondary: @escaping () -> Void = {}
+        onConfirm: (() -> Void)? = nil,
+        onCancel: (() -> Void)? = nil,
+        onSecondary: (() -> Void)? = nil
     ) -> some View {
         self.modifier(NekiAlertModifier(
             isPresented: isPresented,

--- a/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiAlertModifier.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiAlertModifier.swift
@@ -37,10 +37,7 @@ struct NekiAlertModifier: ViewModifier {
                     .ignoresSafeArea()
                     .zIndex(1)
                     .transition(.opacity)
-                    .onTapGesture {
-                        // 필요 시 배경 탭으로 닫기 로직 추가 가능
-                        // isPresented.toggle()
-                    }
+                    .onTapGesture { isPresented.toggle() }
                 
                 NekiAlertModal(hasIcon: hasIcon) {
                     VStack(spacing: 4) {


### PR DESCRIPTION
## 🌴 작업한 브랜치
- chore/#190-alert-interaction


## ✅ 작업한 내용
1. 만료된 QR 얼럿 문구를 수정했습니다.
2. 얼럿 밖의 영역을 터치하여 얼럿을 닫을 수 있도록 수정했습니다.


## ❗️PR Point
얼럿에 따라 `onCancel()` 클로저로 얼럿을 닫을 때 상태의 변경이 같이 이루어져야 하는 것들도 있을텐데 단순히 `isPresented.toggle()`을 해도 무방한지 모르겠습니다!


## 📸 스크린샷
생략합니다!


## 📟 관련 이슈
- Resolved: #190


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 만료된 QR 코드 알림 메시지를 더 명확하고 자세하게 업데이트했습니다.
  * 만료된 QR 알림의 확인 버튼을 누르면 알림을 닫고 바로 갤러리에서 사진을 추가할 수 있도록 동작을 개선했습니다.
  * 알림의 어두운 배경(디머)을 터치해 알림을 닫을 수 있도록 동작을 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->