### PR TITLE
[Chore] 앱 업데이트를 위한 앱스토어 이동 로직 구현

### DIFF
--- a/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
+++ b/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
@@ -176,7 +176,7 @@ struct AppCoordinator {
                 
             case .didTapUpdateAlert:
                 return .run { _ in
-                    let appStoreURL = URL(string: "https://neki.suitestudy.com")!
+                    let appStoreURL = URL(string: "https://apps.apple.com/kr/app/neki/id6757490609")!
                     await openURL(appStoreURL)
                 }
                 

--- a/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
+++ b/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
@@ -175,9 +175,8 @@ struct AppCoordinator {
                 return .send(.route(.mainTab(.archive(.root(.addPhotoFromShareExtension(appGroupID: appGroupID))))))
                 
             case .didTapUpdateAlert:
-                // TODO: 앱스토어 URL 필요
                 return .run { _ in
-                    let appStoreURL = URL(string: "https://itunes.apple.com/kr/app/neki")!
+                    let appStoreURL = URL(string: "https://neki.suitestudy.com")!
                     await openURL(appStoreURL)
                 }
                 

--- a/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiAlertModifier.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiAlertModifier.swift
@@ -117,6 +117,7 @@ struct NekiAlertModifier: ViewModifier {
             onSecondary?()
         } label: {
             Text(secondaryText ?? "선택")
+                .frame(maxWidth: .infinity)
                 .padding(.horizontal, 32)
                 .padding(.vertical, 4)
                 .underline()

--- a/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiAlertModifier.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiAlertModifier.swift
@@ -122,6 +122,7 @@ struct NekiAlertModifier: ViewModifier {
                 .padding(.vertical, 4)
                 .underline()
                 .tint(.primary500)
+                .nekiFont(.body14Regular)
         }
         .disabled(isProcessing)
     }


### PR DESCRIPTION
## 🌴 작업한 브랜치
- chore/#199-appstore-navigation


## ✅ 작업한 내용
앱스토어로 이동을 위해 Neki 유니버셜링크를 입력했으며 기존 Todo주석을 제거했습니다.


## ❗️PR Point
~앱스토어 링크 자체를 입력해도 됐으나, 유니버셜링크를 쓰고 싶어서 그렇게 했습니다. 뭔가 차이가 있다거나 예상되는 문제점이 있다면 알려주세요!~ (앱스토어 링크 쓰기로 결정)


## 📸 스크린샷
생략합니다.


## 📟 관련 이슈
- Resolved: #199


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 앱 업데이트 알림에서 열리는 링크를 더 정확한 App Store 주소(앱 ID 포함)로 변경하여 사용자가 업데이트 페이지로 직접 이동할 수 있도록 개선했습니다.
* **디자인/스타일**
  * 보조 버튼의 레이블이 가로 공간을 채우고 지정된 본문 글꼴을 적용하여 버튼 텍스트가 더 안정적으로 읽히고 일관된 UI를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->