### PR TITLE
[Style] 프로필 사진 변경 기능 사용성 확보

### DIFF
--- a/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
+++ b/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
@@ -193,13 +193,8 @@ struct AppCoordinator {
                 
                 switch newStatus {
                 case let .signedIn(user):
-                    if case var .mainTab(mainTabState) = state.route {
-                        mainTabState.user = user
-                        mainTabState.myPage.root.user = user
-                        state.route = .mainTab(mainTabState)
-                        return .none
-                    }
-                    state.route = .mainTab(.init(user: user))
+                    if case .mainTab = state.route { return .none }
+                    state.route = .mainTab(.init())
                     return .none
                     
                 case .signedOut:
@@ -222,22 +217,15 @@ struct AppCoordinator {
                 
             case let .route(.auth(.delegate(.moveToMainTab(user)))):
                 state.$userSessionStatus.withLock { $0 = .signedIn(user) }
-                state.route = .mainTab(.init(user: user))
+                state.route = .mainTab(.init())
                 return .send(.executePendingShareExtensionIfNeeded)
                 
-            case .route(.mainTab(.delegate(.signedOut))):
+            case .route(.mainTab(.delegate(.signedOut))), .route(.mainTab(.delegate(.withdraw))):
                 state.$userSessionStatus.withLock { $0 = .signedOut }
+                if case .route(.mainTab(.delegate(.withdraw))) = action {
+                    state.initializeUserDefaults()
+                }
                 state.route = .auth(.init())
-                return .none
-                
-            case .route(.mainTab(.delegate(.withdraw))):
-                state.$userSessionStatus.withLock { $0 = .signedOut }
-                state.initializeUserDefaults()
-                state.route = .auth(.init())
-                return .none
-                
-            case let .route(.mainTab(.delegate(.profileUpdated(user)))):
-                state.$userSessionStatus.withLock { $0 = .signedIn(user) }
                 return .none
                 
             case .binding(\.isAlertPresented):
@@ -254,8 +242,8 @@ struct AppCoordinator {
     
     private func navigateToNextScreen(state: inout State, sessionStatus: UserSessionStatus) -> Effect<Action> {
         switch sessionStatus {
-        case .signedIn(let user):
-            state.route = .mainTab(.init(user: user))
+        case .signedIn:
+            state.route = .mainTab(.init())
             return .send(.executePendingShareExtensionIfNeeded)
             
         case .signedOut, .expired:

--- a/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
+++ b/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
@@ -195,7 +195,8 @@ struct AppCoordinator {
                 case let .signedIn(user):
                     if case var .mainTab(mainTabState) = state.route {
                         mainTabState.user = user
-                        state.route = .mainTab(.init(user: user))
+                        mainTabState.myPage.root.user = user
+                        state.route = .mainTab(mainTabState)
                         return .none
                     }
                     state.route = .mainTab(.init(user: user))

--- a/Neki-iOS/APP/Sources/MainTab/MainTabCoordinator.swift
+++ b/Neki-iOS/APP/Sources/MainTab/MainTabCoordinator.swift
@@ -16,14 +16,14 @@ struct MainTabCoordinator {
     
     @ObservableState
     struct State {
-        var user: User
+        @Shared(.appStorage(AppStorageKey.userSessionStatus)) var userSessionStatus: UserSessionStatus = .signedOut
         var selectedTab: NekiTab = .archive
         
         // 하위 코디네이터들의 State를 보유
         var pose = PoseCoordinator.State()
         var archive = ArchiveCoordinator.State()
         var map = MapCoordinator.State()
-        var myPage: MyPageCoordinator.State
+        var myPage = MyPageCoordinator.State()
         
         var imagePicker = ImagePickerFeature.State(mediaType: .photoBooth, autoUpload: false)
         
@@ -37,9 +37,15 @@ struct MainTabCoordinator {
         var toast: NekiToastItem? = nil
         var isPermissionAlertPresented: Bool = false
         
-        init(user: User) {
-            self.user = user
-            myPage = MyPageCoordinator.State(user: user)
+        var user: User {
+            get {
+                guard case let .signedIn(user) = userSessionStatus else { return .dummy }
+                return user
+            }
+            
+            set {
+                $userSessionStatus.withLock { $0 = .signedIn(newValue) }
+            }
         }
     }
     
@@ -72,7 +78,6 @@ struct MainTabCoordinator {
         enum Delegate {
             case signedOut
             case withdraw
-            case profileUpdated(User)
         }
     }
     
@@ -169,9 +174,6 @@ struct MainTabCoordinator {
                     await send(.archive(.root(.clearData)))
                     await send(.delegate(.withdraw))
                 }
-                
-            case let .myPage(.delegate(.profileUpdated(user))):
-                return .send(.delegate(.profileUpdated(user)))
                 
             case let .imagePicker(.delegate(.imagesConverted(entities))):
                 state.isPhotoPickerPresented = false

--- a/Neki-iOS/Core/Sources/Auth/Sources/Domain/Sources/Entities/User.swift
+++ b/Neki-iOS/Core/Sources/Auth/Sources/Domain/Sources/Entities/User.swift
@@ -16,3 +16,7 @@ public struct User: Sendable, Equatable, Codable {
     let providerType: ProviderType
     var allRequiredTermsAgreed: Bool
 }
+
+extension User {
+    static var dummy: Self { User(id: -1, nickname: "-", email: nil, profileImageURL: nil, providerType: .local, allRequiredTermsAgreed: true) }
+}

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Coordinator/MyPageCoordinator.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Coordinator/MyPageCoordinator.swift
@@ -12,12 +12,10 @@ import ComposableArchitecture
 struct MyPageCoordinator {
     @ObservableState
     struct State {
-        var root: MyPageFeature.State
-        var path = StackState<Path.State>()
+        @Shared(.appStorage(AppStorageKey.userSessionStatus)) var userSessionStatus: UserSessionStatus = .signedOut
         
-        init(user: User) {
-            root = MyPageFeature.State(user: user)
-        }
+        var root = MyPageFeature.State()
+        var path = StackState<Path.State>()
     }
     
     enum Action {
@@ -28,7 +26,6 @@ struct MyPageCoordinator {
         enum Delegate {
             case didLogout
             case didWithdraw
-            case profileUpdated(User)
         }
     }
     
@@ -43,11 +40,12 @@ struct MyPageCoordinator {
                 return routeMyPageCellTapped(state: &state, cellItem)
                 
             case .root(.profileTapped):
-                state.path.append(.accountPreference(.init(user: state.root.user)))
+                state.path.append(.accountPreference(.init()))
                 return .none
                 
             case .path(.element(id: _, action: .accountPreference(.editProfileButtonTapped))):
-                state.path.append(.profileEdit(.init(user: state.root.user)))
+                guard case let .signedIn(user) = state.userSessionStatus else { return .none }
+                state.path.append(.profileEdit(.init(user: user)))
                 return .none
                 
             case .path(.element(id: _, action: .accountPreference(.didSignOut))):
@@ -55,9 +53,6 @@ struct MyPageCoordinator {
                 
             case .path(.element(id: _, action: .accountPreference(.didWithdraw))):
                 return .send(.delegate(.didWithdraw))
-                
-            case let .path(.element(id: _, action: .profileEdit(.profileUpdated(user)))):
-                return .send(.delegate(.profileUpdated(user)))
                 
             default:
                 return .none

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/AccountPreferenceFeature.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/AccountPreferenceFeature.swift
@@ -13,11 +13,16 @@ import os
 struct AccountPreferenceFeature {
     @ObservableState
     struct State {
-        var user: User
+        @Shared(.appStorage(AppStorageKey.userSessionStatus)) var userSessionStatus: UserSessionStatus = .signedOut
         
         var isLogoutAlertPresented: Bool = false
         var isUnregisterAlertPresented: Bool = false
         var isLoading: Bool = false
+        
+        var user: User {
+            guard case let .signedIn(user) = userSessionStatus else { return .dummy }
+            return user
+        }
     }
     
     enum Action: BindableAction {
@@ -71,9 +76,9 @@ struct AccountPreferenceFeature {
                 state.isUnregisterAlertPresented = false
                 state.isLoading = true
                 
-                return .run { [userId = state.user.id] send in
+                return .run { [userID = state.user.id] send in
                     try await authClient.withdraw()
-                    UserDefaults.standard.removeObject(forKey: "TermsAgreed_\(userId)")
+                    UserDefaults.standard.removeObject(forKey: "TermsAgreed_\(userID)")
                     await send(.didWithdraw)
                 } catch: { error, send in
                     Logger.presentation.error("회원탈퇴 과정 중 에러 발생: \(error)")

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/MyPageFeature.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/MyPageFeature.swift
@@ -12,8 +12,13 @@ import ComposableArchitecture
 struct MyPageFeature {
     @ObservableState
     struct State {
-        var user: User
+        @Shared(.appStorage(AppStorageKey.userSessionStatus)) var userSessionStatus: UserSessionStatus = .signedOut
         var appVersion: AppVersion = AppVersion(major: 0, minor: 0, revision: 0)
+        
+        var user: User {
+            guard case let .signedIn(user) = userSessionStatus else { return .dummy }
+            return user
+        }
     }
     
     enum Action {

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/ProfileEditFeature.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/ProfileEditFeature.swift
@@ -14,7 +14,7 @@ import os
 struct ProfileEditFeature {
     @ObservableState
     struct State {
-        @ObservationStateIgnored let user: User
+        @Shared(.appStorage(AppStorageKey.userSessionStatus)) var userSessionStatus: UserSessionStatus = .signedOut
         var nickname: String
         var currentProfileImageURL: URL?
         var selectedProfileImage: UIImage?
@@ -29,8 +29,18 @@ struct ProfileEditFeature {
         
         var isProfileSelectionAlertPresented: Bool = false
         
+        var user: User {
+            get {
+                guard case let .signedIn(user) = userSessionStatus else { return .dummy }
+                return user
+            }
+            
+            set {
+                $userSessionStatus.withLock { $0 = .signedIn(newValue) }
+            }
+        }
+        
         init(user: User) {
-            self.user = user
             nickname = user.nickname
             currentProfileImageURL = user.profileImageURL
         }
@@ -50,9 +60,6 @@ struct ProfileEditFeature {
         
         // Binding Actions
         case binding(BindingAction<State>)
-        
-        // Delegate Actions
-        case profileUpdated(User)
     }
     
     private enum CancelID { case imageLoad }
@@ -134,8 +141,8 @@ struct ProfileEditFeature {
                 
             case let .updateProfileResponse(.success(user)):
                 state.isLoading = false
-                return .run { send in
-                    await send(.profileUpdated(user))
+                state.user = user
+                return .run { _ in
                     await dismiss()
                 }
                 

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/AccountPreferenceView.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/AccountPreferenceView.swift
@@ -69,12 +69,20 @@ private extension AccountPreferenceView {
     
     var profileArea: some View {
         VStack(spacing: 16) {
-            KFImage(store.user.profileImageURL)
-                .resizable()
-                .onFailureImage(.iconDefaultProfile)
-                .scaledToFill()
-                .frame(width: 142, height: 142)
-                .clipShape(.circle)
+            ZStack(alignment: .bottomTrailing) {
+                KFImage(store.user.profileImageURL)
+                    .resizable()
+                    .onFailureImage(.iconDefaultProfile)
+                    .scaledToFill()
+                    .frame(width: 142, height: 142)
+                    .clipShape(.circle)
+                
+                Button {
+                    store.send(.editProfileButtonTapped)
+                } label: {
+                    Image(.iconProfileCamera)
+                }
+            }
             
             HStack(spacing: 9) {
                 Text(store.user.nickname)


### PR DESCRIPTION
## 🌴 작업한 브랜치
- style/#204-adjust-profile-image


## ✅ 작업한 내용
계정 설정 화면에서 보이는 프로필 사진 영역에 카메라 모양의 버튼을 제공합니다.
해당 버튼을 누르면 프로필 사진 변경이 가능하다는 시각적 UX를 제공하여 프로필 사진 변경 기능의 사용성을 용이하게 했습니다.

또 프로필 편집 후에 AppCoordinator 수준에서 새로운 유저 정보로 아예 덮어씌워버리니까 프로필 편집 화면의 이전 화면이 아닌, 아카이빙 탭이 나타나는 문제를 발견하여 조치했습니다.
이제 메인탭 상태를 초기화하지 않고 유지하는 것으로 기존에 열려있던 탭인 마이페이지 탭이 그대로 살아있게 합니다.


## ❗️PR Point
해당 이슈는 계정 설정 화면에서 프로필 사진 변경을 어떻게 하느냐라는 기능 사용성의 불편함에서 비롯되었습니다.
그러나 프로필 사진 변경을 위해 **프로필 사진 영역을 두 번 탭해야 하는** 새로운 불편함을 초래하기도 했습니다.
(계정 설정 화면에서 프사 터치 -> 프로필 편집 화면으로 이동 -> 프로필 편집 화면에서 프사 터치 -> 프로필 변경 기능)

기디 수준에서 재검토가 필요할 수 있습니다.
(사실 PM에게는 이미 알려줬음)


번외로, 프로필 정보 변경 관련해 메인탭 상태 변경 로직을 디버깅하는 과정에서 다음의 수정이 있었습니다.
* 기존: 유저 로그인 세션 정보를 생성자를 통해 주입
* 변경: `@Shared` 상태 공유

변경의 이유는 다음과 같습니다.
1. 로그인 또는 비로그인 상태에서 User 값을 변경할 때, 변경사항을 상위 코디네이터급 리듀서로 전파하면서 직접 상태 관리해야함.
2. 이러한 상태 변경 코드가 리듀서마다 작성되어야 하며 네비게이션 스택에 따라 각 피처급 리듀서를 순회하면서 다시 상태 변경을 챙겨줘야함.
3. 유저 로그인 세션이라는 단일진실공급원을 AppCoordinator가 관리하면서 하위 화면에는 생성자 주입을 하는, 로그인 상태가 변경되었을 때 자동으로 갱신되는 방식이 더 자연스럽다고 판단해 기존안으로 구현하였으나, 현재에 이르러서는 상태 관리 로직이 더 많아짐에 따라 매우 귀찮고 알아보기 힘들어짐.

아래의 사항을 주로 고민했습니다.
1. 마이페이지 탭 및 그 하위 화면은 **로그인 필수 기능**으로써, 유저 정보가 옵셔널로 선언되면 그 의미가 변질됨.
2. 하지만 `UserSessionStatus`는 열거형이므로, 로그인된 상태에서만 접근할 수 있는 화면임에도 불구하고 비로그인 상태까지 고려하여 옵셔널로 선언해야함.
3. 따라서 getter/setter를 활용한 프록시 패턴을 적용해 뷰에서 유저 정보를 읽거나 자식 리듀서 내에서 유저 정보를 쓸 때 `store.user?.nickname`처럼 코드를 작성하지 않도록 만듦.
4. 유저 값 변경에 대한 모든 Delegate 액션을 제거하여 코드 다이어트.


## 📸 스크린샷
작은 변경사항이라 생략합니다.


## 📟 관련 이슈
- Resolved: #204 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 내 페이지의 프로필 이미지 우측 하단에 카메라 아이콘 버튼이 추가되었습니다. 사용자가 해당 버튼을 탭하면 프로필 편집 화면이 바로 실행됩니다. 기존의 프로필 이미지 탭 및 닉네임 편집 동작은 그대로 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->