### PR TITLE
[Refactor] #210 - 스프린트4발 QA 쳐내기

### DIFF
--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
@@ -255,12 +255,17 @@ extension NaverMapRepresentable {
             let toRemoveIDs = currentKeyByID.keys.filter { newIDs.contains($0) == false }
             keysToRemove.append(contentsOf: toRemoveIDs.compactMap { currentKeyByID[$0] })
             
+            var coordinateFrequency = [String: Int]()
+            
             for booth in photoBooths {
+                let coordinateKey = "\(booth.coordinate.latitude), \(booth.coordinate.longitude)"
+                let overlapIndex = coordinateFrequency[coordinateKey, default: .zero]
+                coordinateFrequency[coordinateKey] = overlapIndex + 1
                 let isNew = currentKeyByID.keys.contains(booth.id) == false
                 let isSelectedAffected = selectionChanged && (booth.id == selectedBoothID || booth.id == oldSelected)
                 
                 if isNew || isSelectedAffected {
-                    let position = NMGLatLng(lat: booth.coordinate.latitude, lng: booth.coordinate.longitude)
+                    let position = calculateJitteredPosition(latitude: booth.coordinate.latitude, longitude: booth.coordinate.longitude, overlapIndex: overlapIndex)
                     let key = BoothClusteringKey(identifier: booth.id, brandID: booth.brand.id, position: position)
                     
                     if isSelectedAffected, let oldKey = currentKeyByID[booth.id] {
@@ -280,6 +285,16 @@ extension NaverMapRepresentable {
             }
             
             lastSelectedBoothID = selectedBoothID
+        }
+        
+        func calculateJitteredPosition(latitude: Double, longitude: Double, overlapIndex: Int) -> NMGLatLng {
+            guard overlapIndex > .zero else { return NMGLatLng(lat: latitude, lng: longitude) }
+            
+            let offsetRadius = 0.00005
+            let angle = Double(overlapIndex) * (Double.pi / 3)
+            let latitudeOffset = offsetRadius * cos(angle)
+            let longitudeOffset = offsetRadius * sin(angle)
+            return NMGLatLng(lat: latitude + latitudeOffset, lng: longitude + longitudeOffset)
         }
         
         func applyOverlay(to marker: NMFMarker, overlay: NMFOverlayImage, expectedID: Int) {

--- a/Neki-iOS/Shared/DesignSystem/Sources/Component/NekiToast/NekiToast.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Component/NekiToast/NekiToast.swift
@@ -38,7 +38,7 @@ public struct NekiToastItem: Identifiable, Equatable {
     public init(
         _ message: String,
         style: NekiToastStyle = .info,
-        duration: Double = 3.0,
+        duration: Double = 1.8,
         buttonTitle: String? = nil,
         action: Interaction? = nil
     ) {


### PR DESCRIPTION
## 🌴 작업한 브랜치
- refactor/#210-sprint4-qa


## ✅ 작업한 내용
1. NekiToast 지속시간을 줄였습니다. 이제 토스트가 UI를 가리는 시간이 단축되어 사용자가 곧바로 다음 행동을 취하기에 불편함이 줄어듭니다.
2. 동일 좌표 POI의 마커 오버레이가 서로 겹쳐 나타나는 문제를 해소했습니다.


## ❗️PR Point
1. NekiToast 기본 지속시간 3초에서 1.8초로 변경했습니다. UI를 가리는 시간을 줄이면서도 사용자에게 안내문구를 노출하는 적절한 시간을 찾기 위해 직접 조절해가면서 결정했는데, 저 외의 다른 사람들도 체감상 괜찮은지 다시 QA 필요합니다.
2. 동일 좌표 POI 마커 오버레이에 대해서 이제 기준 좌표를 중앙으로 하여 원형을 그리며 퍼뜨려져 나타냅니다.


## 📸 스크린샷
QA시트에 스크린샷 첨부해두었습니다. 이것으로 대체합니다.


## 📟 관련 이슈
- Resolved: #210


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 지도에서 동일한 좌표에 위치한 여러 포토부스 마커들이 이제 중복되지 않도록 적절히 분산되어 표시됩니다.

* **작업**
  * 토스트 알림 메시지의 기본 표시 시간이 3초에서 1.8초로 단축되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->