### PR TITLE
[Chore] #213 - 외부 앱 공유 과정 중 앨범선택여부 전 이미지 업로드 과정 취소 시 임시 저장소 비우기

### DIFF
--- a/Neki-iOS/APP/Sources/MainTab/MainTabCoordinator.swift
+++ b/Neki-iOS/APP/Sources/MainTab/MainTabCoordinator.swift
@@ -180,7 +180,7 @@ struct MainTabCoordinator {
                 state.isLoading = false
                 state.selectedTab = .archive
                 guard !entities.isEmpty else { return .none }
-                return .send(.archive(.root(.processUploadImages(entities: entities))))
+                return .send(.archive(.root(.processUploadImages(entities: entities, appGroupID: nil))))
                 
             case let .destination(.presented(.qrScan(.addPhotoFromQRScanner(imageID)))):
                 state.destination = nil

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFeature.swift
@@ -69,8 +69,8 @@ struct ArchiveFeature {
         
         case addPhotoFromQRScanner(imageID: Int)
         
-        case processUploadImages(entities: [ImageUploadEntity])
-        case uploadSharedImagesResponse(Result<[ImageUploadEntity], Error>)
+        case processUploadImages(entities: [ImageUploadEntity], appGroupID: String?)
+        case uploadSharedImagesResponse(Result<[ImageUploadEntity], Error>, appGroupID: String?)
         
         case addPhotoFromShareExtension(appGroupID: String)
         case cleanSharedImages(appGroupID: String)
@@ -217,12 +217,12 @@ struct ArchiveFeature {
             case .loadMorePhotos: return .send(.fetchPhotos)
                 
             case let .imagePicker(.delegate(.imagesConverted(entities))):
-                return .send(.processUploadImages(entities: entities))
+                return .send(.processUploadImages(entities: entities, appGroupID: nil))
                 
-            case let .processUploadImages(entities):
+            case let .processUploadImages(entities, appGroupID):
                 state.isLoading = false
                 guard !entities.isEmpty else { return .none }
-                state.selectUploadAlbum = SelectUploadAlbumFeature.State(pendingUploadImages: entities)
+                state.selectUploadAlbum = SelectUploadAlbumFeature.State(pendingUploadImages: entities, appGroupID: appGroupID)
                 return .none
                 
             case let .addPhotoFromShareExtension(appGroupID):
@@ -232,7 +232,7 @@ struct ArchiveFeature {
                         let fileURLs = try await sharedImageClient.fetchSharedImageURLs(appGroupID: appGroupID)
                         guard !fileURLs.isEmpty else {
                             await send(.delegate(.showToast(NekiToastItem("가져올 수 있는 이미지가 없어요.", style: .error))))
-                            await send(.uploadSharedImagesResponse(.failure(UploadError.uploadFailed)))
+                            await send(.uploadSharedImagesResponse(.failure(UploadError.uploadFailed), appGroupID: appGroupID))
                             return
                         }
                         
@@ -243,10 +243,10 @@ struct ArchiveFeature {
                             }
                         }
                         await send(.cleanSharedImages(appGroupID: appGroupID))
-                        await send(.uploadSharedImagesResponse(.success(entities)))
+                        await send(.uploadSharedImagesResponse(.success(entities), appGroupID: appGroupID))
                     } catch {
                         await send(.cleanSharedImages(appGroupID: appGroupID))
-                        await send(.uploadSharedImagesResponse(.failure(error)))
+                        await send(.uploadSharedImagesResponse(.failure(error), appGroupID: appGroupID))
                     }
                 }
                 
@@ -285,10 +285,10 @@ struct ArchiveFeature {
                     try? await sharedImageClient.clearSharedImages(appGroupID: appGroupID)
                 }
                 
-            case let .uploadSharedImagesResponse(.success(entities)):
-                return .send(.processUploadImages(entities: entities))
+            case let .uploadSharedImagesResponse(.success(entities), appGroupID):
+                return .send(.processUploadImages(entities: entities, appGroupID: appGroupID))
                 
-            case .uploadSharedImagesResponse(.failure):
+            case .uploadSharedImagesResponse(.failure, _):
                 state.isLoading = false
                 return .send(.delegate(.showToast(NekiToastItem("업로드에 실패했어요", style: .error))))
                 

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/SelectUploadAlbumFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/SelectUploadAlbumFeature.swift
@@ -17,10 +17,18 @@ struct SelectUploadAlbumFeature {
     @ObservableState
     struct State {
         let pendingUploadImages: [ImageUploadEntity]
-        var viewMode: ViewMode = .prompt
-        var isLoading: Bool = false
+        var viewMode: ViewMode
+        var isLoading: Bool
+        var appGroupID: String?
         
         var albumSelection: AlbumSelectionFeature.State?
+        
+        init(pendingUploadImages: [ImageUploadEntity], appGroupID: String? = nil, viewMode: ViewMode = .prompt, isLoading: Bool = false) {
+            self.pendingUploadImages = pendingUploadImages
+            self.viewMode = viewMode
+            self.isLoading = isLoading
+            self.appGroupID = appGroupID
+        }
     }
     
     enum Action: BindableAction {
@@ -43,6 +51,7 @@ struct SelectUploadAlbumFeature {
     
     @Dependency(\.archiveClient) var archiveClient
     @Dependency(\.imageUploadClient) var imageUploadClient
+    @Dependency(\.sharedImageClient) var sharedImageClient
     @Dependency(\.dismiss) var dismiss
     
     var body: some ReducerOf<Self> {
@@ -50,7 +59,12 @@ struct SelectUploadAlbumFeature {
         
         Reduce { state, action in
             switch action {
-            case .tapDimmedBackground: return .run { _ in await self.dismiss() }
+            case .tapDimmedBackground: return .run { [appGroupID = state.appGroupID] _ in
+                if let appGroupID {
+                    try? await sharedImageClient.clearSharedImages(appGroupID)
+                }
+                await self.dismiss()
+            }
                 
             case .tapUploadWithoutAlbum:
                 state.isLoading = true


### PR DESCRIPTION
## 🌴 작업한 브랜치
- chore/#213-filemanager-clear


## ✅ 작업한 내용
하위 리듀서로 추출된 SelectUploadAlbumFeature의 딤배경 탭으로 취소하는 액션에 임시 공유저장소를 비우는 사이드이펙트를 처리하도록 했습니다.
외부 앱 공유 및 이미지 업로드 과정은 ArchiveFeature에서 진행하던 부분이었으나, 이 주요 로직이 SelectUploadAlbumFeature로 이동하게 되면서 같은 플로우를 타야하는 상황에 AppGroupID를 전달하고 취소할 수 있도록 액션을 다시 이어주었습니다.


## ❗️PR Point
가장 코드 수정량을 최소화하는 방향으로 선택해 진행했습니다.
외부 앱 공유 로직에서만 AppGroupID를 주입하여 SelectUploadAlbumFeature의 State를 초기화해주면 되며, QR스캐너를 포함한 그 외의 로직에서는 불필요합니다.


## 📸 스크린샷
생략합니다.


## 📟 관련 이슈
- Resolved: #213
