### PR TITLE
[Feat] #217 - Firebase Analytics GA4 아카이빙 및 메인 화면 진입 이벤트 로깅 구현

### DIFF
--- a/Neki-iOS/APP/Sources/MainTab/MainTabAnalyticsEvent.swift
+++ b/Neki-iOS/APP/Sources/MainTab/MainTabAnalyticsEvent.swift
@@ -1,0 +1,26 @@
+//
+//  MainTabAnalyticsEvent.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 4/19/26.
+//
+
+import Foundation
+
+public enum MainTabAnalyticsEvent: AnalyticsEvent {
+    case archivingView
+    case poseView
+    case mapView
+    
+    public var name: AnalyticsEventName {
+        switch self {
+        case .archivingView: return .archivingView
+        case .poseView: return .poseView
+        case .mapView: return .mapView
+        }
+    }
+    
+    public var parameters: [AnalyticsParameterKey: Any]? {
+        return nil
+    }
+}

--- a/Neki-iOS/APP/Sources/MainTab/MainTabCoordinator.swift
+++ b/Neki-iOS/APP/Sources/MainTab/MainTabCoordinator.swift
@@ -74,6 +74,9 @@ struct MainTabCoordinator {
         case dismissPermissionAlert
         case openAppSettings
         
+        case onAppear
+        case tabChanged(NekiTab)
+        
         case delegate(Delegate)
         enum Delegate {
             case signedOut
@@ -83,6 +86,7 @@ struct MainTabCoordinator {
     
     @Dependency(\.qrScannerClient) private var qrScannerClient
     @Dependency(\.openURL) private var openURL
+    @Dependency(\.analyticsClient) private var analyticsClient
     
     var body: some ReducerOf<Self> {
         BindingReducer()
@@ -96,6 +100,20 @@ struct MainTabCoordinator {
         Reduce { (state: inout State, action: Action) -> Effect<Action> in
             switch action {
             case .binding: return .none
+                
+            case .onAppear:
+                return .send(.tabChanged(state.selectedTab))
+                
+            case let .tabChanged(tab):
+                return .run { _ in
+                    switch tab {
+                    case .archive: analyticsClient.logEvent(MainTabAnalyticsEvent.archivingView)
+                    case .pose: analyticsClient.logEvent(MainTabAnalyticsEvent.poseView)
+                    case .map: analyticsClient.logEvent(MainTabAnalyticsEvent.mapView)
+                    default: break
+                    }
+                }
+                
             case .onTapAddButton:
                 state.destination = .uploadSelection
                 return .none
@@ -161,7 +179,6 @@ struct MainTabCoordinator {
             case let .archive(.delegate(.showToast(item))):
                 state.toast = item
                 return .none
-                
                 
             case .myPage(.delegate(.didLogout)):
                 return .run { send in

--- a/Neki-iOS/APP/Sources/MainTab/MainTabCoordinatorView.swift
+++ b/Neki-iOS/APP/Sources/MainTab/MainTabCoordinatorView.swift
@@ -44,6 +44,12 @@ struct MainTabCoordinatorView: View {
                 LoadingView(message: "사진을 업로드하고 있어요.")
             }
         }
+        .onAppear {
+            store.send(.onAppear)
+        }
+        .onChange(of: store.selectedTab) { _, newTab in
+            store.send(.tabChanged(newTab))
+        }
         .nekiToast(item: $store.toast)
         .nekiAlert(
             isPresented: $store.isPermissionAlertPresented,

--- a/Neki-iOS/Core/Sources/Analytics/Sources/Domain/Sources/Clients/AnalyticsClient.swift
+++ b/Neki-iOS/Core/Sources/Analytics/Sources/Domain/Sources/Clients/AnalyticsClient.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Dependencies
 import DependenciesMacros
+import os
 
 @DependencyClient
 public struct AnalyticsClient {
@@ -22,6 +23,7 @@ extension AnalyticsClient: DependencyKey {
         return AnalyticsClient { userID in
             Task.detached(priority: .background) { await repository.setUserSession(with: userID) }
         } logEvent: { event in
+            Logger.domain.info("📊 [GA4 Event] 명칭: \(event.name.value, privacy: .public) | 파라미터: \(String(describing: event.parameters ?? [:]), privacy: .public)")
             Task.detached(priority: .background) { await repository.logEvent(event) }
         }
     }()

--- a/Neki-iOS/Core/Sources/Analytics/Sources/Domain/Sources/Clients/AnalyticsClient.swift
+++ b/Neki-iOS/Core/Sources/Analytics/Sources/Domain/Sources/Clients/AnalyticsClient.swift
@@ -23,7 +23,6 @@ extension AnalyticsClient: DependencyKey {
         return AnalyticsClient { userID in
             Task.detached(priority: .background) { await repository.setUserSession(with: userID) }
         } logEvent: { event in
-            Logger.domain.info("📊 [GA4 Event] 명칭: \(event.name.value, privacy: .public) | 파라미터: \(String(describing: event.parameters ?? [:]), privacy: .public)")
             Task.detached(priority: .background) { await repository.logEvent(event) }
         }
     }()

--- a/Neki-iOS/Core/Sources/Analytics/Sources/Domain/Sources/Clients/AnalyticsClient.swift
+++ b/Neki-iOS/Core/Sources/Analytics/Sources/Domain/Sources/Clients/AnalyticsClient.swift
@@ -26,3 +26,10 @@ extension AnalyticsClient: DependencyKey {
         }
     }()
 }
+
+extension DependencyValues {
+    var analyticsClient: AnalyticsClient {
+        get { self[AnalyticsClient.self] }
+        set { self[AnalyticsClient.self] = newValue }
+    }
+}

--- a/Neki-iOS/Features/Archive/Sources/Domain/Sources/Analytics/ArchiveAnalyticsEvent.swift
+++ b/Neki-iOS/Features/Archive/Sources/Domain/Sources/Analytics/ArchiveAnalyticsEvent.swift
@@ -1,15 +1,8 @@
-//
-//  ArchiveAnalyticsEvent.swift
-//  Neki-iOS
-//
-//  Created by OneTen on 4/19/26.
-//
-
 import Foundation
 
 public enum ArchiveAnalyticsEvent: AnalyticsEvent {
     case archivingView
-    case photoUpload(method: String, count: Int)
+    case photoUpload(method: PhotoUploadMethod, count: Int)
     case albumCreate
     case albumAddFromDetail(albumCount: Int)
     case albumAddFromMulti(photoCount: Int, albumCount: Int)
@@ -37,7 +30,8 @@ public enum ArchiveAnalyticsEvent: AnalyticsEvent {
     public var parameters: [AnalyticsParameterKey: Any]? {
         switch self {
         case let .photoUpload(method, count):
-            return [.method: method, .count: count]
+            let methodString = (method == .qr) ? "qr" : "gallery"
+            return [.method: methodString, .count: count]
             
         case let .albumAddFromDetail(albumCount):
             return [.albumCount: albumCount]

--- a/Neki-iOS/Features/Archive/Sources/Domain/Sources/Analytics/ArchiveAnalyticsEvent.swift
+++ b/Neki-iOS/Features/Archive/Sources/Domain/Sources/Analytics/ArchiveAnalyticsEvent.swift
@@ -1,0 +1,55 @@
+//
+//  ArchiveAnalyticsEvent.swift
+//  Neki-iOS
+//
+//  Created by OneTen on 4/19/26.
+//
+
+import Foundation
+
+public enum ArchiveAnalyticsEvent: AnalyticsEvent {
+    case archivingView
+    case photoUpload(method: String, count: Int)
+    case albumCreate
+    case albumAddFromDetail(albumCount: Int)
+    case albumAddFromMulti(photoCount: Int, albumCount: Int)
+    case photoAddToAlbum(photoCount: Int, albumCount: Int)
+    case photoMove
+    case photoCopy
+    case photoDetailView
+    case photoMemoCreate
+    
+    public var name: AnalyticsEventName {
+        switch self {
+        case .archivingView: return .archivingView
+        case .photoUpload: return .photoUpload
+        case .albumCreate: return .albumCreate
+        case .albumAddFromDetail: return .albumAddFromDetail
+        case .albumAddFromMulti: return .albumAddFromMulti
+        case .photoAddToAlbum: return .photoAddToAlbum
+        case .photoMove: return .photoMove
+        case .photoCopy: return .photoCopy
+        case .photoDetailView: return .photoDetailView
+        case .photoMemoCreate: return .photoMemoCreate
+        }
+    }
+    
+    public var parameters: [AnalyticsParameterKey: Any]? {
+        switch self {
+        case let .photoUpload(method, count):
+            return [.method: method, .count: count]
+            
+        case let .albumAddFromDetail(albumCount):
+            return [.albumCount: albumCount]
+            
+        case let .albumAddFromMulti(photoCount, albumCount):
+            return [.photoCount: photoCount, .albumCount: albumCount]
+            
+        case let .photoAddToAlbum(photoCount, albumCount):
+            return [.photoCount: photoCount, .albumCount: albumCount]
+            
+        default:
+            return nil
+        }
+    }
+}

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/AlbumSelectionFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/AlbumSelectionFeature.swift
@@ -52,7 +52,7 @@ struct AlbumSelectionFeature {
         case tapConfirm
         
         // 내부 통신 결과 처리
-        case taskCompleted(message: String)
+        case taskCompleted(message: String, albumCount: Int)
         case taskFailed(message: String)
         
         // 앨범 생성 액션
@@ -62,7 +62,7 @@ struct AlbumSelectionFeature {
         
         case delegate(DelegateAction)
         enum DelegateAction {
-            case didCompleteTask(message: String)
+            case didCompleteTask(message: String, albumCount: Int)
             case didTapCancel
             case showToast(NekiToastItem)
             case didSelectForUpload(albumId: Int)
@@ -148,6 +148,7 @@ struct AlbumSelectionFeature {
                 
                 let purpose = state.selectionPurpose
                 let targetFolderIDs = Array(state.selectedAlbumIDs)
+                let albumCount = targetFolderIDs.count
                 
                 state.isLoading = true
                 let photoIDs = state.photoIDs
@@ -159,15 +160,13 @@ struct AlbumSelectionFeature {
                         case .duplicate:
                             // 복제 - sourceFolderId 없음
                             try await archiveClient.duplicatePhoto(photoIDs: photoIDs, targetFolderIDs: targetFolderIDs)
-                            analyticsClient.logEvent(ArchiveAnalyticsEvent.photoCopy)
-                            await send(.taskCompleted(message: "사진을 앨범에 추가했어요"))
+                            await send(.taskCompleted(message: "사진을 앨범에 추가했어요", albumCount: albumCount))
                             
                         case .move:
                             // 이동 - sourceFolderId 필수
                             if let sourceFolderId = currentAlbumId {
                                 try await archiveClient.movePhoto(sourceFolderId: sourceFolderId, photoIDs: photoIDs, targetFolderIDs: targetFolderIDs)
-                                analyticsClient.logEvent(ArchiveAnalyticsEvent.photoMove)
-                                await send(.taskCompleted(message: "사진을 앨범으로 이동했어요"))
+                                await send(.taskCompleted(message: "사진을 앨범으로 이동했어요", albumCount: albumCount))
                             } else {
                                 await send(.taskFailed(message: "사진 이동에 실패했어요"))
                             }
@@ -181,9 +180,9 @@ struct AlbumSelectionFeature {
                     }
                 }
                 
-            case let .taskCompleted(message):
+            case let .taskCompleted(message, albumCount):
                 state.isLoading = false
-                return .send(.delegate(.didCompleteTask(message: message)))
+                return .send(.delegate(.didCompleteTask(message: message, albumCount: albumCount)))
                 
             case let .taskFailed(message):
                 state.isLoading = false
@@ -207,7 +206,6 @@ struct AlbumSelectionFeature {
                 }
                 
             case .addFolderResponse(.success):
-                analyticsClient.logEvent(ArchiveAnalyticsEvent.albumCreate)
                 return .merge(
                     .send(.delegate(.showToast(NekiToastItem("새로운 앨범을 추가했어요", style: .success)))),
                     .send(.onAppear)

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/AlbumSelectionFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/AlbumSelectionFeature.swift
@@ -70,6 +70,7 @@ struct AlbumSelectionFeature {
     }
     
     @Dependency(\.archiveClient) var archiveClient
+    @Dependency(\.analyticsClient) var analyticsClient
     
     var body: some ReducerOf<Self> {
         BindingReducer()
@@ -158,12 +159,14 @@ struct AlbumSelectionFeature {
                         case .duplicate:
                             // 복제 - sourceFolderId 없음
                             try await archiveClient.duplicatePhoto(photoIDs: photoIDs, targetFolderIDs: targetFolderIDs)
+                            analyticsClient.logEvent(ArchiveAnalyticsEvent.photoCopy)
                             await send(.taskCompleted(message: "사진을 앨범에 추가했어요"))
                             
                         case .move:
                             // 이동 - sourceFolderId 필수
                             if let sourceFolderId = currentAlbumId {
                                 try await archiveClient.movePhoto(sourceFolderId: sourceFolderId, photoIDs: photoIDs, targetFolderIDs: targetFolderIDs)
+                                analyticsClient.logEvent(ArchiveAnalyticsEvent.photoMove)
                                 await send(.taskCompleted(message: "사진을 앨범으로 이동했어요"))
                             } else {
                                 await send(.taskFailed(message: "사진 이동에 실패했어요"))
@@ -204,6 +207,7 @@ struct AlbumSelectionFeature {
                 }
                 
             case .addFolderResponse(.success):
+                analyticsClient.logEvent(ArchiveAnalyticsEvent.albumCreate)
                 return .merge(
                     .send(.delegate(.showToast(NekiToastItem("새로운 앨범을 추가했어요", style: .success)))),
                     .send(.onAppear)

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveAlbumDetailFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveAlbumDetailFeature.swift
@@ -59,7 +59,7 @@ struct ArchiveAlbumDetailFeature {
         case imagePicker(ImagePickerFeature.Action)
         case processUploadImages(entities: [ImageUploadEntity])
         case registerPhotos(entities: [ImageUploadEntity])
-        case registerPhotosResponse(Result<Void, Error>)
+        case registerPhotosResponse(Result<Int, Error>)
         
         case onTapDuplicateButton
         case onTapMoveButton
@@ -92,6 +92,7 @@ struct ArchiveAlbumDetailFeature {
     @Dependency(\.archiveClient) var archiveClient
     @Dependency(\.imageUploadClient) var imageUploadClient
     @Dependency(\.imageDownloadClient) var imageDownloadClient
+    @Dependency(\.analyticsClient) var analyticsClient
     
     var body: some ReducerOf<Self> {
         BindingReducer()
@@ -138,11 +139,13 @@ struct ArchiveAlbumDetailFeature {
                         let mediaIds = try await imageUploadClient.upload(entities, .photoBooth)
                         let uploads = mediaIds.map { (mediaID: $0, memo: String?.none, uploadMethod: PhotoUploadMethod.direct) }
                         try await archiveClient.registerPhotos(folderId: albumId, uploads: uploads ,favorite: false)
+                        return entities.count
                     }))
                 }
-            case .registerPhotosResponse(.success):
+            case let .registerPhotosResponse(.success(count)):
                 state.isLoading = false
                 return .run { send in
+                    analyticsClient.logEvent(ArchiveAnalyticsEvent.photoUpload(method: .direct, count: count))
                     await send(.delegate(.showToast(NekiToastItem("이미지를 추가했어요", style: .success))))
                     await send(.fetchPhotos)
                 }
@@ -203,11 +206,13 @@ struct ArchiveAlbumDetailFeature {
                 return .none
             case let .albumSelection(.presented(.delegate(delegateAction))):
                 switch delegateAction {
-                case let .didCompleteTask(message):
+                case let .didCompleteTask(message, albumCount):
+                    let photoCount = state.selectedIDs.count
                     state.albumSelection = nil
                     state.isSelectionMode = false
                     state.selectedIDs.removeAll()
                     return .merge(
+                        .run { _ in analyticsClient.logEvent(ArchiveAnalyticsEvent.albumAddFromMulti(photoCount: photoCount, albumCount: albumCount)) },
                         .send(.delegate(.showToast(NekiToastItem(message, style: .success)))),
                         .send(.fetchPhotos)
                     )
@@ -270,14 +275,18 @@ struct ArchiveAlbumDetailFeature {
                 
             case .onTapImportPhotos:
                 state.showDropDownMenu = false
-                state.photoImport = PhotoImportFeature.State(targetAlbumId: state.album.id) // 목적지 ID 주입
+                state.photoImport = PhotoImportFeature.State(targetAlbumId: state.album.id)
                 return .none
                 
             case let .photoImport(.presented(.delegate(delegateAction))):
                 switch delegateAction {
-                case let .didCompleteTask(message):
+                case let .didCompleteTask(message, photoCount):
+                    let albumCount = 1
                     state.photoImport = nil
+                    state.isSelectionMode = false
+                    state.selectedIDs.removeAll()
                     return .merge(
+                        .run { _ in analyticsClient.logEvent(ArchiveAnalyticsEvent.photoAddToAlbum(photoCount: photoCount, albumCount: albumCount)) },
                         .send(.delegate(.showToast(NekiToastItem(message, style: .success)))),
                         .send(.fetchPhotos)
                     )

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveAllAlbumsFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveAllAlbumsFeature.swift
@@ -61,6 +61,7 @@ struct ArchiveAllAlbumsFeature {
     
     @Dependency(\.dismiss) var dismiss
     @Dependency(\.archiveClient) var archiveClient
+    @Dependency(\.analyticsClient) var analyticsClient
     
     var body: some ReducerOf<Self> {
         BindingReducer()
@@ -149,6 +150,7 @@ struct ArchiveAllAlbumsFeature {
                 }
                 
             case .addFolderResponse(.success):
+                analyticsClient.logEvent(ArchiveAnalyticsEvent.albumCreate)
                 let toastItem = NekiToastItem("새로운 앨범을 추가했어요", style: .success)
                 
                 return .merge(

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveAllPhotosFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveAllPhotosFeature.swift
@@ -26,7 +26,6 @@ struct ArchiveAllPhotosFeature {
             return IdentifiedArray(uniqueElements: filtered)
         }
         var isLoading: Bool = false
-        
     }
     
     enum Action: BindableAction {
@@ -62,6 +61,7 @@ struct ArchiveAllPhotosFeature {
     @Dependency(\.dismiss) var dismiss
     @Dependency(\.archiveClient) var archiveClient
     @Dependency(\.imageDownloadClient) var imageDownloadClient
+    @Dependency(\.analyticsClient) var analyticsClient
     
     var body: some ReducerOf<Self> {
         BindingReducer()
@@ -180,12 +180,14 @@ struct ArchiveAllPhotosFeature {
                 
             case let .albumSelection(.presented(.delegate(delegateAction))):
                 switch delegateAction {
-                case let .didCompleteTask(message):
+                case let .didCompleteTask(message, albumCount):
+                    let photoCount = state.selectedIDs.count
                     state.albumSelection = nil
                     state.isSelectionMode = false
                     state.selectedIDs.removeAll()
                     
                     return .merge(
+                        .run { _ in analyticsClient.logEvent(ArchiveAnalyticsEvent.albumAddFromMulti(photoCount: photoCount, albumCount: albumCount)) },
                         .send(.delegate(.showToast(NekiToastItem(message, style: .success)))),
                         .send(.fetchPhotos)
                     )

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFavoriteAlbumFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFavoriteAlbumFeature.swift
@@ -43,7 +43,7 @@ struct ArchiveFavoriteAlbumFeature {
         case imagePicker(ImagePickerFeature.Action)
         case processUploadImages(entities: [ImageUploadEntity])
         case registerPhotos(entities: [ImageUploadEntity])
-        case registerPhotosResponse(Result<Void, Error>)
+        case registerPhotosResponse(Result<Int, Error>)
         case onTapDeleteButton
         case deletePhotos
         case deletePhotosResponse(Result<Void, Error>)
@@ -63,6 +63,7 @@ struct ArchiveFavoriteAlbumFeature {
     @Dependency(\.archiveClient) var archiveClient
     @Dependency(\.imageUploadClient) var imageUploadClient
     @Dependency(\.imageDownloadClient) var imageDownloadClient
+    @Dependency(\.analyticsClient) var analyticsClient
     
     var body: some ReducerOf<Self> {
         BindingReducer()
@@ -115,12 +116,14 @@ struct ArchiveFavoriteAlbumFeature {
                         let mediaIds = try await imageUploadClient.upload(entities, .photoBooth)
                         let uploads = mediaIds.map { (mediaID: $0, memo: String?.none, uploadMethod: PhotoUploadMethod.direct) }
                         try await archiveClient.registerPhotos(folderId: nil, uploads: uploads, favorite: true)
+                        return entities.count
                     }))
                 }
                 
-            case .registerPhotosResponse(.success):
+            case let .registerPhotosResponse(.success(count)):
                 state.isLoading = false
                 return .run { send in
+                    analyticsClient.logEvent(ArchiveAnalyticsEvent.photoUpload(method: .direct, count: count))
                     await send(.delegate(.showToast(NekiToastItem("이미지를 추가했어요", style: .success))))
                     await send(.fetchFavoritePhotos)
                 }
@@ -133,7 +136,7 @@ struct ArchiveFavoriteAlbumFeature {
                 guard !state.isFetchingPhotos else { return .none }
                 state.isFetchingPhotos = true
                 return .run { send in
-                    await send(.favoritePhotoListResponse(Result { try await archiveClient.fetchFavoritePhotoList(20, "DESC") }))
+                    await send(.favoritePhotoListResponse(Result { try await archiveClient.fetchFavoritePhotoList(size: 20, sortOrder: "DESC") }))
                 }
                 
             case let .favoritePhotoListResponse(.success(result)):
@@ -168,7 +171,6 @@ struct ArchiveFavoriteAlbumFeature {
                 }
                 return .none
                 
-            // 💡 캡슐화 적용
             case .onTapDuplicateButton:
                 state.albumSelection = AlbumSelectionFeature.State(photoIDs: Array(state.selectedIDs), selectionPurpose: .duplicate, currentAlbumId: state.album.id)
                 return .none
@@ -179,12 +181,14 @@ struct ArchiveFavoriteAlbumFeature {
                 
             case let .albumSelection(.presented(.delegate(delegateAction))):
                 switch delegateAction {
-                case let .didCompleteTask(message):
+                case let .didCompleteTask(message, albumCount):
+                    let photoCount = state.selectedIDs.count
                     state.albumSelection = nil
                     state.isSelectionMode = false
                     state.selectedIDs.removeAll()
                     
                     return .merge(
+                        .run { _ in analyticsClient.logEvent(ArchiveAnalyticsEvent.albumAddFromMulti(photoCount: photoCount, albumCount: albumCount)) },
                         .send(.delegate(.showToast(NekiToastItem(message, style: .success)))),
                         .send(.fetchFavoritePhotos)
                     )
@@ -221,7 +225,7 @@ struct ArchiveFavoriteAlbumFeature {
             case .deletePhotos:
                 let idsToDelete = Array(state.selectedIDs)
                 return .run { send in
-                    await send(.deletePhotosResponse(Result { try await archiveClient.deletePhotoList(idsToDelete) }))
+                    await send(.deletePhotosResponse(Result { try await archiveClient.deletePhotoList(photoIds: idsToDelete) }))
                 }
                 
             case .deletePhotosResponse(.success):

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFeature.swift
@@ -85,6 +85,7 @@ struct ArchiveFeature {
     @Dependency(\.archiveClient) var archiveClient
     @Dependency(\.imageUploadClient) var imageUploadClient
     @Dependency(\.sharedImageClient) var sharedImageClient
+    @Dependency(\.analyticsClient) var analyticsClient
     
     var body: some ReducerOf<Self> {
         BindingReducer()
@@ -138,6 +139,7 @@ struct ArchiveFeature {
                 }
                 
             case .addFolderResponse(.success):
+                analyticsClient.logEvent(ArchiveAnalyticsEvent.albumCreate)
                 return .run { send in
                     await send(.delegate(.showToast(NekiToastItem("새로운 앨범을 추가했어요", style: .success))))
                     await send(.fetchAlbums)

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFeature.swift
@@ -98,9 +98,7 @@ struct ArchiveFeature {
             case .clearData:
                 state.photos.removeAll()
                 state.albums.removeAll()
-                return .run { _ in
-                    await archiveClient.clearCache()
-                }
+                return .run { _ in await archiveClient.clearCache() }
                 
             case .onAppear:
                 return .merge(.send(.fetchAlbums), .send(.fetchPhotos))
@@ -135,7 +133,7 @@ struct ArchiveFeature {
                 state.newAlbumTitle = ""
                 state.albumTitleErrorMessage = nil
                 return .run { send in
-                    await send(.addFolderResponse(Result { try await archiveClient.addFolder(title) }))
+                    await send(.addFolderResponse(Result { try await archiveClient.addFolder(name: title) }))
                 }
                 
             case .addFolderResponse(.success):
@@ -192,7 +190,7 @@ struct ArchiveFeature {
                 guard !state.isFetchingPhotos else { return .none }
                 state.isFetchingPhotos = true
                 return .run { send in
-                    await send(.photoListResponse(Result { try await archiveClient.fetchPhotoList(nil, nil, nil) }))
+                    await send(.photoListResponse(Result { try await archiveClient.fetchPhotoList(folderId: nil, size: nil, sortOrder: nil) }))
                 }
                 
             case let .photoListResponse(.success(entities)):
@@ -275,7 +273,8 @@ struct ArchiveFeature {
                 
             case let .addPhotoFromQRScanner(imageID):
                 return .run { send in
-                    try await archiveClient.registerPhotos(nil, [(imageID, nil, PhotoUploadMethod.qr)], false)
+                    try await archiveClient.registerPhotos(folderId: nil, uploads: [(imageID, nil, PhotoUploadMethod.qr)], favorite: false)
+                    analyticsClient.logEvent(ArchiveAnalyticsEvent.photoUpload(method: .qr, count: 1))
                     await send(.delegate(.showToast(NekiToastItem("이미지를 추가했어요", style: .success))))
                     await send(.fetchPhotos)
                 } catch: { error, send in

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchivePhotoDetailFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchivePhotoDetailFeature.swift
@@ -85,7 +85,8 @@ struct ArchivePhotoDetailFeature {
             switch action {
                 
             case .onAppear:
-                return .run( _ in analyticsClient.logEvent(ArchiveAnalyticsEvent.photoDetailView) )
+                analyticsClient.logEvent(ArchiveAnalyticsEvent.photoDetailView)
+                return .none
                 
             case .onTapBackButton:
                 return .run { _ in await dismiss() }

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchivePhotoDetailFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchivePhotoDetailFeature.swift
@@ -37,6 +37,8 @@ struct ArchivePhotoDetailFeature {
     enum Action: BindableAction {
         case binding(BindingAction<State>)
         
+        case onAppear
+        
         case toggleMemoVisibility
         case toggleMemoExpanded(Bool)
         case startMemoEditing
@@ -81,6 +83,9 @@ struct ArchivePhotoDetailFeature {
         
         Reduce { state, action in
             switch action {
+                
+            case .onAppear:
+                return .run( _ in analyticsClient.logEvent(ArchiveAnalyticsEvent.photoDetailView) )
                 
             case .onTapBackButton:
                 return .run { _ in await dismiss() }

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchivePhotoDetailFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchivePhotoDetailFeature.swift
@@ -74,6 +74,7 @@ struct ArchivePhotoDetailFeature {
     @Dependency(\.dismiss) var dismiss
     @Dependency(\.archiveClient) var archiveClient
     @Dependency(\.imageDownloadClient) var imageDownloadClient
+    @Dependency(\.analyticsClient) var analyticsClient
     
     var body: some ReducerOf<Self> {
         BindingReducer()
@@ -122,6 +123,7 @@ struct ArchivePhotoDetailFeature {
                 
                 return .run { send in
                     try? await archiveClient.updatePhotoMemo(photoID: photoID, memo: limitedText)
+                    analyticsClient.logEvent(ArchiveAnalyticsEvent.photoMemoCreate)
                 }
                 
             case .clearAllMemoEditing:

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchivePhotoDetailFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchivePhotoDetailFeature.swift
@@ -167,11 +167,19 @@ struct ArchivePhotoDetailFeature {
                 state.albumSelection = AlbumSelectionFeature.State(photoIDs: [state.currentItemID], selectionPurpose: .duplicate, currentAlbumId: state.folderId)
                 return .none
                 
+            // 🌟 에러 수정 및 단일 상세 앨범 추가 GA4 로깅 적용 부분
             case let .albumSelection(.presented(.delegate(delegateAction))):
                 switch delegateAction {
-                case let .didCompleteTask(message):
+                case let .didCompleteTask(message, albumCount): // 💡 누락되었던 albumCount 파라미터 추가!
                     state.albumSelection = nil
-                    return .send(.delegate(.showToast(NekiToastItem(message, style: .success))))
+                    
+                    return .merge(
+                        .run { _ in
+                            // 🌟 요구사항: 단일 정리 행동 분석 (album_add_from_detail)
+                            analyticsClient.logEvent(ArchiveAnalyticsEvent.albumAddFromDetail(albumCount: albumCount))
+                        },
+                        .send(.delegate(.showToast(NekiToastItem(message, style: .success))))
+                    )
                     
                 case .didTapCancel:
                     state.albumSelection = nil
@@ -180,7 +188,7 @@ struct ArchivePhotoDetailFeature {
                 case let .showToast(toastItem):
                     return .send(.delegate(.showToast(toastItem)))
                     
-                case .didSelectForUpload(albumId: _):
+                case .didSelectForUpload:
                     return .none
                 }
                 

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/PhotoImportFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/PhotoImportFeature.swift
@@ -54,12 +54,12 @@ struct PhotoImportFeature {
         case tapClose
         case tapUpload
         
-        case taskCompleted(message: String)
+        case taskCompleted(message: String, photoCount: Int)
         case taskFailed(message: String)
         
         case delegate(DelegateAction)
         enum DelegateAction {
-            case didCompleteTask(message: String)
+            case didCompleteTask(message: String, photoCount: Int)
             case didTapCancel
             case showToast(NekiToastItem)
         }
@@ -187,20 +187,21 @@ struct PhotoImportFeature {
                 state.isLoading = true
                 
                 let photoIDs = Array(state.selectedIDs)
+                let photoCount = photoIDs.count
                 let targetFolderIDs = [state.targetAlbumId]
                 
                 return .run { send in
                     do {
                         try await archiveClient.duplicatePhoto(photoIDs: photoIDs, targetFolderIDs: targetFolderIDs)
-                        await send(.taskCompleted(message: "사진을 앨범에 가져왔어요"))
+                        await send(.taskCompleted(message: "사진을 앨범에 가져왔어요", photoCount: photoCount))
                     } catch {
                         await send(.taskFailed(message: "사진을 가져오지 못했어요"))
                     }
                 }
                 
-            case let .taskCompleted(message):
+            case let .taskCompleted(message, photoCount):
                 state.isLoading = false
-                return .send(.delegate(.didCompleteTask(message: message)))
+                return .send(.delegate(.didCompleteTask(message: message, photoCount: photoCount)))
                 
             case let .taskFailed(message):
                 state.isLoading = false

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/SelectUploadAlbumFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/SelectUploadAlbumFeature.swift
@@ -53,6 +53,7 @@ struct SelectUploadAlbumFeature {
     @Dependency(\.imageUploadClient) var imageUploadClient
     @Dependency(\.sharedImageClient) var sharedImageClient
     @Dependency(\.dismiss) var dismiss
+    @Dependency(\.analyticsClient) var analyticsClient
     
     var body: some ReducerOf<Self> {
         BindingReducer()
@@ -103,7 +104,11 @@ struct SelectUploadAlbumFeature {
                 
             case let .uploadResponse(.success(albumId)):
                 state.isLoading = false
-                return .send(.delegate(.uploadDidSuccess(albumId: albumId)))
+                let count = state.pendingUploadImages.count
+                return .merge(
+                    .run { _ in analyticsClient.logEvent(ArchiveAnalyticsEvent.photoUpload(method: .direct, count: count)) },
+                    .send(.delegate(.uploadDidSuccess(albumId: albumId)))
+                )
                 
             case let .uploadResponse(.failure(error)):
                 state.isLoading = false

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveAlbumDetailView.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveAlbumDetailView.swift
@@ -54,6 +54,7 @@ struct ArchiveAlbumDetailView: View {
                 LoadingView(message: "요청을 처리하고 있어요.")
             }
         }
+        .animation(.easeInOut(duration: 0.3), value: store.isFetchingPhotos)
         .animation(.easeInOut(duration: 0.3), value: store.photos)
         .task { await store.send(.onAppear).finish() }
         .fullScreenCover(item: $store.scope(state: \.albumSelection, action: \.albumSelection)) { selectionStore in

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveAllPhotosView.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveAllPhotosView.swift
@@ -55,6 +55,7 @@ struct ArchiveAllPhotosView: View {
                 
             }
         }
+        .animation(.easeInOut(duration: 0.3), value: store.isFetchingPhotos)
         .animation(.easeInOut(duration: 0.3), value: store.photos)
         .nekiAlert(
             isPresented: $showDeleteAlert,

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveAllPhotosView.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveAllPhotosView.swift
@@ -182,7 +182,7 @@ private extension ArchiveAllPhotosView {
     var filterBar: some View {
         HStack(alignment: .center, spacing: 6) {
             Button(store.state.selectedSortedTime) {
-                withAnimation { showDropDownMenu.toggle() }
+                showDropDownMenu.toggle()
             }
             .buttonStyle(
                 .nekiChip(

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveFavoriteAlbumView.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveFavoriteAlbumView.swift
@@ -51,6 +51,7 @@ struct ArchiveFavoriteAlbumView: View {
             }
             
         }
+        .animation(.easeInOut(duration: 0.3), value: store.isFetchingPhotos)
         .animation(.easeInOut(duration: 0.3), value: store.photos)
         .task { await store.send(.onAppear).finish() }
         .fullScreenCover(item: $store.scope(state: \.albumSelection, action: \.albumSelection)) { selectionStore in

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchivePhotoDetailView.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchivePhotoDetailView.swift
@@ -61,6 +61,9 @@ struct ArchivePhotoDetailView: View {
                 .zIndex(10)
             }
         }
+        .onAppear {
+            store.send(.onAppear)
+        }
         .onChange(of: store.currentItemID) { _, _ in
             store.send(.closeDropDownMenu)
             store.send(.binding(.set(\.isMemoVisible, false)))


### PR DESCRIPTION
## 🌴 작업한 브랜치
- feat/#217-analytics-archive


## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
사용자의 주요 UX 흐름(앱 화면 진입, 콘텐츠 업로드, 앨범 정리 패턴)을 분석하기 위해 기획서에 정의된 GA4 이벤트를 추가했습니다.

- archiving_view: 아카이빙 탭(화면)에 진입했을 때 기록됩니다.
- pose_view: 포즈 탭(화면)에 진입했을 때 기록됩니다.
- map_view: 네컷지도 탭(화면)에 진입했을 때 기록됩니다.
- photo_upload: 갤러리나 QR을 통해 기기에 사진 업로드가 최종 완료되었을 때 기록됩니다.
- album_create: 새로운 앨범 생성을 완료했을 때 기록됩니다.
- album_add_from_detail: 단일 사진 상세 화면에서 해당 사진을 앨범에 추가(정리) 완료했을 때 기록됩니다.
- album_add_from_multi: 여러 장의 사진을 다중 선택하여 한 번에 앨범에 추가(정리) 완료했을 때 기록됩니다.
- photo_add_to_album: 특정 앨범 내부에서 '사진 가져오기'를 통해 기존 사진들을 불러와 추가(재구성) 완료했을 때 기록됩니다.
- photo_move: 사진을 다른 앨범으로 완전히 이동 완료했을 때 기록됩니다.
- photo_copy: 사진을 다른 앨범으로 복제 완료했을 때 기록됩니다.
- photo_detail_view: 특정 사진을 눌러 상세 화면에 진입했을 때 기록됩니다.
- photo_memo_create: 사진에 새로운 메모를 작성하여 저장 완료했을 때 기록됩니다.

## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/cf08f4fc-5299-466f-a24b-171f0c44b7e5" width ="250">|


## 📟 관련 이슈
- Resolved: #217 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **UI/UX 개선**
  * 사진 로딩 중 화면 전환 시 부드러운 애니메이션이 추가되었습니다.
  * 앨범 상세, 모든 사진, 즐겨찾기 앨범 화면에서 사진 조회 상태 변화 시 0.3초의 이징 애니메이션이 적용됩니다.

* **개선 사항**
  * 내부 기능 향상을 위해 사진 및 앨범 작업 추적이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->