### PR TITLE
[Fix] #224 - 사진 삭제 시 포함되어 있던 폴더와 모든 사진에서 반영되지 않던 문제 해결

### DIFF
--- a/Neki-iOS/Features/Archive/Sources/Data/Sources/DefaultArchiveRepository.swift
+++ b/Neki-iOS/Features/Archive/Sources/Data/Sources/DefaultArchiveRepository.swift
@@ -362,11 +362,19 @@ extension DefaultArchiveRepository {
         let endpoint = ArchiveEndpoint.deletePhoto(request: request)
         let _ = try await networkProvider.request(endpoint: endpoint)
         
+        for (folderID, list) in photoCache {
+            let containsDeletedPhoto = list.contains(where: { photoIDs.contains($0.photoID) })
+            if containsDeletedPhoto {
+                self.isPhotoCacheDirty[folderID] = true
+            }
+        }
+
         for (key, var list) in photoCache {
             list.removeAll { photoIDs.contains($0.photoID) }
             photoCache[key] = list
         }
         
+        self.isPhotoCacheDirty[nil] = true
         self.isAlbumCacheDirty = true
         self.isFavoriteCacheDirty = true
         self.isFavoriteAlbumInfoDirty = true

--- a/Neki-iOS/Features/Archive/Sources/Data/Sources/DefaultArchiveRepository.swift
+++ b/Neki-iOS/Features/Archive/Sources/Data/Sources/DefaultArchiveRepository.swift
@@ -362,16 +362,15 @@ extension DefaultArchiveRepository {
         let endpoint = ArchiveEndpoint.deletePhoto(request: request)
         let _ = try await networkProvider.request(endpoint: endpoint)
         
-        for (folderID, list) in photoCache {
-            let containsDeletedPhoto = list.contains(where: { photoIDs.contains($0.photoID) })
-            if containsDeletedPhoto {
-                self.isPhotoCacheDirty[folderID] = true
-            }
-        }
-
-        for (key, var list) in photoCache {
+        for (folderID, var list) in photoCache {
+            let originalCount = list.count
             list.removeAll { photoIDs.contains($0.photoID) }
-            photoCache[key] = list
+            
+            // 기존 갯수보다 줄어들었다면 해당 앨범에서 사진이 삭제되었다는 뜻
+            if list.count < originalCount {
+                self.isPhotoCacheDirty[folderID] = true
+                photoCache[folderID] = list
+            }
         }
         
         self.isPhotoCacheDirty[nil] = true


### PR DESCRIPTION
## 🌴 작업한 브랜치
- fix/#224-delete-issue


## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->

사진 삭제 시 포함되어 있던 폴더와 모든 사진에서 반영되지 않던 문제를 해결했습니다.

## ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

간단한 수정이라 생략합니다

## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

마찬가지로 생략합니다

## 📟 관련 이슈
- Resolved: #224 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 사진 삭제 후 사진 목록이 모든 보관함에서 더욱 정확하게 업데이트되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->