### PR TITLE
[Feat] #233 - 모노맨션 브랜드 QR 파싱 전략 추가

### DIFF
--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Repositories/DefaultQRCodeScanRepository.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Repositories/DefaultQRCodeScanRepository.swift
@@ -15,6 +15,7 @@ struct DefaultQRCodeScanRepository: QRCodeScanRepository {
         PhotograyStrategy(),
         PhotoSignatureStrategy(),
         Life4CutStrategy(),
+        MonomansionStrategy(),
         PhotoismStrategy()
     ]
     

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/MonomansionStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/MonomansionStrategy.swift
@@ -6,57 +6,71 @@
 //
 
 import Foundation
+import os
 
-// TODO: 모노맨션 브랜드는 나중에 출시
-//struct MonoMansionStrategy: QRCodeParsingStrategy {
-//    var strategyType: ParsingStrategyType { .htmlCrawling }
-//    
-//    func canHandle(host: String) -> Bool {
-//        PhotoBoothBrand.monoMansion.hostKeywords.contains(host)
-//    }
-//    
-//    func parse(_ url: URL, networkProvider: NetworkProvider) async throws(QRParseError) -> ParsedQRResult {
-//        // 1. HTML 데이터 요청
-//        var request = URLRequest(url: url)
-//        // 봇 차단 방지용 헤더
-//        request.setValue("Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1", forHTTPHeaderField: "User-Agent")
-//        
-//        let data: Data
-//        do {
-//            // 현재 단계에서는 URLSession 직접 사용
-//            (data, _) = try await URLSession.shared.data(for: request)
-//        } catch {
-//            guard let urlError = error as? URLError else { throw .parsingFailed }
-//            switch urlError.code {
-//            case .notConnectedToInternet, .networkConnectionLost:
-//                throw .networkError(.networkFail)
-//            default:
-//                throw .networkError(.unknownError(urlError))
-//            }
-//        }
-//        
-//        // 2. HTML 문자열 변환
-//        guard let htmlString = String(data: data, encoding: .utf8) else {
-//            throw .parsingFailed
-//        }
-//        
-//        // 3. 정규식을 통한 이미지 URL 추출
-//        // 제공된 정규식: href\s*=\s*["'](https://[^"']*ncloudstorage\.com[^"']+\.jpg)["']
-//        // 그룹 1번(괄호 안의 내용)이 실제 URL입니다.
-//        let pattern = "href\\s*=\\s*[\"'](https://[^\"']*ncloudstorage\\.com[^\"']+\\.jpg)[\"']"
-//        
-//        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
-//              let match = regex.firstMatch(in: htmlString, options: [], range: NSRange(location: 0, length: htmlString.utf16.count)),
-//              let range = Range(match.range(at: 1), in: htmlString) else {
-//            throw .parsingFailed
-//        }
-//        
-//        let imageURLString = String(htmlString[range])
-//        
-//        guard let imageURL = URL(string: imageURLString) else {
-//            throw .urlConstructionFailed
-//        }
-//        
-//        return ParsedQRResult(brand: .monoMansion, originalImageURL: imageURL)
-//    }
-//}
+struct MonomansionStrategy: QRCodeParsingStrategy {
+    var strategyType: ParsingStrategyType { .htmlCrawling }
+    
+    func canHandle(host: String) -> Bool { QRCodeBrand.monoMansion.hostKeywords.contains { host.lowercased().contains($0.lowercased()) } }
+    
+    func parse(_ url: URL, networkProvider: NetworkProvider) async throws(QRParseError) -> ParsedQRResult {
+        Logger.data.debug("모노맨션 파싱 시도: \(url.absoluteString)")
+        
+        let request = URLRequest(url: url)
+        let htmlData: Data
+        
+        do {
+            (htmlData, _) = try await URLSession.shared.data(for: request)
+        } catch {
+            Logger.network.error("모노맨션 HTML 요청 실패: \(error.localizedDescription)")
+            if let urlError = error as? URLError,
+               [.notConnectedToInternet, .networkConnectionLost].contains(urlError.code) {
+                throw .networkError(.networkFail)
+            }
+            throw .fallbackToWebView(url)
+        }
+        
+        guard let htmlString = String(data: htmlData, encoding: .utf8) else {
+            Logger.domain.warning("모노맨션 HTML 문자열 변환 실패.")
+            throw .fallbackToWebView(url)
+        }
+        
+        let pattern = #"href\s*=\s*["'](https://[^"']*ncloudstorage\.com[^"']+\.jpg)["']"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+              let match = regex.firstMatch(
+                in: htmlString,
+                options: [],
+                range: NSRange(location: 0, length: htmlString.utf16.count)
+              ),
+              let range = Range(match.range(at: 1), in: htmlString)
+        else {
+            Logger.domain.warning("모노맨션 이미지 URL 추출 실패. 웹뷰 폴백.")
+            throw .fallbackToWebView(url)
+        }
+        
+        let imageURLString = String(htmlString[range])
+            .replacingOccurrences(of: "&amp;", with: "&")
+        
+        guard let imageURL = URL(string: imageURLString) else {
+            Logger.domain.error("모노맨션 이미지 URL 생성 실패.")
+            throw .fallbackToWebView(url)
+        }
+        
+        do {
+            let (data, response) = try await URLSession.shared.data(from: imageURL)
+            
+            if let httpResponse = response as? HTTPURLResponse,
+               (200..<300).contains(httpResponse.statusCode) == false {
+                Logger.network.warning("모노맨션 이미지 다운로드 실패 (상태코드: \(httpResponse.statusCode)). 웹뷰 폴백.")
+                throw QRParseError.fallbackToWebView(url)
+            }
+            
+            return ParsedQRResult(brand: .monoMansion, originalImage: data)
+        } catch let error as QRParseError {
+            throw error
+        } catch {
+            Logger.network.warning("모노맨션 이미지 다운로드 실패: \(error.localizedDescription)")
+            throw .imageDownloadFailed
+        }
+    }
+}

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/MonomansionStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/MonomansionStrategy.swift
@@ -35,7 +35,7 @@ struct MonomansionStrategy: QRCodeParsingStrategy {
             throw .fallbackToWebView(url)
         }
         
-        let pattern = #"href\s*=\s*["'](https://[^"']*ncloudstorage\.com[^"']+\.jpg)["']"#
+        let pattern = #"href\s*=\s*["'](https://[^"']*ncloudstorage\.com[^"']+\.jpg(?:\?[^"']*)?)["']"#
         guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
               let match = regex.firstMatch(
                 in: htmlString,

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/PhotosignatureStrategy.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Data/Sources/Strategies/Implementations/PhotosignatureStrategy.swift
@@ -16,6 +16,10 @@ struct PhotoSignatureStrategy: QRCodeParsingStrategy {
     func parse(_ url: URL, networkProvider: NetworkProvider) async throws(QRParseError) -> ParsedQRResult {
         Logger.data.debug("포토시그니처 파싱 시도: \(url.absoluteString)")
         
+        if url.host() == "photosignature-viewer.web.app" {
+            return try await parseViewerURL(url)
+        }
+        
         let urlString = url.absoluteString
         var imageURLString = String()
         
@@ -47,5 +51,58 @@ struct PhotoSignatureStrategy: QRCodeParsingStrategy {
             Logger.network.warning("이미지 없음(404 등). 만료 확인.")
             throw .imageDownloadFailed
         }
+    }
+}
+
+private extension PhotoSignatureStrategy {
+    func parseViewerURL(_ url: URL) async throws(QRParseError) -> ParsedQRResult {
+        guard let sessionID = sessionID(from: url) else {
+            Logger.domain.warning("포토시그니처 뷰어 URL에서 sessionID 추출 실패. 웹뷰 폴백.")
+            throw .fallbackToWebView(url)
+        }
+        
+        guard let imageURL = URL(string: "https://photosignature-asset-cdn.photosignature.workers.dev/sessions/\(sessionID)/final.jpg") else {
+            Logger.domain.error("포토시그니처 뷰어 이미지 URL 생성 실패.")
+            throw .fallbackToWebView(url)
+        }
+        
+        do {
+            let (data, response) = try await URLSession.shared.data(from: imageURL)
+            
+            if let httpResponse = response as? HTTPURLResponse,
+               (200..<300).contains(httpResponse.statusCode) == false {
+                Logger.domain.notice("포토시그니처 뷰어 이미지 다운로드 에러. 웹뷰 폴백.")
+                throw QRParseError.fallbackToWebView(url)
+            }
+            
+            return ParsedQRResult(brand: .photosignature, originalImage: data)
+        } catch let error as QRParseError {
+            throw error
+        } catch {
+            Logger.network.warning("포토시그니처 뷰어 이미지 없음(404 등). 만료 확인.")
+            throw .imageDownloadFailed
+        }
+    }
+    
+    func sessionID(from url: URL) -> String? {
+        if let fragment = url.fragment,
+           let sessionID = sessionID(fromRoute: fragment) {
+            return sessionID
+        }
+        
+        return sessionID(fromRoute: url.path())
+    }
+    
+    func sessionID(fromRoute route: String) -> String? {
+        let routeWithoutQuery = route.split(separator: "?", maxSplits: 1).first.map(String.init) ?? route
+        let pathComponents = routeWithoutQuery
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            .split(separator: "/")
+        
+        guard let viewIndex = pathComponents.firstIndex(of: "view") else { return nil }
+        let sessionIDIndex = pathComponents.index(after: viewIndex)
+        
+        guard pathComponents.indices.contains(sessionIDIndex) else { return nil }
+        return String(pathComponents[sessionIDIndex])
     }
 }

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Entities/QRCodeBrand.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Entities/QRCodeBrand.swift
@@ -15,6 +15,7 @@ public enum QRCodeBrand: CustomStringConvertible, Sendable {
     case photoism
     case photogray
     case photosignature
+    case monoMansion
     case planBStudio
     case harufilm
     
@@ -24,6 +25,7 @@ public enum QRCodeBrand: CustomStringConvertible, Sendable {
         case .photoism: ["seobuk.kr"]
         case .photogray: ["aprd.io", "pgshort.aprd.io"]
         case .photosignature: ["photoqr3.kr"]
+        case .monoMansion: ["qr.mono-mansion.com"]
         case .planBStudio: []
         case .harufilm: ["haru4.mx2.co.kr", "haru3.mx2.co.kr", "haru2.mx2.co.kr", "haru1.mx2.co.kr", "haru.mx2.co.kr"]
         }
@@ -35,6 +37,7 @@ public enum QRCodeBrand: CustomStringConvertible, Sendable {
         case .photoism: return "포토이즘"
         case .photogray: return "포토그레이"
         case .photosignature: return "포토시그니처"
+        case .monoMansion: return "모노맨션"
         case .planBStudio: return "플랜비스튜디오"
         case .harufilm: return "하루필름"
         }

--- a/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Entities/QRCodeBrand.swift
+++ b/Neki-iOS/Features/QRCodeScanner/Sources/Domain/Sources/Entities/QRCodeBrand.swift
@@ -24,7 +24,7 @@ public enum QRCodeBrand: CustomStringConvertible, Sendable {
         case .life4cut: ["life4cut.net", "api.life4cut.net", "life-4cut.net"]
         case .photoism: ["seobuk.kr"]
         case .photogray: ["aprd.io", "pgshort.aprd.io"]
-        case .photosignature: ["photoqr3.kr"]
+        case .photosignature: ["photoqr3.kr", "photosignature-viewer.web.app"]
         case .monoMansion: ["qr.mono-mansion.com"]
         case .planBStudio: []
         case .harufilm: ["haru4.mx2.co.kr", "haru3.mx2.co.kr", "haru2.mx2.co.kr", "haru1.mx2.co.kr", "haru.mx2.co.kr"]


### PR DESCRIPTION
## 🌴 작업한 브랜치
- feat/#233-monomansion-parsing-strategy


## ✅ 작업한 내용
- QRCodeBrand에 모노맨션 브랜드를 추가했습니다.
- 모노맨션 QR URL 호스트(`qr.mono-mansion.com`)를 인식하도록 host keyword를 등록했습니다.
- `MonomansionStrategy`를 `.htmlCrawling` 전략으로 구현했습니다.
- 모노맨션 QR 페이지 HTML에서 `ncloudstorage.com` 원본 이미지 URL을 추출하도록 구현했습니다.
- 추출한 이미지 URL을 통해 원본 이미지 데이터를 다운로드하도록 구현했습니다.
- `DefaultQRCodeScanRepository`에 `MonomansionStrategy`를 등록했습니다.


## ❗️PR Point
- 실제 확보한 QR URL(`https://qr.mono-mansion.com/nO7qKdnR`)을 QR 이미지로 생성해 스캐너로 검증했습니다.
- 전략이 정상적으로 실행되고, HTML 내 원본 이미지 URL을 통해 실제 원본 이미지 확보가 가능함을 확인했습니다.
- 기존 파싱 전략들과 크게 다른 부분이 없어서 PR 포인트도 많이 없을 것 같습니다.


## 📸 스크린샷
생략합니다.


## 📟 관련 이슈
- Resolved: #233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 모노맨션 QR 코드 지원 추가: 앱이 모노맨션 브랜드의 QR을 인식하고 이미지 추출을 시도합니다. 실패 시 안전하게 웹뷰로 이어집니다.
  * photosignature 뷰어용 URL 처리 추가: 특정 뷰어 링크에서 세션 ID를 추출해 CDN 이미지를 직접 가져옵니다.
* **버그 수정**
  * photosignature 관련 파싱 실패 시 더 안정적인 폴백 동작 적용.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YAPP-Github/Neki-iOS/pull/234)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->