### PR TITLE
[Fix] #235 - 지도 POI 검색 디버깅

### DIFF
--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/MapInitialSearchState.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/MapInitialSearchState.swift
@@ -1,0 +1,17 @@
+//
+//  MapInitialSearchState.swift
+//  Neki-iOS
+//
+//  Created by OpenAI Codex on 5/6/26.
+//
+
+import Foundation
+
+/// 지도 진입 직후 첫 POI 검색이 가능한지 표현하는 상태
+public enum MapInitialSearchState: Sendable, Equatable {
+    case awaitingPermission
+    case waitingForUserLocation
+    case readyForDefaultLocation
+    case readyForUserLocation
+    case completed
+}

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
@@ -37,8 +37,8 @@ public struct MapFeature {
         var isSDKAuthSuccessful: Bool = false
         var detent: NekiSheetDetent = SheetStage.first.detent
         var isSearchHereButtonVisible: Bool = false
-        var isFirstLoad: Bool = true
         var isPermissionAlertPresented: Bool = false
+        var initialSearchState: MapInitialSearchState = .awaitingPermission
         
         // Map State
         var cameraPosition: GeographicCoordinate?
@@ -89,6 +89,7 @@ public struct MapFeature {
         case setUserTrackingMode(Bool)
         case didDetectMapInteraction
         case presentPermissionAlert
+        case attemptInitialSearch
         
         // Map Logic Actions
         case mapLoaded(GeographicBoundingBox)
@@ -169,6 +170,7 @@ public struct MapFeature {
                 state.locationAuthorizationStatus = status
                 switch status {
                 case .authorizedAlways, .authorizedWhenInUse:
+                    state.initialSearchState = .waitingForUserLocation
                     return .merge(
                         .run { send in
                             for await location in await mapClient.trackingLocation() {
@@ -179,17 +181,14 @@ public struct MapFeature {
                     )
                     
                 case .notDetermined:
+                    state.initialSearchState = .awaitingPermission
                     return state.locationAuthorizationNeeded ? .send(.requestPermission) : .none
                     
                 case .denied, .restricted:
                     state.isUserTrackingMode = false
-                    
-                    guard state.isFirstLoad, let bounds = state.currentBounds else { return .none }
-                    state.isFirstLoad = false
-                    return .merge(
-                        .send(.fetchPhotoBooths(bounds: bounds)),
-                        .send(.fetchNearbyPhotoBooths(bounds.center))
-                    )
+                    state.initialSearchState = .readyForDefaultLocation
+                    updateCameraPosition(&state, to: Constants.defaultInitialPosition.coordinate)
+                    return .send(.attemptInitialSearch)
                     
                 @unknown default:
                     return .none
@@ -214,7 +213,7 @@ public struct MapFeature {
             case let .mapLoaded(bounds):
                 state.currentBounds = bounds
                 state.cameraPosition = bounds.center
-                return .none
+                return .send(.attemptInitialSearch)
                 
             case .didTapCurrentLocationButton:
                 resetToMapMode(&state, for: .first)
@@ -234,11 +233,14 @@ public struct MapFeature {
             case let .updateUserLocation(.success(location)):
                 state.userLocation = location
                 
-                if state.isFirstLoad || state.isUserTrackingMode {
+                if state.isUserTrackingMode {
                     updateCameraPosition(&state, to: location.coordinate)
-                    guard state.isFirstLoad else { return .none }
-                    state.isSearchHereButtonVisible = false
                 }
+                
+                guard state.initialSearchState == .waitingForUserLocation else { return .none }
+                state.isSearchHereButtonVisible = false
+                state.initialSearchState = .readyForUserLocation
+                updateCameraPosition(&state, to: location.coordinate)
                 return .none
                 
             case .updateUserLocation(.failure):
@@ -263,21 +265,7 @@ public struct MapFeature {
             case let .cameraMotionEnded(bounds):
                 state.currentBounds = bounds
                 state.cameraPosition = bounds.center
-                
-                guard state.isFirstLoad else { return .none }
-                guard state.locationAuthorizationStatus != .notDetermined else { return .none }
-                
-                let targetCoordinate = state.isLocationAuthorized ? (state.userLocation ?? Constants.defaultInitialPosition) : Constants.defaultInitialPosition
-                let currentCameraLocation = CLLocation(latitude: bounds.center.latitude, longitude: bounds.center.longitude)
-                
-                guard currentCameraLocation.distance(from: targetCoordinate) <= Constants.cameraTargetDistanceThreshold else { return .none }
-                state.isFirstLoad = false
-                let nearbyTargetCoordinate = state.userGeographicCoordinate ?? bounds.center
-                state.lastSearchedLocation = currentCameraLocation
-                return .merge(
-                    .send(.fetchPhotoBooths(bounds: bounds)),
-                    .send(.fetchNearbyPhotoBooths(nearbyTargetCoordinate))
-                )
+                return .send(.attemptInitialSearch)
                 
             case let .updateSearchButtonVisibility(isVisible):
                 state.isSearchHereButtonVisible = isVisible
@@ -285,7 +273,6 @@ public struct MapFeature {
                 
             case .didTapSearchHereButton:
                 guard let bounds = state.currentBounds else { return .none }
-                let nearbyTargetCoordinate = state.userGeographicCoordinate ?? bounds.center
                 let currentCenterLocation = CLLocation(latitude: bounds.center.latitude, longitude: bounds.center.longitude)
                 let isRegionChanged = checkIfRegionChanged(from: state.lastSearchedLocation, to: currentCenterLocation)
                 let hasFilter = state.photoBoothListState.filteredBrands.isEmpty == false
@@ -294,7 +281,22 @@ public struct MapFeature {
                 return .merge(
                     .run { _ in analytics.logEvent(event: event) },
                     .send(.fetchPhotoBooths(bounds: bounds)),
-                    .send(.fetchNearbyPhotoBooths(nearbyTargetCoordinate))
+                    nearbyPhotoBoothsEffect(for: state)
+                )
+                
+            case .attemptInitialSearch:
+                guard let bounds = state.currentBounds else { return .none }
+                guard let targetCoordinate = initialSearchTargetCoordinate(for: state) else { return .none }
+                
+                let currentCameraLocation = CLLocation(latitude: bounds.center.latitude, longitude: bounds.center.longitude)
+                let targetLocation = CLLocation(latitude: targetCoordinate.latitude, longitude: targetCoordinate.longitude)
+                
+                guard currentCameraLocation.distance(from: targetLocation) <= Constants.cameraTargetDistanceThreshold else { return .none }
+                state.initialSearchState = .completed
+                state.lastSearchedLocation = currentCameraLocation
+                return .merge(
+                    .send(.fetchPhotoBooths(bounds: bounds)),
+                    nearbyPhotoBoothsEffect(for: state)
                 )
                 
                 // MARK: - Data Fetching
@@ -468,5 +470,31 @@ private extension MapFeature {
     func checkIfRegionChanged(from lastLocation: CLLocation?, to currentLocation: CLLocation) -> Bool {
         guard let lastLocation else { return false }
         return currentLocation.distance(from: lastLocation) >= Constants.regionChangeDistanceThreshold
+    }
+    
+    func initialSearchTargetCoordinate(for state: State) -> GeographicCoordinate? {
+        switch state.initialSearchState {
+        case .awaitingPermission, .waitingForUserLocation, .completed:
+            return nil
+        case .readyForDefaultLocation:
+            return .init(
+                latitude: Constants.defaultInitialPosition.coordinate.latitude,
+                longitude: Constants.defaultInitialPosition.coordinate.longitude
+            )
+        case .readyForUserLocation:
+            return state.userGeographicCoordinate
+        }
+    }
+    
+    func nearbyPhotoBoothsEffect(for state: State) -> Effect<Action> {
+        guard let userGeographicCoordinate = state.userGeographicCoordinate else {
+            let emptyBooths = IdentifiedArrayOf<PhotoBooth>()
+            return .merge(
+                .send(.photoBoothListAction(.setNearbyBooths(emptyBooths))),
+                .send(.photoBoothListAction(.setVisibleBooths(emptyBooths)))
+            )
+        }
+        
+        return .send(.fetchNearbyPhotoBooths(userGeographicCoordinate))
     }
 }


### PR DESCRIPTION
## 🌴 작업한 브랜치
- `fix/#235-map-initial-search-debug`


## ✅ 작업한 내용
- Map 진입 시 초기 POI 검색 조건을 `isFirstLoad` 단일 플래그가 아닌 `MapInitialSearchState` 기반 상태로 재구성했습니다.
- 위치 권한이 `notDetermined`인 경우 즉시 검색하지 않고, 권한 요청 플로우를 거친 뒤 권한 결과에 따라 후속 동작으로 회귀하도록 정리했습니다.
- 위치 권한이 허용된 경우, 실제 `userLocation` 확보 전에는 기본 좌표 기준 초기 검색이 실행되지 않도록 수정했습니다.
- 위치 권한이 거부되었거나 제한된 경우에는 기존 기획대로 기본좌표(강남역) 기준으로 지도와 POI가 로드되도록 유지했습니다.
- 지도 초기 `cameraIdle` 이벤트와 실제 검색 가능 상태를 분리해, 초기 카메라가 임시 기본좌표인 상태에서 잘못된 POI가 노출되던 문제를 해결했습니다.
- 주변 포토부스 목록은 기획 의도에 맞게 항상 현재 위치 기준으로만 조회되도록 정리했고, 현재 위치가 없는 경우에는 기본좌표/지도 중심으로 대체 조회하지 않도록 수정했습니다.


## ❗️PR Point
- 이번 수정의 핵심은 조건문 보강이 아니라 초기 검색 시점을 상태로 모델링한 것입니다. `isFirstLoad` 단일 플래그 대신, 권한 미결정, 현재 위치 대기, 기본좌표 검색 가능, 현재 위치 검색 가능, 초기 검색 완료를 명시적으로 분리해 초기 진입 로직의 동작과정을 분명히 했습니다.
- 지도 POI 검색 기준과 주변 포토부스 목록 기준은 기획 의도에 따라 다르게 유지했습니다.
  - 지도 POI 검색: 초기 상태에 따라 기본좌표 또는 현재 위치, 이후에는 사용자가 보고 있는 지도 중심
  - 주변 포토부스 목록: 항상 현재 위치 기준

- 위치 권한 없을 시, 사용자는 본인의 집에 있는데 지도에는 강남역을 기준으로 POI가 나타나면 '왜 이러지?' 싶은 UX를 불러일으킬 수 있을 것 같다는 생각이 문득 들었습니다. 이 경우에는 '기본 좌표를 사용하고 있다'는 정보를 살짝 알려주는 것만으로도 해소될 수 있을 것 같은데, 아직 디자인적 결정사항이 없어서 Future Task로 두고 나중에 건의해보는게 좋을 것 같아서 이 부분 관련해서는 진행하지 않았습니다.

## 📸 스크린샷
생략합니당!


## 📟 관련 이슈
- Resolved: #235


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 지도 검색의 권한 기반 초기화 기능 추가
  * 사용자 위치 감지 및 검색 흐름 개선
  * 권한 상태에 따른 단계별 검색 로직 구현 (권한 대기 → 위치 대기 → 기본 위치 준비 → 사용자 위치 준비 → 완료)

* **개선사항**
  * 위치 기반 검색 동작 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->