### PR TITLE
Feat/#241 fcm notification

### DIFF
--- a/Neki-iOS.xcodeproj/project.pbxproj
+++ b/Neki-iOS.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		6C0C1ACB2F6FD2E30037F650 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 6C0C1ACA2F6FD2E30037F650 /* FirebaseAnalytics */; };
 		6C0C1ACD2F6FD2E30037F650 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 6C0C1ACC2F6FD2E30037F650 /* FirebaseCrashlytics */; };
 		6C0C1ACF2F6FD2E30037F650 /* FirebaseInstallations in Frameworks */ = {isa = PBXBuildFile; productRef = 6C0C1ACE2F6FD2E30037F650 /* FirebaseInstallations */; };
+		6C0C1AD12F6FD2E30037F650 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 6C0C1AD02F6FD2E30037F650 /* FirebaseMessaging */; };
 		6C4D99E52F365E1700E93BF0 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 6C4D99E42F365E1700E93BF0 /* Lottie */; };
 /* End PBXBuildFile section */
 
@@ -84,9 +85,7 @@
 		6C499D3A2F05594E006BE1DB /* Exceptions for "Neki-iOS" folder in "Neki-iOS" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
-				APP/Sources/Resources/FirebaseConfig/Debug/.gitkeep,
 				"APP/Sources/Resources/FirebaseConfig/Debug/GoogleService-Info.plist",
-				APP/Sources/Resources/FirebaseConfig/Release/.gitkeep,
 				"APP/Sources/Resources/FirebaseConfig/Release/GoogleService-Info.plist",
 				Info.plist,
 			);
@@ -145,6 +144,7 @@
 				592F2C5E2F0508FE00802BB7 /* ComposableArchitecture in Frameworks */,
 				5970335C2F2482E1000B8194 /* KakaoSDKCertCore in Frameworks */,
 				6C0C1ACD2F6FD2E30037F650 /* FirebaseCrashlytics in Frameworks */,
+				6C0C1AD12F6FD2E30037F650 /* FirebaseMessaging in Frameworks */,
 				597033602F2482E1000B8194 /* KakaoSDKUser in Frameworks */,
 				592F345C2F0E1F1700802BB7 /* NMapsMap in Frameworks */,
 				597033582F2482E1000B8194 /* KakaoSDKAuth in Frameworks */,
@@ -265,6 +265,7 @@
 				6C0C1ACA2F6FD2E30037F650 /* FirebaseAnalytics */,
 				6C0C1ACC2F6FD2E30037F650 /* FirebaseCrashlytics */,
 				6C0C1ACE2F6FD2E30037F650 /* FirebaseInstallations */,
+				6C0C1AD02F6FD2E30037F650 /* FirebaseMessaging */,
 			);
 			productName = "Neki-iOS";
 			productReference = 6C4998DD2EF7EF62006BE1DB /* Neki-iOS.app */;
@@ -918,6 +919,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6C0C1AC92F6FD2E30037F650 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseInstallations;
+		};
+		6C0C1AD02F6FD2E30037F650 /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6C0C1AC92F6FD2E30037F650 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
 		};
 		6C4D99E42F365E1700E93BF0 /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
+++ b/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
@@ -67,6 +67,8 @@ struct AppCoordinator {
         case didRegisterAPNSToken
         case checkPushNotificationAuthorization
         case checkPushNotificationAuthorizationResponse(Result<UNAuthorizationStatus, Error>)
+        case requestPushNotificationAuthorization
+        case requestPushNotificationAuthorizationResponse(Result<UNAuthorizationStatus, Error>)
         case synchronizePushNotification
         case synchronizePushNotificationResponse(Result<UNAuthorizationStatus, Error>)
         
@@ -184,8 +186,7 @@ struct AppCoordinator {
                 
                 return .merge(
                     configureEffect,
-                    navigateToNextScreen(state: &state, sessionStatus: finalStatus),
-                    synchronizePushNotificationIfNeeded(for: finalStatus)
+                    navigateToNextScreen(state: &state, sessionStatus: finalStatus)
                 )
                 
             case .executePendingShareExtensionIfNeeded:
@@ -211,10 +212,7 @@ struct AppCoordinator {
                 state.versionAlert = nil
                 guard let pendingSessionStatus = state.pendingSessionStatus else { return .none }
                 state.pendingSessionStatus = nil
-                return .merge(
-                    navigateToNextScreen(state: &state, sessionStatus: pendingSessionStatus),
-                    synchronizePushNotificationIfNeeded(for: pendingSessionStatus)
-                )
+                return navigateToNextScreen(state: &state, sessionStatus: pendingSessionStatus)
                 
             case let .userSessionStatusChanged(newStatus):
                 if state.userSessionStatus != newStatus { state.$userSessionStatus.withLock { $0 = newStatus } }
@@ -226,11 +224,13 @@ struct AppCoordinator {
                 
                 let navigationEffect: Effect<Action>
                 switch newStatus {
-                case .signedIn:
+                case let .signedIn(user):
                     if case .mainTab = state.route {
                         navigationEffect = .none
                     } else {
-                        state.route = .mainTab(.init())
+                        state.route = .mainTab(.init(
+                            shouldPresentMarketingConsentAlert: isMarketingConsentAlertEligible(for: user)
+                        ))
                         navigationEffect = .none
                     }
                     
@@ -246,7 +246,7 @@ struct AppCoordinator {
                 return .merge(
                     configureEffect,
                     navigationEffect,
-                    synchronizePushNotificationIfNeeded(for: newStatus)
+                    .send(.checkPushNotificationAuthorization)
                 )
                 
             case .route(.onboarding(.delegate(.didFinishOnboarding))):
@@ -261,27 +261,65 @@ struct AppCoordinator {
                 state.$userSessionStatus.withLock { $0 = .signedIn(user) }
                 state.route = .mainTab(.init(
                     shouldPresentMarketingConsentAlert: shouldPresentMarketingConsentAlert
+                        || isMarketingConsentAlertEligible(for: user)
                 ))
                 let configureEffect: Effect<Action> = .run { _ in analytics.configure(user.id) }
                 return .merge(
                     configureEffect,
-                    .send(.synchronizePushNotification),
+                    .send(.checkPushNotificationAuthorization),
                     .send(.executePendingShareExtensionIfNeeded)
                 )
 
-            case .checkPushNotificationAuthorization:
+            case .route(.mainTab(.delegate(.pushNotificationAuthorizationResolved))):
                 guard case .signedIn = state.userSessionStatus else { return .none }
+                state.hasSynchronizedPushNotification = false
+                guard state.isSynchronizingPushNotification == false else {
+                    state.shouldRetryPushNotificationSynchronization = true
+                    return .none
+                }
+                return .send(.synchronizePushNotification)
+
+            case .checkPushNotificationAuthorization:
+                guard case .signedIn = state.userSessionStatus,
+                      case .mainTab = state.route
+                else { return .none }
                 return .run { send in
                     await send(.checkPushNotificationAuthorizationResponse( Result { try await pushNotificationClient.checkAuthorizationStatus() } ))
                 }
 
             case let .checkPushNotificationAuthorizationResponse(.success(status)):
+                if status == .notDetermined {
+                    guard case let .signedIn(user) = state.userSessionStatus,
+                          user.marketingTermAgreed
+                    else { return .none }
+                    return .send(.requestPushNotificationAuthorization)
+                }
+
                 let currentAgreement = status.isPushNotificationAgreed
                 guard state.lastSynchronizedPushAgreement != currentAgreement else { return .none }
                 state.hasSynchronizedPushNotification = false
                 return .send(.synchronizePushNotification)
 
             case .checkPushNotificationAuthorizationResponse(.failure):
+                return .none
+
+            case .requestPushNotificationAuthorization:
+                return .run { send in
+                    await send(.requestPushNotificationAuthorizationResponse(Result {
+                        _ = try await pushNotificationClient.requestAuthorization()
+                        return try await pushNotificationClient.checkAuthorizationStatus()
+                    }))
+                }
+
+            case .requestPushNotificationAuthorizationResponse(.success):
+                state.hasSynchronizedPushNotification = false
+                guard state.isSynchronizingPushNotification == false else {
+                    state.shouldRetryPushNotificationSynchronization = true
+                    return .none
+                }
+                return .send(.synchronizePushNotification)
+
+            case .requestPushNotificationAuthorizationResponse(.failure):
                 return .none
 
             case .synchronizePushNotification:
@@ -350,9 +388,14 @@ private extension UNAuthorizationStatus {
 private extension AppCoordinator {
     func navigateToNextScreen(state: inout State, sessionStatus: UserSessionStatus) -> Effect<Action> {
         switch sessionStatus {
-        case .signedIn:
-            state.route = .mainTab(.init())
-            return .send(.executePendingShareExtensionIfNeeded)
+        case let .signedIn(user):
+            state.route = .mainTab(.init(
+                shouldPresentMarketingConsentAlert: isMarketingConsentAlertEligible(for: user)
+            ))
+            return .merge(
+                .send(.checkPushNotificationAuthorization),
+                .send(.executePendingShareExtensionIfNeeded)
+            )
             
         case .signedOut, .expired:
             if state.hasSeenOnboarding {
@@ -370,12 +413,12 @@ private extension AppCoordinator {
         return user.id
     }
 
-    func synchronizePushNotificationIfNeeded(
-        for status: UserSessionStatus
-    ) -> Effect<Action> {
-        guard case .signedIn = status else { return .none }
-        return .send(.synchronizePushNotification)
+    func isMarketingConsentAlertEligible(for user: User) -> Bool {
+        guard user.marketingTermAgreed == false else { return false }
+        let key = AppStorageKey.marketingConsentAlertPresentationCount(userID: user.id)
+        return UserDefaults.standard.integer(forKey: key) < 2
     }
+
 }
 
 extension AppCoordinator {

--- a/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
+++ b/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
@@ -13,6 +13,7 @@ import UserNotifications
 struct AppCoordinator {
     enum Constants {
         static let versionCheckInterval: TimeInterval = 60 *  60 * 24 // 1일
+        static let requiredTermsAgreementPolicyVersion: String = "2026-06-push-notification"
     }
     
     @ObservableState
@@ -256,18 +257,31 @@ struct AppCoordinator {
                 
             case let .route(.auth(.delegate(.moveToMainTab(
                 user,
-                shouldPresentMarketingConsentAlert
+                shouldPresentMarketingConsentAlert,
+                didCompleteTermsAgreement
             )))):
+                if didCompleteTermsAgreement {
+                    markRequiredTermsAgreementPolicyCompleted(for: user)
+                }
                 state.$userSessionStatus.withLock { $0 = .signedIn(user) }
-                state.route = .mainTab(.init(
-                    shouldPresentMarketingConsentAlert: shouldPresentMarketingConsentAlert
-                        || isMarketingConsentAlertEligible(for: user)
-                ))
                 let configureEffect: Effect<Action> = .run { _ in analytics.configure(user.id) }
                 return .merge(
                     configureEffect,
-                    .send(.checkPushNotificationAuthorization),
+                    navigateToNextScreen(
+                        state: &state,
+                        sessionStatus: .signedIn(user),
+                        shouldPresentMarketingConsentAlert: shouldPresentMarketingConsentAlert
+                    ),
                     .send(.executePendingShareExtensionIfNeeded)
+                )
+
+            case let .route(.termsAgreement(.didFinishOnboarding(user))):
+                markRequiredTermsAgreementPolicyCompleted(for: user)
+                state.$userSessionStatus.withLock { $0 = .signedIn(user) }
+                return navigateToNextScreen(
+                    state: &state,
+                    sessionStatus: .signedIn(user),
+                    shouldPresentMarketingConsentAlert: user.marketingTermAgreed == false
                 )
 
             case .route(.mainTab(.delegate(.pushNotificationAuthorizationResolved))):
@@ -386,11 +400,21 @@ private extension UNAuthorizationStatus {
 // MARK: - AppCoordinator + Helpers
 
 private extension AppCoordinator {
-    func navigateToNextScreen(state: inout State, sessionStatus: UserSessionStatus) -> Effect<Action> {
+    func navigateToNextScreen(
+        state: inout State,
+        sessionStatus: UserSessionStatus,
+        shouldPresentMarketingConsentAlert: Bool = false
+    ) -> Effect<Action> {
         switch sessionStatus {
         case let .signedIn(user):
+            guard shouldPresentRequiredTermsAgreement(for: user) == false else {
+                state.route = .termsAgreement(.init())
+                return .none
+            }
+
             state.route = .mainTab(.init(
-                shouldPresentMarketingConsentAlert: isMarketingConsentAlertEligible(for: user)
+                shouldPresentMarketingConsentAlert: shouldPresentMarketingConsentAlert
+                    || isMarketingConsentAlertEligible(for: user)
             ))
             return .merge(
                 .send(.checkPushNotificationAuthorization),
@@ -419,6 +443,17 @@ private extension AppCoordinator {
         return UserDefaults.standard.integer(forKey: key) < 2
     }
 
+    func shouldPresentRequiredTermsAgreement(for user: User) -> Bool {
+        guard user.allRequiredTermsAgreed else { return false }
+        let key = AppStorageKey.requiredTermsAgreementPolicyVersion(userID: user.id)
+        return UserDefaults.standard.string(forKey: key) != Constants.requiredTermsAgreementPolicyVersion
+    }
+
+    func markRequiredTermsAgreementPolicyCompleted(for user: User) {
+        let key = AppStorageKey.requiredTermsAgreementPolicyVersion(userID: user.id)
+        UserDefaults.standard.set(Constants.requiredTermsAgreementPolicyVersion, forKey: key)
+    }
+
 }
 
 extension AppCoordinator {
@@ -429,6 +464,7 @@ extension AppCoordinator {
             case splash
             case onboarding(OnboardingCoordinator.State)
             case auth(LoginCoordinator.State)
+            case termsAgreement(TermsAgreementFeature.State)
             case mainTab(MainTabCoordinator.State)
         }
         
@@ -436,6 +472,7 @@ extension AppCoordinator {
             case splash
             case onboarding(OnboardingCoordinator.Action)
             case auth(LoginCoordinator.Action)
+            case termsAgreement(TermsAgreementFeature.Action)
             case mainTab(MainTabCoordinator.Action)
         }
         
@@ -445,6 +482,7 @@ extension AppCoordinator {
             }
             .ifCaseLet(\.onboarding, action: \.onboarding) { OnboardingCoordinator() }
             .ifCaseLet(\.auth, action: \.auth) { LoginCoordinator() }
+            .ifCaseLet(\.termsAgreement, action: \.termsAgreement) { TermsAgreementFeature() }
             .ifCaseLet(\.mainTab, action: \.mainTab) { MainTabCoordinator() }
         }
     }

--- a/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
+++ b/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
@@ -41,6 +41,7 @@ struct AppCoordinator {
         var shouldRetryPushNotificationSynchronization: Bool = false
         var hasSynchronizedPushNotification: Bool = false
         var lastSynchronizedPushAgreement: Bool?
+        var pushNotificationEvent = PushNotificationEventFeature.State()
         
         init() {
             self.route = .splash
@@ -72,6 +73,7 @@ struct AppCoordinator {
         case requestPushNotificationAuthorizationResponse(Result<UNAuthorizationStatus, Error>)
         case synchronizePushNotification
         case synchronizePushNotificationResponse(Result<UNAuthorizationStatus, Error>)
+        case pushNotificationEvent(PushNotificationEventFeature.Action)
         
         // Binding Actions
         case binding(BindingAction<State>)
@@ -90,6 +92,10 @@ struct AppCoordinator {
     
     var body: some ReducerOf<Self> {
         BindingReducer()
+
+        Scope(state: \.pushNotificationEvent, action: \.pushNotificationEvent) {
+            PushNotificationEventFeature()
+        }
         
         Scope(state: \.route, action: \.route) { Route() }
         
@@ -98,7 +104,7 @@ struct AppCoordinator {
             case .onAppLaunched:
                 state.lastVersionCheckedTime = now
                 
-                return .run { [currentStatus = state.userSessionStatus] send in
+                let launchEffect: Effect<Action> = .run { [currentStatus = state.userSessionStatus] send in
                     async let timer: Void = clock.sleep(for: .milliseconds(1500))
                     
                     async let nextStatus: UserSessionStatus = {
@@ -125,6 +131,10 @@ struct AppCoordinator {
                     
                     await send(.splashSequenceCompleted(finalStatus, finalVersionResult))
                 }
+                return .merge(
+                    .send(.pushNotificationEvent(.task)),
+                    launchEffect
+                )
                 
             case let .onOpenURL(url):
                 guard (url.scheme == "neki" || url.scheme == "neki-dev") && url.host == "shareExtension" else { return .none }

--- a/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
+++ b/Neki-iOS/APP/Sources/Application/AppCoordinator.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
+import UserNotifications
 
 @Reducer
 struct AppCoordinator {
@@ -35,6 +36,10 @@ struct AppCoordinator {
         var pendingSessionStatus: UserSessionStatus?
         var pendingShareAppGroupID: String?
         var lastVersionCheckedTime: Date?
+        var isSynchronizingPushNotification: Bool = false
+        var shouldRetryPushNotificationSynchronization: Bool = false
+        var hasSynchronizedPushNotification: Bool = false
+        var lastSynchronizedPushAgreement: Bool?
         
         init() {
             self.route = .splash
@@ -59,6 +64,11 @@ struct AppCoordinator {
         case scenePhaseChanged(ScenePhase)
         case backgroundVersionCheckResult(Result<AppVersionClient.VersionResult, Error>)
         case executePendingShareExtensionIfNeeded
+        case didRegisterAPNSToken
+        case checkPushNotificationAuthorization
+        case checkPushNotificationAuthorizationResponse(Result<UNAuthorizationStatus, Error>)
+        case synchronizePushNotification
+        case synchronizePushNotificationResponse(Result<UNAuthorizationStatus, Error>)
         
         // Binding Actions
         case binding(BindingAction<State>)
@@ -70,6 +80,7 @@ struct AppCoordinator {
     @Dependency(\.authClient) private var authClient
     @Dependency(\.appVersionClient) private var appVersionClient
     @Dependency(\.analyticsClient) private var analytics
+    @Dependency(\.pushNotificationClient) private var pushNotificationClient
     @Dependency(\.continuousClock) var clock
     @Dependency(\.openURL) private var openURL
     @Dependency(\.date.now) private var now
@@ -124,16 +135,17 @@ struct AppCoordinator {
                 
             case let .scenePhaseChanged(phase):
                 guard phase == .active else { return .none }
-                if state.versionAlert == .updateNeeded { return .none }
-                if let lastTime = state.lastVersionCheckedTime, now.timeIntervalSince(lastTime) < Constants.versionCheckInterval { return .none }
-                return .run { send in
-                    do {
-                        let result = try await appVersionClient.checkVersion()
-                        await send(.backgroundVersionCheckResult(.success(result)))
-                    } catch {
-                        await send(.backgroundVersionCheckResult(.failure(error)))
-                    }
+                let authorizationEffect: Effect<Action> = .send(.checkPushNotificationAuthorization)
+
+                guard state.versionAlert != .updateNeeded else { return authorizationEffect }
+                guard state.lastVersionCheckedTime.map({ now.timeIntervalSince($0) >= Constants.versionCheckInterval }) ?? true else { return authorizationEffect }
+
+                let versionEffect: Effect<Action> = .run { send in
+                    await send(.backgroundVersionCheckResult(
+                        Result { try await appVersionClient.checkVersion() }
+                    ))
                 }
+                return .merge(authorizationEffect, versionEffect)
                 
             case let .backgroundVersionCheckResult(result):
                 guard case let .success(version) = result else { return .none }
@@ -172,7 +184,8 @@ struct AppCoordinator {
                 
                 return .merge(
                     configureEffect,
-                    navigateToNextScreen(state: &state, sessionStatus: finalStatus)
+                    navigateToNextScreen(state: &state, sessionStatus: finalStatus),
+                    synchronizePushNotificationIfNeeded(for: finalStatus)
                 )
                 
             case .executePendingShareExtensionIfNeeded:
@@ -180,6 +193,15 @@ struct AppCoordinator {
                 guard case .mainTab = state.route else { return .none }
                 state.pendingShareAppGroupID = nil
                 return .send(.route(.mainTab(.archive(.root(.addPhotoFromShareExtension(appGroupID: appGroupID))))))
+
+            case .didRegisterAPNSToken:
+                guard case .signedIn = state.userSessionStatus else { return .none }
+                state.hasSynchronizedPushNotification = false
+                guard state.isSynchronizingPushNotification == false else {
+                    state.shouldRetryPushNotificationSynchronization = true
+                    return .none
+                }
+                return .send(.synchronizePushNotification)
                 
             case .didTapUpdateAlert:
                 guard let appStoreURL = URL(string: "https://apps.apple.com/kr/app/id6757490609") else { return .none }
@@ -189,7 +211,10 @@ struct AppCoordinator {
                 state.versionAlert = nil
                 guard let pendingSessionStatus = state.pendingSessionStatus else { return .none }
                 state.pendingSessionStatus = nil
-                return navigateToNextScreen(state: &state, sessionStatus: pendingSessionStatus)
+                return .merge(
+                    navigateToNextScreen(state: &state, sessionStatus: pendingSessionStatus),
+                    synchronizePushNotificationIfNeeded(for: pendingSessionStatus)
+                )
                 
             case let .userSessionStatusChanged(newStatus):
                 if state.userSessionStatus != newStatus { state.$userSessionStatus.withLock { $0 = newStatus } }
@@ -210,28 +235,82 @@ struct AppCoordinator {
                     }
                     
                 case .signedOut, .expired:
+                    state.hasSynchronizedPushNotification = false
+                    state.shouldRetryPushNotificationSynchronization = false
+                    state.lastSynchronizedPushAgreement = nil
                     state.route = .auth(.init())
                     if case .expired = newStatus { state.toastItem = .init("다시 로그인 해주세요.") }
                     navigationEffect = .none
                 }
                 
-                return .merge(configureEffect, navigationEffect)
+                return .merge(
+                    configureEffect,
+                    navigationEffect,
+                    synchronizePushNotificationIfNeeded(for: newStatus)
+                )
                 
             case .route(.onboarding(.delegate(.didFinishOnboarding))):
                 state.$hasSeenOnboarding.withLock { $0 = true }
                 state.route = .auth(.init())
                 return .none
                 
-            case let .route(.auth(.delegate(.moveToMainTab(user)))):
+            case let .route(.auth(.delegate(.moveToMainTab(
+                user,
+                shouldPresentMarketingConsentAlert
+            )))):
                 state.$userSessionStatus.withLock { $0 = .signedIn(user) }
-                state.route = .mainTab(.init())
+                state.route = .mainTab(.init(
+                    shouldPresentMarketingConsentAlert: shouldPresentMarketingConsentAlert
+                ))
                 let configureEffect: Effect<Action> = .run { _ in analytics.configure(user.id) }
                 return .merge(
                     configureEffect,
+                    .send(.synchronizePushNotification),
                     .send(.executePendingShareExtensionIfNeeded)
                 )
+
+            case .checkPushNotificationAuthorization:
+                guard case .signedIn = state.userSessionStatus else { return .none }
+                return .run { send in
+                    await send(.checkPushNotificationAuthorizationResponse( Result { try await pushNotificationClient.checkAuthorizationStatus() } ))
+                }
+
+            case let .checkPushNotificationAuthorizationResponse(.success(status)):
+                let currentAgreement = status.isPushNotificationAgreed
+                guard state.lastSynchronizedPushAgreement != currentAgreement else { return .none }
+                state.hasSynchronizedPushNotification = false
+                return .send(.synchronizePushNotification)
+
+            case .checkPushNotificationAuthorizationResponse(.failure):
+                return .none
+
+            case .synchronizePushNotification:
+                guard case .signedIn = state.userSessionStatus else { return .none }
+                guard state.isSynchronizingPushNotification == false,
+                      state.hasSynchronizedPushNotification == false
+                else { return .none }
+                state.isSynchronizingPushNotification = true
+                return .run { send in
+                    await send(.synchronizePushNotificationResponse( Result { try await pushNotificationClient.synchronizeDeviceToken() } ))
+                }
+
+            case let .synchronizePushNotificationResponse(.success(status)):
+                state.isSynchronizingPushNotification = false
+                state.shouldRetryPushNotificationSynchronization = false
+                state.hasSynchronizedPushNotification = true
+                state.lastSynchronizedPushAgreement = status.isPushNotificationAgreed
+                return .none
+
+            case .synchronizePushNotificationResponse(.failure):
+                state.isSynchronizingPushNotification = false
+                guard state.shouldRetryPushNotificationSynchronization else { return .none }
+                state.shouldRetryPushNotificationSynchronization = false
+                return .send(.synchronizePushNotification)
                 
             case .route(.mainTab(.delegate(.signedOut))), .route(.mainTab(.delegate(.withdraw))):
+                state.hasSynchronizedPushNotification = false
+                state.shouldRetryPushNotificationSynchronization = false
+                state.lastSynchronizedPushAgreement = nil
                 state.$userSessionStatus.withLock { $0 = .signedOut }
                 if case .route(.mainTab(.delegate(.withdraw))) = action {
                     state.initializeUserDefaults()
@@ -248,6 +327,19 @@ struct AppCoordinator {
             default:
                 return .none
             }
+        }
+    }
+}
+
+private extension UNAuthorizationStatus {
+    var isPushNotificationAgreed: Bool {
+        switch self {
+        case .authorized, .provisional, .ephemeral:
+            true
+        case .notDetermined, .denied:
+            false
+        @unknown default:
+            false
         }
     }
 }
@@ -276,6 +368,13 @@ private extension AppCoordinator {
     func extractUserID(from status: UserSessionStatus) -> Int? {
         guard case let .signedIn(user) = status else { return nil }
         return user.id
+    }
+
+    func synchronizePushNotificationIfNeeded(
+        for status: UserSessionStatus
+    ) -> Effect<Action> {
+        guard case .signedIn = status else { return .none }
+        return .send(.synchronizePushNotification)
     }
 }
 

--- a/Neki-iOS/APP/Sources/Application/AppCoordinatorView.swift
+++ b/Neki-iOS/APP/Sources/Application/AppCoordinatorView.swift
@@ -22,9 +22,6 @@ struct AppCoordinatorView: View {
             .onChange(of: scenePhase) { _, newValue in
                 store.send(.scenePhaseChanged(newValue))
             }
-            .onReceive(NotificationCenter.default.publisher(for: .didRegisterAPNSToken)) { _ in
-                store.send(.didRegisterAPNSToken)
-            }
             .nekiToast(item: $store.toastItem)
             .modifier(VersionUpdateAlertModifier(store: store))
     }

--- a/Neki-iOS/APP/Sources/Application/AppCoordinatorView.swift
+++ b/Neki-iOS/APP/Sources/Application/AppCoordinatorView.swift
@@ -9,9 +9,28 @@ import SwiftUI
 import ComposableArchitecture
 
 struct AppCoordinatorView: View {
+    @Environment(\.scenePhase) private var scenePhase
+
     @Bindable var store: StoreOf<AppCoordinator>
     
     var body: some View {
+        routeContent
+            .task { await store.send(.onAppLaunched).finish() }
+            .onChange(of: store.userSessionStatus) { _, newValue in
+                store.send(.userSessionStatusChanged(newValue))
+            }
+            .onChange(of: scenePhase) { _, newValue in
+                store.send(.scenePhaseChanged(newValue))
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .didRegisterAPNSToken)) { _ in
+                store.send(.didRegisterAPNSToken)
+            }
+            .nekiToast(item: $store.toastItem)
+            .modifier(VersionUpdateAlertModifier(store: store))
+    }
+
+    @ViewBuilder
+    private var routeContent: some View {
         Group {
             switch store.route {
             case .splash:
@@ -33,18 +52,26 @@ struct AppCoordinatorView: View {
                 }
             }
         }
-        .task { await store.send(.onAppLaunched).finish() }
-        .onChange(of: store.userSessionStatus) { _, newValue in
-            store.send(.userSessionStatusChanged(newValue))
-        }
-        .nekiToast(item: $store.toastItem)
-        .nekiAlert(
+    }
+}
+
+
+// MARK: - VersionUpdateAlertModifier
+
+private struct VersionUpdateAlertModifier: ViewModifier {
+    @Bindable var store: StoreOf<AppCoordinator>
+
+    func body(content: Content) -> some View {
+        let alert: AppCoordinator.VersionUpdateAlertType? = store.versionAlert
+
+        content.nekiAlert(
             isPresented: $store.isAlertPresented,
-            style: store.versionAlert?.style ?? .cancelable,
-            title: store.versionAlert?.title ?? "",
-            subtitle: store.versionAlert?.subtitle ?? "",
-            confirmText: store.versionAlert?.confirmText ?? "",
-            cancelText: store.versionAlert?.cancelText,
+            style: alert?.style ?? NekiAlertStyle.cancelable,
+            contentStyle: .standard,
+            title: alert?.title ?? "",
+            subtitle: alert?.subtitle ?? "",
+            confirmText: alert?.confirmText ?? "",
+            cancelText: alert?.cancelText ?? nil,
             hasIcon: true,
             onConfirm: { store.send(.didTapUpdateAlert) },
             onCancel: { store.send(.didTapLaterAlert) }

--- a/Neki-iOS/APP/Sources/Application/AppCoordinatorView.swift
+++ b/Neki-iOS/APP/Sources/Application/AppCoordinatorView.swift
@@ -42,6 +42,11 @@ struct AppCoordinatorView: View {
                 if let store = store.scope(state: \.route.auth, action: \.route.auth) {
                     LoginCoordinatorView(store: store)
                 }
+
+            case .termsAgreement:
+                if let store = store.scope(state: \.route.termsAgreement, action: \.route.termsAgreement) {
+                    TermsAgreementView(store: store)
+                }
                 
             case .mainTab:
                 if let store = store.scope(state: \.route.mainTab, action: \.route.mainTab) {

--- a/Neki-iOS/APP/Sources/Application/NekiApplicationDelegate.swift
+++ b/Neki-iOS/APP/Sources/Application/NekiApplicationDelegate.swift
@@ -1,0 +1,35 @@
+//
+//  NekiApplicationDelegate.swift
+//  Neki-iOS
+//
+//  Created by Codex on 6/14/26.
+//
+
+import UIKit
+import Dependencies
+
+extension Notification.Name {
+    static let didRegisterAPNSToken = Notification.Name("didRegisterAPNSToken")
+}
+
+final class NekiApplicationDelegate: NSObject, UIApplicationDelegate {
+    @Dependency(\.pushNotificationClient) private var pushNotificationClient
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        application.registerForRemoteNotifications()
+        return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        Task {
+            try? await pushNotificationClient.updateAPNSToken(deviceToken)
+            await MainActor.run { NotificationCenter.default.post(name: .didRegisterAPNSToken, object: nil) }
+        }
+    }
+}

--- a/Neki-iOS/APP/Sources/Application/NekiApplicationDelegate.swift
+++ b/Neki-iOS/APP/Sources/Application/NekiApplicationDelegate.swift
@@ -10,28 +10,24 @@ import Combine
 import Dependencies
 import FirebaseCore
 import FirebaseMessaging
+import os
+import UserNotifications
 
 final class NekiApplicationDelegate: NSObject, UIApplicationDelegate, MessagingDelegate, ObservableObject {
     @Dependency(\.pushNotificationClient) private var pushNotificationClient
 
     @Published private(set) var isAPNSTokenRegistered = false
 
+    private let pushNotificationDelegate = PushNotificationDelegate()
+
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
-#if DEBUG
-        print("[Push] Application delegate launched")
-#endif
         FirebaseApp.configure()
-#if DEBUG
-        print("[Push] Firebase configured: \(FirebaseApp.app() != nil)")
-#endif
         Messaging.messaging().delegate = self
+        UNUserNotificationCenter.current().delegate = pushNotificationDelegate
         application.registerForRemoteNotifications()
-#if DEBUG
-        print("[APNs] Remote notification registration requested")
-#endif
         return true
     }
 
@@ -39,23 +35,14 @@ final class NekiApplicationDelegate: NSObject, UIApplicationDelegate, MessagingD
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
-#if DEBUG
-        print("[APNs] Device token received (\(deviceToken.count) bytes)")
-#endif
         Task {
             do {
                 try await pushNotificationClient.updateAPNSToken(deviceToken)
-#if DEBUG
-                print("[APNs] Device token assigned to Firebase Messaging")
-#endif
                 await MainActor.run {
                     isAPNSTokenRegistered = true
-                    printCurrentFCMToken()
                 }
             } catch {
-#if DEBUG
-                print("[APNs] Device token assignment failed: \(error)")
-#endif
+                Logger.data.error("APNs 토큰을 Firebase Messaging에 전달하지 못함: \(error)")
             }
         }
     }
@@ -64,35 +51,14 @@ final class NekiApplicationDelegate: NSObject, UIApplicationDelegate, MessagingD
         _ application: UIApplication,
         didFailToRegisterForRemoteNotificationsWithError error: Error
     ) {
-#if DEBUG
-        print("[APNs] Registration failed: \(error)")
-#endif
+        Logger.data.error("APNs 원격 알림 등록 실패: \(error)")
     }
 
     func messaging(
         _ messaging: Messaging,
         didReceiveRegistrationToken fcmToken: String?
     ) {
-#if DEBUG
-        guard let fcmToken, fcmToken.isEmpty == false else {
-            print("[FCM] Registration token callback returned an empty token")
-            return
-        }
-        print("[FCM] Registration Token: \(fcmToken)")
-#endif
-    }
-
-    private func printCurrentFCMToken() {
-#if DEBUG
-        Messaging.messaging().token { token, error in
-            if let error {
-                print("[FCM] Token retrieval failed: \(error)")
-            } else if let token, token.isEmpty == false {
-                print("[FCM] Current Token: \(token)")
-            } else {
-                print("[FCM] Token retrieval returned an empty token")
-            }
-        }
-#endif
+        guard fcmToken?.isEmpty == false else { return }
+        Logger.data.debug("FCM 등록 토큰 갱신 감지")
     }
 }

--- a/Neki-iOS/APP/Sources/Application/NekiApplicationDelegate.swift
+++ b/Neki-iOS/APP/Sources/Application/NekiApplicationDelegate.swift
@@ -6,20 +6,32 @@
 //
 
 import UIKit
+import Combine
 import Dependencies
+import FirebaseCore
+import FirebaseMessaging
 
-extension Notification.Name {
-    static let didRegisterAPNSToken = Notification.Name("didRegisterAPNSToken")
-}
-
-final class NekiApplicationDelegate: NSObject, UIApplicationDelegate {
+final class NekiApplicationDelegate: NSObject, UIApplicationDelegate, MessagingDelegate, ObservableObject {
     @Dependency(\.pushNotificationClient) private var pushNotificationClient
+
+    @Published private(set) var isAPNSTokenRegistered = false
 
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
+#if DEBUG
+        print("[Push] Application delegate launched")
+#endif
+        FirebaseApp.configure()
+#if DEBUG
+        print("[Push] Firebase configured: \(FirebaseApp.app() != nil)")
+#endif
+        Messaging.messaging().delegate = self
         application.registerForRemoteNotifications()
+#if DEBUG
+        print("[APNs] Remote notification registration requested")
+#endif
         return true
     }
 
@@ -27,9 +39,60 @@ final class NekiApplicationDelegate: NSObject, UIApplicationDelegate {
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
+#if DEBUG
+        print("[APNs] Device token received (\(deviceToken.count) bytes)")
+#endif
         Task {
-            try? await pushNotificationClient.updateAPNSToken(deviceToken)
-            await MainActor.run { NotificationCenter.default.post(name: .didRegisterAPNSToken, object: nil) }
+            do {
+                try await pushNotificationClient.updateAPNSToken(deviceToken)
+#if DEBUG
+                print("[APNs] Device token assigned to Firebase Messaging")
+#endif
+                await MainActor.run {
+                    isAPNSTokenRegistered = true
+                    printCurrentFCMToken()
+                }
+            } catch {
+#if DEBUG
+                print("[APNs] Device token assignment failed: \(error)")
+#endif
+            }
         }
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+#if DEBUG
+        print("[APNs] Registration failed: \(error)")
+#endif
+    }
+
+    func messaging(
+        _ messaging: Messaging,
+        didReceiveRegistrationToken fcmToken: String?
+    ) {
+#if DEBUG
+        guard let fcmToken, fcmToken.isEmpty == false else {
+            print("[FCM] Registration token callback returned an empty token")
+            return
+        }
+        print("[FCM] Registration Token: \(fcmToken)")
+#endif
+    }
+
+    private func printCurrentFCMToken() {
+#if DEBUG
+        Messaging.messaging().token { token, error in
+            if let error {
+                print("[FCM] Token retrieval failed: \(error)")
+            } else if let token, token.isEmpty == false {
+                print("[FCM] Current Token: \(token)")
+            } else {
+                print("[FCM] Token retrieval returned an empty token")
+            }
+        }
+#endif
     }
 }

--- a/Neki-iOS/APP/Sources/Application/Neki_iOSApp.swift
+++ b/Neki-iOS/APP/Sources/Application/Neki_iOSApp.swift
@@ -6,8 +6,8 @@
 //
 
 import SwiftUI
+import Combine
 import ComposableArchitecture
-import Firebase
 
 @main
 struct Neki_iOSApp: App {
@@ -17,13 +17,16 @@ struct Neki_iOSApp: App {
         AppCoordinator()
     }
     
-    init() {
-        FirebaseApp.configure()
-    }
-    
     var body: some Scene {
         WindowGroup {
             AppCoordinatorView(store: store)
+                .onReceive(
+                    applicationDelegate.$isAPNSTokenRegistered
+                        .removeDuplicates()
+                        .filter { $0 }
+                ) { _ in
+                    store.send(.didRegisterAPNSToken)
+                }
                 .onOpenURL { handleIncomingURL($0) }
         }
     }

--- a/Neki-iOS/APP/Sources/Application/Neki_iOSApp.swift
+++ b/Neki-iOS/APP/Sources/Application/Neki_iOSApp.swift
@@ -11,6 +11,8 @@ import Firebase
 
 @main
 struct Neki_iOSApp: App {
+    @UIApplicationDelegateAdaptor(NekiApplicationDelegate.self) private var applicationDelegate
+
     let store = Store(initialState: AppCoordinator.State()) {
         AppCoordinator()
     }

--- a/Neki-iOS/APP/Sources/Application/PushNotificationAnalyticsEvent.swift
+++ b/Neki-iOS/APP/Sources/Application/PushNotificationAnalyticsEvent.swift
@@ -1,0 +1,48 @@
+//
+//  PushNotificationAnalyticsEvent.swift
+//  Neki-iOS
+//
+//  Created by Codex on 6/16/26.
+//
+
+import Foundation
+
+enum PushNotificationAnalyticsEvent {
+    case notificationClick(payload: PushNotificationPayload)
+}
+
+extension PushNotificationAnalyticsEvent: AnalyticsEvent {
+    var name: AnalyticsEventName {
+        switch self {
+        case .notificationClick:
+            return .pushNotificationClick
+        }
+    }
+
+    var parameters: [AnalyticsParameterKey: Any]? {
+        switch self {
+        case let .notificationClick(payload):
+            return payload.analyticsParameters
+        }
+    }
+}
+
+private extension PushNotificationPayload {
+    var analyticsParameters: [AnalyticsParameterKey: Any]? {
+        var parameters: [AnalyticsParameterKey: Any] = [:]
+
+        if let notificationType = value(for: "notification_type", "notificationType", "type") {
+            parameters[.notificationType] = notificationType
+        }
+
+        if let notificationTone = value(for: "notification_tone", "notificationTone", "tone") {
+            parameters[.notificationTone] = notificationTone
+        }
+
+        return parameters.isEmpty ? nil : parameters
+    }
+
+    func value(for keys: String...) -> String? {
+        keys.lazy.compactMap { values[$0] }.first
+    }
+}

--- a/Neki-iOS/APP/Sources/Application/PushNotificationEventFeature.swift
+++ b/Neki-iOS/APP/Sources/Application/PushNotificationEventFeature.swift
@@ -1,0 +1,58 @@
+//
+//  PushNotificationEventFeature.swift
+//  Neki-iOS
+//
+//  Created by Codex on 6/16/26.
+//
+
+import ComposableArchitecture
+import Foundation
+import os
+
+@Reducer
+struct PushNotificationEventFeature {
+    @ObservableState
+    struct State: Equatable {}
+
+    enum Action {
+        case task
+        case eventReceived(PushNotificationEvent)
+    }
+
+    @Dependency(\.analyticsClient) private var analyticsClient
+    @Dependency(\.pushNotificationEventClient) private var eventClient
+
+    private enum CancelID: Hashable {
+        case eventStream
+    }
+
+    var body: some ReducerOf<Self> {
+        Reduce { _, action in
+            switch action {
+            case .task:
+                return .run { send in
+                    for await event in await eventClient.events() {
+                        await send(.eventReceived(event))
+                    }
+                }
+                .cancellable(id: CancelID.eventStream, cancelInFlight: true)
+
+            case let .eventReceived(.foregroundReceived(payload)):
+                Logger.data.debug("Foreground 푸시 알림 수신: \(payload.redactedLogDescription)")
+                return .none
+
+            case let .eventReceived(.responseReceived(payload)):
+                Logger.data.debug("푸시 알림 클릭 이벤트 수신: \(payload.redactedLogDescription)")
+                return .run { _ in
+                    analyticsClient.logEvent(PushNotificationAnalyticsEvent.notificationClick(payload: payload))
+                }
+            }
+        }
+    }
+}
+
+private extension PushNotificationPayload {
+    var redactedLogDescription: String {
+        "keys=\(values.keys.sorted().joined(separator: ","))"
+    }
+}

--- a/Neki-iOS/APP/Sources/MainTab/MainTabCoordinator.swift
+++ b/Neki-iOS/APP/Sources/MainTab/MainTabCoordinator.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import ComposableArchitecture
 import AVFoundation
+import UserNotifications
 // import Pose
 // import Archive
 
@@ -83,6 +84,8 @@ struct MainTabCoordinator {
         case dismissMarketingConsentAlert
         case updateMarketingConsent(Bool)
         case marketingConsentUpdateResponse(Bool, Result<Void, Error>)
+        case requestPushNotificationAuthorizationIfNeeded
+        case pushNotificationAuthorizationResponse(Result<UNAuthorizationStatus, Error>)
         
         case onAppear
         case tabChanged(NekiTab)
@@ -91,6 +94,7 @@ struct MainTabCoordinator {
         enum Delegate {
             case signedOut
             case withdraw
+            case pushNotificationAuthorizationResolved
         }
     }
     
@@ -98,6 +102,7 @@ struct MainTabCoordinator {
     @Dependency(\.openURL) private var openURL
     @Dependency(\.analyticsClient) private var analyticsClient
     @Dependency(\.authClient) private var authClient
+    @Dependency(\.pushNotificationClient) private var pushNotificationClient
     
     var body: some ReducerOf<Self> {
         BindingReducer()
@@ -117,6 +122,11 @@ struct MainTabCoordinator {
                    state.shouldPresentMarketingConsentAlert {
                     state.shouldPresentMarketingConsentAlert = false
                     state.isMarketingConsentAlertPresented = true
+                    let key = AppStorageKey.marketingConsentAlertPresentationCount(userID: state.user.id)
+                    UserDefaults.standard.set(
+                        UserDefaults.standard.integer(forKey: key) + 1,
+                        forKey: key
+                    )
                 }
                 return .send(.tabChanged(state.selectedTab))
                 
@@ -207,10 +217,26 @@ struct MainTabCoordinator {
                 state.isUpdatingMarketingConsent = false
                 state.isMarketingConsentAlertPresented = false
                 state.user.marketingTermAgreed = isAgreed
-                return .none
+                return .send(.requestPushNotificationAuthorizationIfNeeded)
 
             case .marketingConsentUpdateResponse(_, .failure):
                 state.isUpdatingMarketingConsent = false
+                return .none
+
+            case .requestPushNotificationAuthorizationIfNeeded:
+                return .run { send in
+                    await send(.pushNotificationAuthorizationResponse(Result {
+                        let status = try await pushNotificationClient.checkAuthorizationStatus()
+                        guard status == .notDetermined else { return status }
+                        _ = try await pushNotificationClient.requestAuthorization()
+                        return try await pushNotificationClient.checkAuthorizationStatus()
+                    }))
+                }
+
+            case .pushNotificationAuthorizationResponse(.success):
+                return .send(.delegate(.pushNotificationAuthorizationResolved))
+
+            case .pushNotificationAuthorizationResponse(.failure):
                 return .none
                 
             case .archive(.delegate(.requestQRScan)), .pose(.delegate(.requestQRScan)):

--- a/Neki-iOS/APP/Sources/MainTab/MainTabCoordinator.swift
+++ b/Neki-iOS/APP/Sources/MainTab/MainTabCoordinator.swift
@@ -36,6 +36,13 @@ struct MainTabCoordinator {
         var isTabbarHidden: Bool = false
         var toast: NekiToastItem? = nil
         var isPermissionAlertPresented: Bool = false
+        var shouldPresentMarketingConsentAlert: Bool
+        var isMarketingConsentAlertPresented: Bool = false
+        var isUpdatingMarketingConsent: Bool = false
+
+        init(shouldPresentMarketingConsentAlert: Bool = false) {
+            self.shouldPresentMarketingConsentAlert = shouldPresentMarketingConsentAlert
+        }
         
         var user: User {
             get {
@@ -73,6 +80,9 @@ struct MainTabCoordinator {
         case presentPermissionAlert
         case dismissPermissionAlert
         case openAppSettings
+        case dismissMarketingConsentAlert
+        case updateMarketingConsent(Bool)
+        case marketingConsentUpdateResponse(Bool, Result<Void, Error>)
         
         case onAppear
         case tabChanged(NekiTab)
@@ -87,6 +97,7 @@ struct MainTabCoordinator {
     @Dependency(\.qrScannerClient) private var qrScannerClient
     @Dependency(\.openURL) private var openURL
     @Dependency(\.analyticsClient) private var analyticsClient
+    @Dependency(\.authClient) private var authClient
     
     var body: some ReducerOf<Self> {
         BindingReducer()
@@ -102,6 +113,11 @@ struct MainTabCoordinator {
             case .binding: return .none
                 
             case .onAppear:
+                if state.selectedTab == .archive,
+                   state.shouldPresentMarketingConsentAlert {
+                    state.shouldPresentMarketingConsentAlert = false
+                    state.isMarketingConsentAlertPresented = true
+                }
                 return .send(.tabChanged(state.selectedTab))
                 
             case let .tabChanged(tab):
@@ -171,10 +187,41 @@ struct MainTabCoordinator {
                     guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
                     await openURL(url)
                 }
+
+            case .dismissMarketingConsentAlert:
+                guard state.isUpdatingMarketingConsent == false else { return .none }
+                state.isMarketingConsentAlertPresented = false
+                return .none
+
+            case let .updateMarketingConsent(isAgreed):
+                guard state.isUpdatingMarketingConsent == false else { return .none }
+                state.isUpdatingMarketingConsent = true
+                return .run { send in
+                    await send(.marketingConsentUpdateResponse(
+                        isAgreed,
+                        Result { try await authClient.updateMarketingConsent(isAgreed) }
+                    ))
+                }
+
+            case let .marketingConsentUpdateResponse(isAgreed, .success):
+                state.isUpdatingMarketingConsent = false
+                state.isMarketingConsentAlertPresented = false
+                state.user.marketingTermAgreed = isAgreed
+                return .none
+
+            case .marketingConsentUpdateResponse(_, .failure):
+                state.isUpdatingMarketingConsent = false
+                return .none
                 
             case .archive(.delegate(.requestQRScan)), .pose(.delegate(.requestQRScan)):
                 state.destination = nil
                 return .send(.onTapQRScan)
+
+            case .archive(.delegate(.requestNotificationList)),
+                 .pose(.delegate(.requestNotificationList)),
+                 .myPage(.delegate(.requestNotificationList)):
+                state.destination = .notificationList(.init())
+                return .none
                 
             case let .archive(.delegate(.showToast(item))):
                 state.toast = item
@@ -235,6 +282,7 @@ extension MainTabCoordinator {
     enum Destination {
         case uploadSelection
         case qrScan(QRCodeScanFeature)
+        case notificationList(PushNotificationListFeature)
     }
     enum PendingPresentation {
         case gallery

--- a/Neki-iOS/APP/Sources/MainTab/MainTabCoordinatorView.swift
+++ b/Neki-iOS/APP/Sources/MainTab/MainTabCoordinatorView.swift
@@ -51,6 +51,7 @@ struct MainTabCoordinatorView: View {
             store.send(.tabChanged(newTab))
         }
         .nekiToast(item: $store.toast)
+        .modifier(MarketingConsentAlertModifier(store: store))
         .nekiAlert(
             isPresented: $store.isPermissionAlertPresented,
             style: .cancelable,
@@ -69,12 +70,48 @@ struct MainTabCoordinatorView: View {
         .fullScreenCover(item: $store.scope(state: \.destination?.qrScan, action: \.destination.qrScan)) { qrStore in
             QRCodeScannerView(store: qrStore)
         }
+        .fullScreenCover(item: $store.scope(state: \.destination?.notificationList, action: \.destination.notificationList)) { notificationStore in
+            PushNotificationListView(store: notificationStore)
+        }
         .photosPicker(
             isPresented: $store.isPhotoPickerPresented.sending(\.setPhotosPickerPresented),
             selection: $store.imagePicker.pickerItems.sending(\.imagePicker.pickerItemsChanged),
             maxSelectionCount: store.imagePicker.remainingCount,
             matching: .images
         )
+    }
+}
+
+
+// MARK: - MarketingConsentAlertModifier
+
+private struct MarketingConsentAlertModifier: ViewModifier {
+    @Bindable var store: StoreOf<MainTabCoordinator>
+
+    func body(content: Content) -> some View {
+        content.nekiAlert(
+            isPresented: $store.isMarketingConsentAlertPresented,
+            style: .cancelable,
+            contentStyle: .marketingConsent(description: description),
+            title: "놓치지 마세요!",
+            subtitle: "네키의 이벤트, 혜택 프로모션,\n신규 업데이트 소식을 선별해서 알려드려요.",
+            confirmText: "네, 알려주세요",
+            cancelText: "괜찮아요",
+            isProcessing: store.isUpdatingMarketingConsent,
+            hasIcon: true,
+            onConfirm: { store.send(.updateMarketingConsent(true)) },
+            onCancel: { store.send(.updateMarketingConsent(false)) },
+            onDismiss: { store.send(.dismissMarketingConsentAlert) }
+        )
+    }
+
+    private var description: Text {
+        Text("마케팅 정보 푸시 수신 동의 여부는 ")
+            .foregroundColor(.gray400)
+        + Text("마이페이지 >\n권한 설정 > 알림 설정")
+            .foregroundColor(.primary500)
+        + Text("에서 변경 가능해요.")
+            .foregroundColor(.gray400)
     }
 }
 

--- a/Neki-iOS/Core/Sources/Analytics/Sources/Domain/Sources/Entities/AnalyticsEventName.swift
+++ b/Neki-iOS/Core/Sources/Analytics/Sources/Domain/Sources/Entities/AnalyticsEventName.swift
@@ -10,6 +10,7 @@ import Foundation
 public enum AnalyticsEventName: String {
     // 공통
     case appOpen = "app_open"
+    case pushNotificationClick = "push_notification_click"
     
     // 아카이빙
     case archivingView = "archiving_view"

--- a/Neki-iOS/Core/Sources/Analytics/Sources/Domain/Sources/Entities/AnalyticsParameterKey.swift
+++ b/Neki-iOS/Core/Sources/Analytics/Sources/Domain/Sources/Entities/AnalyticsParameterKey.swift
@@ -12,6 +12,8 @@ public enum AnalyticsParameterKey: String {
     case userId = "user_id"
     case platform = "platform"
     case appVersion = "app_version"
+    case notificationType = "notification_type"
+    case notificationTone = "notification_tone"
     
     // 아카이빙
     case method = "method"

--- a/Neki-iOS/Core/Sources/Auth/Sources/Data/Sources/DTOs/UserInfoDTO.swift
+++ b/Neki-iOS/Core/Sources/Auth/Sources/Data/Sources/DTOs/UserInfoDTO.swift
@@ -15,13 +15,16 @@ enum UserInfoDTO {
         let profileImageURLString: String?
         let providerType: String
         let agreedTerms: Bool
+        let marketingTerm: Bool
+        let pushNotificationAgreed: Bool
         
         enum CodingKeys: String, CodingKey {
             case id = "userId"
             case nickname = "name"
             case profileImageURLString = "profileImageUrl"
             case agreedTerms = "agreeTerms"
-            case email, providerType
+            case pushNotificationAgreed = "pushAgreed"
+            case email, providerType, marketingTerm
         }
     }
 }

--- a/Neki-iOS/Core/Sources/Auth/Sources/Data/Sources/Implementations/DefaultAuthRepository.swift
+++ b/Neki-iOS/Core/Sources/Auth/Sources/Data/Sources/Implementations/DefaultAuthRepository.swift
@@ -10,6 +10,10 @@ import Dependencies
 import os
 
 public struct DefaultAuthRepository: AuthRepository {
+    private enum Constants {
+        static let marketingTermType = "MARKETING"
+    }
+
     @Dependency(\.networkProvider) private var networkProvider
     @Dependency(\.tokenStorage) private var tokenStorage
     
@@ -42,7 +46,16 @@ public struct DefaultAuthRepository: AuthRepository {
             else { throw AuthRepositoryError.networkError(.responseDecodingError) }
             
             let profileImageURL = URL(string: data.profileImageURLString ?? "")
-            return User(id: data.id, nickname: data.nickname, email: data.email, profileImageURL: profileImageURL, providerType: providerType, allRequiredTermsAgreed: data.agreedTerms)
+            return User(
+                id: data.id,
+                nickname: data.nickname,
+                email: data.email,
+                profileImageURL: profileImageURL,
+                providerType: providerType,
+                allRequiredTermsAgreed: data.agreedTerms,
+                marketingTermAgreed: data.marketingTerm,
+                pushNotificationAgreed: data.pushNotificationAgreed
+            )
         } catch let error as NetworkError {
             throw .networkError(error)
         } catch {
@@ -103,21 +116,51 @@ public struct DefaultAuthRepository: AuthRepository {
     }
     
     public func fetchTerms() async throws(AuthRepositoryError) -> [Term] {
+        try await fetchTermDTOs().map { $0.toEntity() }
+    }
+    
+    public func agreeWithTerms(agreements: [UserAgreement]) async throws(AuthRepositoryError) {
+        let agreements = agreements.map { AgreementsDTO(termID: $0.id, agreed: $0.isAgreed) }
+        try await requestTermsAgreement(agreements)
+    }
+
+    public func updateMarketingConsent(isAgreed: Bool) async throws(AuthRepositoryError) {
+        let terms = try await fetchTermDTOs()
+        guard let marketingTerm = terms.first(where: {
+            $0.termType?.caseInsensitiveCompare(Constants.marketingTermType) == .orderedSame
+        }) else {
+            throw .unknown
+        }
+
+        try await requestTermsAgreement([
+            AgreementsDTO(termID: marketingTerm.id, agreed: isAgreed)
+        ])
+    }
+}
+
+
+// MARK: - DefaultAuthRepository + Helpers
+
+private extension DefaultAuthRepository {
+    func fetchTermDTOs() async throws(AuthRepositoryError) -> [TermDTO] {
         let endpoint = AuthEndpoint.fetchTerms
-        
+
         do {
             let responseDTO: BaseResponseDTO<FetchTermsDTO.Response> = try await networkProvider.request(endpoint: endpoint)
-            guard let data = responseDTO.data else { throw AuthRepositoryError.networkError(.responseDecodingError) }
-            return data.terms.map { $0.toEntity() }
+            guard let data = responseDTO.data else {
+                throw AuthRepositoryError.networkError(.responseDecodingError)
+            }
+            return data.terms
+        } catch let error as AuthRepositoryError {
+            throw error
         } catch let error as NetworkError {
             throw .networkError(error)
         } catch {
             throw .unknown
         }
     }
-    
-    public func agreeWithTerms(agreements: [UserAgreement]) async throws(AuthRepositoryError) {
-        let agreements = agreements.map { AgreementsDTO(termID: $0.id, agreed: $0.isAgreed) }
+
+    func requestTermsAgreement(_ agreements: [AgreementsDTO]) async throws(AuthRepositoryError) {
         let dto = AgreeTermsDTO.Request(agreements: agreements)
         let endpoint = AuthEndpoint.agreeWithTerms(dto: dto)
         
@@ -129,12 +172,7 @@ public struct DefaultAuthRepository: AuthRepository {
             throw .unknown
         }
     }
-}
 
-
-// MARK: - DefaultAuthRepository + Helpers
-
-private extension DefaultAuthRepository {
     func requestUpdateProfileImage(id: ProfileImageEditAction.ImageID?) async throws(AuthRepositoryError) {
         let requestDTO = EditProfileImageDTO.Request(imageID: id)
         let endpoint = AuthEndpoint.editProfileImage(dto: requestDTO)

--- a/Neki-iOS/Core/Sources/Auth/Sources/Domain/Sources/AppStorageKey.swift
+++ b/Neki-iOS/Core/Sources/Auth/Sources/Domain/Sources/AppStorageKey.swift
@@ -9,4 +9,8 @@ import Foundation
 
 public struct AppStorageKey {
     public static let userSessionStatus: String = "UserSessionStatus"
+
+    public static func marketingConsentAlertPresentationCount(userID: Int) -> String {
+        "MarketingConsentAlertPresentationCount_\(userID)"
+    }
 }

--- a/Neki-iOS/Core/Sources/Auth/Sources/Domain/Sources/AppStorageKey.swift
+++ b/Neki-iOS/Core/Sources/Auth/Sources/Domain/Sources/AppStorageKey.swift
@@ -13,4 +13,8 @@ public struct AppStorageKey {
     public static func marketingConsentAlertPresentationCount(userID: Int) -> String {
         "MarketingConsentAlertPresentationCount_\(userID)"
     }
+
+    public static func requiredTermsAgreementPolicyVersion(userID: Int) -> String {
+        "RequiredTermsAgreementPolicyVersion_\(userID)"
+    }
 }

--- a/Neki-iOS/Core/Sources/Auth/Sources/Domain/Sources/Clients/AuthClient.swift
+++ b/Neki-iOS/Core/Sources/Auth/Sources/Domain/Sources/Clients/AuthClient.swift
@@ -27,8 +27,10 @@ public struct AuthClient {
     public var loginWithApple: @Sendable (_ idToken: Data) async throws -> User
     public var loginWithKakao: @Sendable () async throws -> User
     public var autoLogin: @Sendable () async throws -> User
+    public var fetchUser: @Sendable () async throws -> User
     public var fetchTerms: @Sendable () async throws -> [Term]
     public var agreeWithTerms: @Sendable (_ agreements: [UserAgreement]) async throws -> Void
+    public var updateMarketingConsent: @Sendable (_ isAgreed: Bool) async throws -> Void
     public var signOut: @Sendable () async throws -> Void
     public var withdraw: @Sendable () async throws -> Void
     public var updateProfile: @Sendable (_ nickname: String?, _ updateAction: ProfileImageUpdateAction) async throws -> User
@@ -81,6 +83,14 @@ extension AuthClient: DependencyKey {
                 throw AuthClient.mapError(error)
             }
         }
+
+        @Sendable func fetchUser() async throws -> User {
+            do {
+                return try await authRepository.fetchUser()
+            } catch {
+                throw AuthClient.mapError(error)
+            }
+        }
         
         @Sendable func fetchTerms() async throws -> [Term] {
             do {
@@ -93,6 +103,14 @@ extension AuthClient: DependencyKey {
         @Sendable func agreeWithTerms(agreements: [UserAgreement]) async throws -> Void {
             do {
                 try await authRepository.agreeWithTerms(agreements: agreements)
+            } catch {
+                throw AuthClient.mapError(error)
+            }
+        }
+
+        @Sendable func updateMarketingConsent(isAgreed: Bool) async throws -> Void {
+            do {
+                try await authRepository.updateMarketingConsent(isAgreed: isAgreed)
             } catch {
                 throw AuthClient.mapError(error)
             }
@@ -168,8 +186,10 @@ extension AuthClient: DependencyKey {
             loginWithApple: loginWithApple,
             loginWithKakao: loginWithKakao,
             autoLogin: autoLogin,
+            fetchUser: fetchUser,
             fetchTerms: fetchTerms,
             agreeWithTerms: agreeWithTerms,
+            updateMarketingConsent: updateMarketingConsent,
             signOut: signOut,
             withdraw: withdraw,
             updateProfile: updateProfile,

--- a/Neki-iOS/Core/Sources/Auth/Sources/Domain/Sources/Entities/User.swift
+++ b/Neki-iOS/Core/Sources/Auth/Sources/Domain/Sources/Entities/User.swift
@@ -15,8 +15,62 @@ public struct User: Sendable, Equatable, Codable {
     let profileImageURL: URL?
     let providerType: ProviderType
     var allRequiredTermsAgreed: Bool
+    var marketingTermAgreed: Bool
+    var pushNotificationAgreed: Bool
+
+    init(
+        id: Int,
+        nickname: String,
+        email: String?,
+        profileImageURL: URL?,
+        providerType: ProviderType,
+        allRequiredTermsAgreed: Bool,
+        marketingTermAgreed: Bool = false,
+        pushNotificationAgreed: Bool = false
+    ) {
+        self.id = id
+        self.nickname = nickname
+        self.email = email
+        self.profileImageURL = profileImageURL
+        self.providerType = providerType
+        self.allRequiredTermsAgreed = allRequiredTermsAgreed
+        self.marketingTermAgreed = marketingTermAgreed
+        self.pushNotificationAgreed = pushNotificationAgreed
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case nickname
+        case email
+        case profileImageURL
+        case providerType
+        case allRequiredTermsAgreed
+        case marketingTermAgreed
+        case pushNotificationAgreed
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(Int.self, forKey: .id)
+        nickname = try container.decode(String.self, forKey: .nickname)
+        email = try container.decodeIfPresent(String.self, forKey: .email)
+        profileImageURL = try container.decodeIfPresent(URL.self, forKey: .profileImageURL)
+        providerType = try container.decode(ProviderType.self, forKey: .providerType)
+        allRequiredTermsAgreed = try container.decode(Bool.self, forKey: .allRequiredTermsAgreed)
+        marketingTermAgreed = try container.decodeIfPresent(Bool.self, forKey: .marketingTermAgreed) ?? false
+        pushNotificationAgreed = try container.decodeIfPresent(Bool.self, forKey: .pushNotificationAgreed) ?? false
+    }
 }
 
 extension User {
-    static var dummy: Self { User(id: -1, nickname: "-", email: nil, profileImageURL: nil, providerType: .local, allRequiredTermsAgreed: true) }
+    static var dummy: Self {
+        User(
+            id: -1,
+            nickname: "-",
+            email: nil,
+            profileImageURL: nil,
+            providerType: .local,
+            allRequiredTermsAgreed: true
+        )
+    }
 }

--- a/Neki-iOS/Core/Sources/Auth/Sources/Domain/Sources/Interfaces/AuthRepository.swift
+++ b/Neki-iOS/Core/Sources/Auth/Sources/Domain/Sources/Interfaces/AuthRepository.swift
@@ -42,4 +42,6 @@ public protocol AuthRepository {
     func fetchTerms() async throws(AuthRepositoryError) -> [Term]
     /// 이용약관 동의
     func agreeWithTerms(agreements: [UserAgreement]) async throws(AuthRepositoryError) -> Void
+    /// 마케팅 수신 동의 변경
+    func updateMarketingConsent(isAgreed: Bool) async throws(AuthRepositoryError) -> Void
 }

--- a/Neki-iOS/Core/Sources/Auth/Sources/Presentation/Sources/Coordinator/LoginCoordinator.swift
+++ b/Neki-iOS/Core/Sources/Auth/Sources/Presentation/Sources/Coordinator/LoginCoordinator.swift
@@ -24,7 +24,7 @@ public struct LoginCoordinator {
         
         case delegate(Delegate)
         public enum Delegate {
-            case moveToMainTab(User)
+            case moveToMainTab(User, shouldPresentMarketingConsentAlert: Bool)
         }
     }
     
@@ -36,7 +36,10 @@ public struct LoginCoordinator {
                 // MARK: - Login Flow
             case let .root(.loginResponse(.success(user))):
                 if user.allRequiredTermsAgreed {
-                    return .send(.delegate(.moveToMainTab(user)))
+                    return .send(.delegate(.moveToMainTab(
+                        user,
+                        shouldPresentMarketingConsentAlert: false
+                    )))
                 } else {
                     state.pendingUser = user
                     state.path.append(.termsAgreement(.init()))
@@ -48,16 +51,18 @@ public struct LoginCoordinator {
                 return .none
                 
                 // MARK: - Onboarding Flow
-            case let .path(.element(id, action: .termsAgreement(.didFinishOnboarding))):
-                guard var user = state.pendingUser else {
+            case let .path(.element(id, action: .termsAgreement(.didFinishOnboarding(user)))):
+                guard state.pendingUser != nil else {
                     Logger.presentation.error("온보딩 과정 중 중단됨.")
                     return .none
                 }
                 
-                user.allRequiredTermsAgreed = true
                 state.pendingUser = nil
                 state.path.pop(from: id)
-                return .send(.delegate(.moveToMainTab(user)))
+                return .send(.delegate(.moveToMainTab(
+                    user,
+                    shouldPresentMarketingConsentAlert: user.marketingTermAgreed == false
+                )))
                 
             default:
                 return .none

--- a/Neki-iOS/Core/Sources/Auth/Sources/Presentation/Sources/Coordinator/LoginCoordinator.swift
+++ b/Neki-iOS/Core/Sources/Auth/Sources/Presentation/Sources/Coordinator/LoginCoordinator.swift
@@ -24,7 +24,11 @@ public struct LoginCoordinator {
         
         case delegate(Delegate)
         public enum Delegate {
-            case moveToMainTab(User, shouldPresentMarketingConsentAlert: Bool)
+            case moveToMainTab(
+                User,
+                shouldPresentMarketingConsentAlert: Bool,
+                didCompleteTermsAgreement: Bool
+            )
         }
     }
     
@@ -38,7 +42,8 @@ public struct LoginCoordinator {
                 if user.allRequiredTermsAgreed {
                     return .send(.delegate(.moveToMainTab(
                         user,
-                        shouldPresentMarketingConsentAlert: false
+                        shouldPresentMarketingConsentAlert: false,
+                        didCompleteTermsAgreement: false
                     )))
                 } else {
                     state.pendingUser = user
@@ -61,7 +66,8 @@ public struct LoginCoordinator {
                 state.path.pop(from: id)
                 return .send(.delegate(.moveToMainTab(
                     user,
-                    shouldPresentMarketingConsentAlert: user.marketingTermAgreed == false
+                    shouldPresentMarketingConsentAlert: user.marketingTermAgreed == false,
+                    didCompleteTermsAgreement: true
                 )))
                 
             default:

--- a/Neki-iOS/Core/Sources/Auth/Sources/Presentation/Sources/Feature/TermsAgreementFeature.swift
+++ b/Neki-iOS/Core/Sources/Auth/Sources/Presentation/Sources/Feature/TermsAgreementFeature.swift
@@ -29,10 +29,10 @@ public struct TermsAgreementFeature {
         
         // Internal Actions
         case fetchTermsResponse(Result<[Term], Error>)
-        case agreeTermsResponse(Result<Void, Error>)
+        case agreeTermsResponse(Result<User, Error>)
         
         // Delegate Actions
-        case didFinishOnboarding
+        case didFinishOnboarding(User)
         
         // Binding Action
         case binding(BindingAction<State>)
@@ -67,7 +67,10 @@ public struct TermsAgreementFeature {
                 let agreementsToSend = Array(state.agreements)
                 
                 return .run { send in
-                    await send(.agreeTermsResponse(Result { try await authClient.agreeWithTerms(agreementsToSend) }))
+                    await send(.agreeTermsResponse(Result {
+                        try await authClient.agreeWithTerms(agreementsToSend)
+                        return try await authClient.fetchUser()
+                    }))
                 }
                 
             case let .fetchTermsResponse(.success(terms)):
@@ -81,9 +84,9 @@ public struct TermsAgreementFeature {
                 Logger.presentation.error("Error occured while fetching terms: \(error)")
                 return .none
                 
-            case .agreeTermsResponse(.success):
+            case let .agreeTermsResponse(.success(user)):
                 state.isLoading = false
-                return .send(.didFinishOnboarding)
+                return .send(.didFinishOnboarding(user))
                 
             case let .agreeTermsResponse(.failure(error)):
                 state.isLoading = false

--- a/Neki-iOS/Core/Sources/Notification/Sources/Data/Sources/DTOs/FCMDeviceTokenDTO.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Data/Sources/DTOs/FCMDeviceTokenDTO.swift
@@ -1,0 +1,20 @@
+//
+//  FCMDeviceTokenDTO.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 6/14/26.
+//
+
+import Foundation
+
+enum FCMDeviceTokenDTO {
+    struct Request: Encodable {
+        let deviceToken: PushNotificationToken
+        let isPushNotificationAgreed: Bool
+        
+        enum CodingKeys: String, CodingKey {
+            case deviceToken
+            case isPushNotificationAgreed = "pushAgreed"
+        }
+    }
+}

--- a/Neki-iOS/Core/Sources/Notification/Sources/Data/Sources/Implementations/DefaultPushNotificationRepository.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Data/Sources/Implementations/DefaultPushNotificationRepository.swift
@@ -1,0 +1,76 @@
+//
+//  DefaultPushNotificationRepository.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 6/13/26.
+//
+
+import Foundation
+import Dependencies
+import FirebaseMessaging
+import UserNotifications
+
+final actor DefaultPushNotificationRepository: PushNotificationRepository {
+    private let notificationCenter: UNUserNotificationCenter
+    @Dependency(\.networkProvider) private var networkProvider
+
+    init(notificationCenter: UNUserNotificationCenter = .current()) {
+        self.notificationCenter = notificationCenter
+    }
+
+    func checkAuthorizationStatus() async -> UNAuthorizationStatus {
+        await notificationCenter.notificationSettings().authorizationStatus
+    }
+
+    func requestAuthorization() async throws -> Bool {
+        try await notificationCenter.requestAuthorization(options: [.alert, .badge, .sound])
+    }
+
+    func fetchFCMToken() async throws -> PushNotificationToken {
+        guard Messaging.messaging().apnsToken != nil else { throw PushNotificationRepositoryError.missingAPNSToken }
+
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<PushNotificationToken, Error>) in
+            Messaging.messaging().token { token, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let token, token.isEmpty == false {
+                    continuation.resume(returning: token)
+                } else {
+                    continuation.resume(throwing: PushNotificationRepositoryError.missingFCMToken)
+                }
+            }
+        }
+    }
+
+    nonisolated func updateAPNSToken(_ token: Data) {
+        Messaging.messaging().apnsToken = token
+    }
+
+    func updateDeviceToken(
+        _ token: PushNotificationToken,
+        isPushNotificationAgreed: Bool
+    ) async throws {
+        let dto = FCMDeviceTokenDTO.Request(
+            deviceToken: token,
+            isPushNotificationAgreed: isPushNotificationAgreed
+        )
+        let endpoint = PushNotificationEndpoint.setDeviceToken(dto: dto)
+        let _: BaseResponseDTO<EmptyData> = try await networkProvider.request(endpoint: endpoint)
+    }
+}
+
+private enum PushNotificationRepositoryError: Error {
+    case missingAPNSToken
+    case missingFCMToken
+}
+
+private enum PushNotificationRepositoryKey: DependencyKey {
+    static let liveValue: any PushNotificationRepository = DefaultPushNotificationRepository()
+}
+
+extension DependencyValues {
+    var pushNotificationRepository: any PushNotificationRepository {
+        get { self[PushNotificationRepositoryKey.self] }
+        set { self[PushNotificationRepositoryKey.self] = newValue }
+    }
+}

--- a/Neki-iOS/Core/Sources/Notification/Sources/Data/Sources/PushNotificationEndpoint.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Data/Sources/PushNotificationEndpoint.swift
@@ -1,0 +1,44 @@
+//
+//  PushNotificationEndpoint.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 6/14/26.
+//
+
+import Foundation
+import os
+
+enum PushNotificationEndpoint {
+    case setDeviceToken(dto: FCMDeviceTokenDTO.Request)
+}
+
+
+// MARK: - PushNotificationEndpoint + Endpoint
+
+extension PushNotificationEndpoint: Endpoint {
+    var authorizationType: AuthorizationType {
+        switch self {
+        case .setDeviceToken: return .bearer
+        }
+    }
+    
+    var contentType: HTTPContentType { .json }
+    
+    var path: String {
+        switch self {
+        case .setDeviceToken: "notifications"
+        }
+    }
+    
+    var method: HTTPMethodType {
+        switch self {
+        case .setDeviceToken: return .patch
+        }
+    }
+    
+    var body: (any Encodable)? {
+        switch self {
+        case let .setDeviceToken(dto): return dto
+        }
+    }
+}

--- a/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Clients/PushNotificationClient.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Clients/PushNotificationClient.swift
@@ -1,0 +1,79 @@
+//
+//  PushNotificationClient.swift
+//  Neki-iOS
+//
+//  Created by Codex on 6/7/26.
+//
+
+import Foundation
+import ComposableArchitecture
+import UserNotifications
+
+@DependencyClient
+public struct PushNotificationClient {
+    public var checkAuthorizationStatus: @Sendable () async throws -> UNAuthorizationStatus
+    public var requestAuthorization: @Sendable () async throws -> Bool
+    public var fetchFCMToken: @Sendable () async throws -> PushNotificationToken
+    public var synchronizeDeviceToken: @Sendable () async throws -> UNAuthorizationStatus
+    public var updateAPNSToken: @Sendable (_ token: Data) async throws -> Void
+}
+
+extension PushNotificationClient: DependencyKey {
+    public static let liveValue: PushNotificationClient = {
+        @Dependency(\.pushNotificationRepository) var repository
+
+        return PushNotificationClient(
+            checkAuthorizationStatus: {
+                await repository.checkAuthorizationStatus()
+            },
+            requestAuthorization: {
+                try await repository.requestAuthorization()
+            },
+            fetchFCMToken: {
+                try await repository.fetchFCMToken()
+            },
+            synchronizeDeviceToken: {
+                let deviceToken = try await repository.fetchFCMToken()
+                let authorizationStatus = await repository.checkAuthorizationStatus()
+                try await repository.updateDeviceToken(
+                    deviceToken,
+                    isPushNotificationAgreed: authorizationStatus.isPushNotificationAgreed
+                )
+                return authorizationStatus
+            },
+            updateAPNSToken: { token in
+                await repository.updateAPNSToken(token)
+            }
+        )
+    }()
+}
+
+extension PushNotificationClient: TestDependencyKey {
+    public static let testValue = PushNotificationClient(
+        checkAuthorizationStatus: { .notDetermined },
+        requestAuthorization: { false },
+        fetchFCMToken: { "" },
+        synchronizeDeviceToken: { .notDetermined },
+        updateAPNSToken: { _ in }
+    )
+}
+
+public extension DependencyValues {
+    var pushNotificationClient: PushNotificationClient {
+        get { self[PushNotificationClient.self] }
+        set { self[PushNotificationClient.self] = newValue }
+    }
+}
+
+private extension UNAuthorizationStatus {
+    var isPushNotificationAgreed: Bool {
+        switch self {
+        case .authorized, .provisional, .ephemeral:
+            true
+        case .notDetermined, .denied:
+            false
+        @unknown default:
+            false
+        }
+    }
+}

--- a/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Clients/PushNotificationClient.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Clients/PushNotificationClient.swift
@@ -13,7 +13,6 @@ import UserNotifications
 public struct PushNotificationClient {
     public var checkAuthorizationStatus: @Sendable () async throws -> UNAuthorizationStatus
     public var requestAuthorization: @Sendable () async throws -> Bool
-    public var fetchFCMToken: @Sendable () async throws -> PushNotificationToken
     public var synchronizeDeviceToken: @Sendable () async throws -> UNAuthorizationStatus
     public var updateAPNSToken: @Sendable (_ token: Data) async throws -> Void
 }
@@ -29,9 +28,6 @@ extension PushNotificationClient: DependencyKey {
             requestAuthorization: {
                 try await repository.requestAuthorization()
             },
-            fetchFCMToken: {
-                try await repository.fetchFCMToken()
-            },
             synchronizeDeviceToken: {
                 let deviceToken = try await repository.fetchFCMToken()
                 let authorizationStatus = await repository.checkAuthorizationStatus()
@@ -42,7 +38,7 @@ extension PushNotificationClient: DependencyKey {
                 return authorizationStatus
             },
             updateAPNSToken: { token in
-                await repository.updateAPNSToken(token)
+                repository.updateAPNSToken(token)
             }
         )
     }()
@@ -52,7 +48,6 @@ extension PushNotificationClient: TestDependencyKey {
     public static let testValue = PushNotificationClient(
         checkAuthorizationStatus: { .notDetermined },
         requestAuthorization: { false },
-        fetchFCMToken: { "" },
         synchronizeDeviceToken: { .notDetermined },
         updateAPNSToken: { _ in }
     )

--- a/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Clients/PushNotificationEventClient.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Clients/PushNotificationEventClient.swift
@@ -1,0 +1,37 @@
+//
+//  PushNotificationEventClient.swift
+//  Neki-iOS
+//
+//  Created by Codex on 6/16/26.
+//
+
+import ComposableArchitecture
+import Foundation
+
+@DependencyClient
+public struct PushNotificationEventClient {
+    public var events: @Sendable () async -> AsyncStream<PushNotificationEvent> = {
+        AsyncStream { $0.finish() }
+    }
+}
+
+extension PushNotificationEventClient: DependencyKey {
+    public static let liveValue = PushNotificationEventClient(
+        events: {
+            await PushNotificationEventBroker.shared.events()
+        }
+    )
+}
+
+extension PushNotificationEventClient: TestDependencyKey {
+    public static let testValue = PushNotificationEventClient(
+        events: { AsyncStream { $0.finish() } }
+    )
+}
+
+public extension DependencyValues {
+    var pushNotificationEventClient: PushNotificationEventClient {
+        get { self[PushNotificationEventClient.self] }
+        set { self[PushNotificationEventClient.self] = newValue }
+    }
+}

--- a/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Entities/PushNotificationPayload.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Entities/PushNotificationPayload.swift
@@ -1,0 +1,38 @@
+//
+//  PushNotificationPayload.swift
+//  Neki-iOS
+//
+//  Created by Codex on 6/16/26.
+//
+
+import Foundation
+
+public struct PushNotificationPayload: Equatable, Sendable {
+    public let values: [String: String]
+
+    public init(userInfo: [AnyHashable: Any]) {
+        self.values = userInfo.reduce(into: [:]) { result, element in
+            guard let key = element.key as? String else { return }
+
+            switch element.value {
+            case let value as String:
+                result[key] = value
+            case let value as Int:
+                result[key] = String(value)
+            case let value as Int64:
+                result[key] = String(value)
+            case let value as Double:
+                result[key] = String(value)
+            case let value as Bool:
+                result[key] = String(value)
+            default:
+                return
+            }
+        }
+    }
+}
+
+public enum PushNotificationEvent: Equatable, Sendable {
+    case foregroundReceived(PushNotificationPayload)
+    case responseReceived(PushNotificationPayload)
+}

--- a/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Entities/PushNotificationRoute.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Entities/PushNotificationRoute.swift
@@ -1,0 +1,28 @@
+//
+//  PushNotificationRoute.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 6/14/26.
+//
+
+import Foundation
+
+public enum PushNotificationRoute: Equatable, Sendable {
+    public typealias ResourceID = Int
+
+    case map
+    case mapBrand(ResourceID)
+    case mapBooth(ResourceID)
+    case archive
+    case archivePhoto(ResourceID)
+    case pose
+    case myPage
+}
+
+public enum PushNotificationLinkError: Error, Equatable {
+    case invalidResourceID
+    case invalidURL
+    case unsupportedScheme
+    case unsupportedRoute
+}
+

--- a/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Entities/PushNotificationToken.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Entities/PushNotificationToken.swift
@@ -1,0 +1,8 @@
+//
+//  PushNotificationToken.swift
+//  Neki-iOS
+//
+//  Created by Codex on 6/7/26.
+//
+
+public typealias PushNotificationToken = String

--- a/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Interfaces/PushNotificationRepository.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Interfaces/PushNotificationRepository.swift
@@ -1,0 +1,20 @@
+//
+//  PushNotificationRepository.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 6/13/26.
+//
+
+import Foundation
+import UserNotifications
+
+protocol PushNotificationRepository {
+    func checkAuthorizationStatus() async -> UNAuthorizationStatus
+    func requestAuthorization() async throws -> Bool
+    func fetchFCMToken() async throws -> PushNotificationToken
+    func updateAPNSToken(_ token: Data)
+    func updateDeviceToken(
+        _ token: PushNotificationToken,
+        isPushNotificationAgreed: Bool
+    ) async throws
+}

--- a/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Utilities/PushNotificationEventBroker.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Utilities/PushNotificationEventBroker.swift
@@ -1,0 +1,49 @@
+//
+//  PushNotificationEventBroker.swift
+//  Neki-iOS
+//
+//  Created by Codex on 6/16/26.
+//
+
+import Foundation
+
+public actor PushNotificationEventBroker {
+    public static let shared = PushNotificationEventBroker()
+
+    private var continuations: [UUID: AsyncStream<PushNotificationEvent>.Continuation] = [:]
+    private var pendingEvents: [PushNotificationEvent] = []
+
+    public func events() -> AsyncStream<PushNotificationEvent> {
+        let id = UUID()
+
+        return AsyncStream { continuation in
+            Task { await self.addContinuation(continuation, id: id) }
+
+            continuation.onTermination = { [weak self] _ in
+                Task { await self?.removeContinuation(id: id) }
+            }
+        }
+    }
+
+    public func publish(_ event: PushNotificationEvent) {
+        guard continuations.isEmpty == false else {
+            pendingEvents.append(event)
+            return
+        }
+
+        continuations.values.forEach { $0.yield(event) }
+    }
+
+    private func addContinuation(
+        _ continuation: AsyncStream<PushNotificationEvent>.Continuation,
+        id: UUID
+    ) {
+        continuations[id] = continuation
+        pendingEvents.forEach { continuation.yield($0) }
+        pendingEvents.removeAll()
+    }
+
+    private func removeContinuation(id: UUID) {
+        continuations.removeValue(forKey: id)
+    }
+}

--- a/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Utilities/PushNotificationLinkBuilder.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Utilities/PushNotificationLinkBuilder.swift
@@ -1,0 +1,71 @@
+//
+//  PushNotificationLinkBuilder.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 6/14/26.
+//
+
+import Foundation
+
+public protocol PushNotificationLinkBuilding: Sendable {
+    func makeLink(for route: PushNotificationRoute) throws -> URL
+}
+
+public struct PushNotificationLinkBuilder: PushNotificationLinkBuilding {
+    private let scheme: String
+    private let allowedSchemes: Set<String> = ["neki", "neki-dev"]
+
+    public init(scheme: String = "neki") {
+        self.scheme = scheme.lowercased()
+    }
+
+    public func makeLink(for route: PushNotificationRoute) throws -> URL {
+        guard allowedSchemes.contains(scheme) else {
+            throw PushNotificationLinkError.unsupportedScheme
+        }
+
+        var components = URLComponents()
+        components.scheme = scheme
+
+        switch route {
+        case .map:
+            components.host = "map"
+
+        case let .mapBrand(id):
+            components.host = "map"
+            components.path = try resourcePath(type: "brand", id: id)
+
+        case let .mapBooth(id):
+            components.host = "map"
+            components.path = try resourcePath(type: "booth", id: id)
+
+        case .archive:
+            components.host = "archive"
+
+        case let .archivePhoto(id):
+            components.host = "archive"
+            components.path = try resourcePath(type: "photo", id: id)
+
+        case .pose:
+            components.host = "pose"
+
+        case .myPage:
+            components.host = "mypage"
+        }
+
+        guard let url = components.url else {
+            throw PushNotificationLinkError.invalidURL
+        }
+        return url
+    }
+
+    private func resourcePath(
+        type: String,
+        id: PushNotificationRoute.ResourceID
+    ) throws -> String {
+        guard id > 0 else {
+            throw PushNotificationLinkError.invalidResourceID
+        }
+        return "/\(type)/\(id)"
+    }
+}

--- a/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Utilities/PushNotificationLinkParser.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Utilities/PushNotificationLinkParser.swift
@@ -1,0 +1,94 @@
+//
+//  PushNotificationLinkParser.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 6/14/26.
+//
+
+import Foundation
+
+public protocol PushNotificationLinkParsing: Sendable {
+    func parse(_ url: URL) throws -> PushNotificationRoute
+}
+
+public struct PushNotificationLinkParser: PushNotificationLinkParsing {
+    private let allowedSchemes: Set<String>
+
+    public init(allowedSchemes: Set<String> = ["neki", "neki-dev"]) {
+        self.allowedSchemes = allowedSchemes
+    }
+
+    public func parse(_ url: URL) throws -> PushNotificationRoute {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let scheme = components.scheme?.lowercased(),
+              allowedSchemes.contains(scheme)
+        else {
+            throw PushNotificationLinkError.unsupportedScheme
+        }
+
+        guard components.user == nil,
+              components.password == nil,
+              components.port == nil,
+              components.query == nil,
+              components.fragment == nil,
+              let host = components.host?.lowercased()
+        else {
+            throw PushNotificationLinkError.unsupportedRoute
+        }
+
+        let pathComponents = components.path
+            .split(separator: "/")
+            .map(String.init)
+
+        switch host {
+        case "map":
+            if pathComponents.isEmpty {
+                return .map
+            }
+            guard pathComponents.count == 2 else {
+                throw PushNotificationLinkError.unsupportedRoute
+            }
+            switch pathComponents[0] {
+            case "brand":
+                return .mapBrand(try resourceID(from: pathComponents[1]))
+            case "booth":
+                return .mapBooth(try resourceID(from: pathComponents[1]))
+            default:
+                throw PushNotificationLinkError.unsupportedRoute
+            }
+
+        case "archive":
+            if pathComponents.isEmpty {
+                return .archive
+            }
+            guard pathComponents.count == 2, pathComponents[0] == "photo" else {
+                throw PushNotificationLinkError.unsupportedRoute
+            }
+            return .archivePhoto(try resourceID(from: pathComponents[1]))
+
+        case "pose":
+            guard pathComponents.isEmpty else {
+                throw PushNotificationLinkError.unsupportedRoute
+            }
+            return .pose
+
+        case "mypage":
+            guard pathComponents.isEmpty else {
+                throw PushNotificationLinkError.unsupportedRoute
+            }
+            return .myPage
+
+        default:
+            throw PushNotificationLinkError.unsupportedRoute
+        }
+    }
+
+    private func resourceID(
+        from rawValue: String
+    ) throws -> PushNotificationRoute.ResourceID {
+        guard let id = Int(rawValue), id > 0 else {
+            throw PushNotificationLinkError.invalidResourceID
+        }
+        return id
+    }
+}

--- a/Neki-iOS/Core/Sources/Notification/Sources/Presentation/Sources/Coordinator/PushNotificationDelegate.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Presentation/Sources/Coordinator/PushNotificationDelegate.swift
@@ -1,0 +1,34 @@
+//
+//  PushNotificationDelegate.swift
+//  Neki-iOS
+//
+//  Created by Codex on 6/16/26.
+//
+
+import Foundation
+import UserNotifications
+
+final class PushNotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
+    private let eventBroker: PushNotificationEventBroker
+
+    init(eventBroker: PushNotificationEventBroker = .shared) {
+        self.eventBroker = eventBroker
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        let payload = PushNotificationPayload(userInfo: notification.request.content.userInfo)
+        await eventBroker.publish(.foregroundReceived(payload))
+        return [.banner, .sound, .badge]
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        let payload = PushNotificationPayload(userInfo: response.notification.request.content.userInfo)
+        await eventBroker.publish(.responseReceived(payload))
+    }
+}

--- a/Neki-iOS/Core/Sources/Notification/Sources/Presentation/Sources/Feature/PushNotificationListFeature.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Presentation/Sources/Feature/PushNotificationListFeature.swift
@@ -1,0 +1,29 @@
+//
+//  PushNotificationListFeature.swift
+//  Neki-iOS
+//
+//  Created by Codex on 6/14/26.
+//
+
+import ComposableArchitecture
+
+@Reducer
+struct PushNotificationListFeature {
+    @ObservableState
+    struct State: Equatable {}
+
+    enum Action {
+        case closeButtonTapped
+    }
+
+    @Dependency(\.dismiss) private var dismiss
+
+    var body: some ReducerOf<Self> {
+        Reduce { _, action in
+            switch action {
+            case .closeButtonTapped:
+                return .run { _ in await dismiss() }
+            }
+        }
+    }
+}

--- a/Neki-iOS/Core/Sources/Notification/Sources/Presentation/Sources/View/PushNotificationConsentAlertPreview.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Presentation/Sources/View/PushNotificationConsentAlertPreview.swift
@@ -1,0 +1,48 @@
+//
+//  PushNotificationConsentAlertPreview.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 6/14/26.
+//
+
+import SwiftUI
+
+struct PushNotificationConsentAlertPreview: View {
+    @State private var isPresented = true
+
+    var body: some View {
+        Color.gray25
+            .ignoresSafeArea()
+            .overlay {
+                Button("알림 다시 보기") {
+                    isPresented = true
+                }
+                .buttonStyle(.nekiCTA(.primary))
+                .padding(.horizontal, 28)
+            }
+            .nekiAlert(
+                isPresented: $isPresented,
+                style: .cancelable,
+                contentStyle: .marketingConsent(
+                    description:
+                        Text("마케팅 정보 푸시 수신 동의 여부는 ")
+                            .foregroundColor(.gray400)
+                        + Text("마이페이지 >\n권한 설정 > 알림 설정")
+                            .foregroundColor(.primary500)
+                        + Text("에서 변경 가능해요.")
+                            .foregroundColor(.gray400)
+                ),
+                title: "놓치지 마세요!",
+                subtitle: "네키의 이벤트, 혜택 프로모션,\n신규 업데이트 소식을 선별해서 알려드려요.",
+                confirmText: "네, 알려주세요",
+                cancelText: "괜찮아요",
+                hasIcon: true,
+                onConfirm: { isPresented = false },
+                onCancel: { isPresented = false }
+            )
+    }
+}
+
+#Preview("마케팅 알림 수신 동의") {
+    PushNotificationConsentAlertPreview()
+}

--- a/Neki-iOS/Core/Sources/Notification/Sources/Presentation/Sources/View/PushNotificationListView.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Presentation/Sources/View/PushNotificationListView.swift
@@ -1,0 +1,46 @@
+//
+//  PushNotificationListView.swift
+//  Neki-iOS
+//
+//  Created by Codex on 6/14/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct PushNotificationListView: View {
+    let store: StoreOf<PushNotificationListFeature>
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: .zero) {
+                Spacer()
+
+                VStack(spacing: 12) {
+                    Image(.iconEmpty)
+
+                    Text("아직 받은 알림이 없어요.")
+                        .nekiFont(.body16Medium)
+                        .foregroundStyle(.gray500)
+                }
+
+                Spacer()
+            }
+            .frame(maxWidth: .infinity)
+            .background(.gray25)
+            .nekiToolbar {
+                NekiToolBar.close { store.send(.closeButtonTapped) }
+            } center: {
+                NekiToolBar.textCenter("알림")
+            }
+        }
+    }
+}
+
+#Preview {
+    PushNotificationListView(
+        store: Store(initialState: PushNotificationListFeature.State()) {
+            PushNotificationListFeature()
+        }
+    )
+}

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Coordinator/ArchiveCoordinator.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Coordinator/ArchiveCoordinator.swift
@@ -26,6 +26,7 @@ struct ArchiveCoordinator {
         enum Delegate {
             case showToast(NekiToastItem)
             case requestQRScan
+            case requestNotificationList
         }
     }
     
@@ -40,6 +41,9 @@ struct ArchiveCoordinator {
                 // root action
             case .root(.delegate(.requestQRScan)):
                 return .send(.delegate(.requestQRScan))
+
+            case .root(.delegate(.requestNotificationList)):
+                return .send(.delegate(.requestNotificationList))
                 
             case .root(.addPhotoFromQRScanner):
                 state.path.removeAll()

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFeature.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/Feature/ArchiveFeature.swift
@@ -53,6 +53,7 @@ struct ArchiveFeature {
         case onTapConfirmAddAlbum
         case addFolderResponse(Result<Int, Error>)
         case onTapQRScan
+        case notificationButtonTapped
         case fetchAlbums
         case fetchPhotos
         case albumsResponse(Result<[AlbumItem], Error>)
@@ -79,6 +80,7 @@ struct ArchiveFeature {
         enum DelegateAction {
             case showToast(NekiToastItem)
             case requestQRScan
+            case requestNotificationList
         }
     }
     
@@ -147,6 +149,9 @@ struct ArchiveFeature {
                 return .send(.delegate(.showToast(NekiToastItem("앨범을 만들지 못했어요", style: .error))))
                 
             case .onTapQRScan: return .send(.delegate(.requestQRScan))
+
+            case .notificationButtonTapped:
+                return .send(.delegate(.requestNotificationList))
                 
             case .fetchAlbums:
                 return .merge(

--- a/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveView.swift
+++ b/Neki-iOS/Features/Archive/Sources/Presentation/Sources/View/ArchiveView.swift
@@ -150,11 +150,11 @@ private extension ArchiveView {
                     showDismiss: false
                 )
                 
-                //                Button {
-                //                    // TODO: - 알림 이벤트
-                //                } label: {
-                //                    Image(.iconBellFill)
-                //                }
+                Button {
+                    store.send(.notificationButtonTapped)
+                } label: {
+                    Image(.iconBellFill)
+                }
             }
         }
         .frame(height: 54)

--- a/Neki-iOS/Features/MyPage/Sources/Data/Sources/DefaultAppVersionRepository.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Data/Sources/DefaultAppVersionRepository.swift
@@ -10,9 +10,6 @@ import Dependencies
 import DependenciesMacros
 
 final actor DefaultAppVersionRepository {
-    private var minimumVersion: AppVersion?
-    private var latestVersion: AppVersion?
-    
     @Dependency(\.networkProvider) private var networkProvider
     
     init() {}
@@ -23,8 +20,6 @@ final actor DefaultAppVersionRepository {
 
 extension DefaultAppVersionRepository: AppVersionRepository {
     func fetchVersionInfo() async throws -> (minimumVersion: AppVersion, latestVersion: AppVersion) {
-        if let minimumVersion, let latestVersion { return (minimumVersion, latestVersion) }
-        
         let platform: String = "ios"
         let endpoint = MyPageEndpoint.fetchAppVersion(platform: platform)
         let responseDTO: BaseResponseDTO<FetchAppVersionDTO.Response> = try await networkProvider.request(endpoint: endpoint)
@@ -32,10 +27,7 @@ extension DefaultAppVersionRepository: AppVersionRepository {
         guard let data = responseDTO.data else { throw NetworkError.responseDecodingError }
         let minimumVersionEntity = AppVersion(value: data.minimumVersion)
         let latestVersionEntity = AppVersion(value: data.currentVersion)
-        
-        self.minimumVersion = minimumVersionEntity
-        self.latestVersion = latestVersionEntity
-        
+
         return (minimumVersionEntity, latestVersionEntity)
     }
 }

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Coordinator/MyPageCoordinator.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Coordinator/MyPageCoordinator.swift
@@ -16,22 +16,29 @@ struct MyPageCoordinator {
         
         var root = MyPageFeature.State()
         var path = StackState<Path.State>()
+        var toastItem: NekiToastItem?
     }
     
-    enum Action {
+    enum Action: BindableAction {
         case root(MyPageFeature.Action)
         case path(StackActionOf<Path>)
         
         case delegate(Delegate)
+        
+        case binding(BindingAction<State>)
+        
         enum Delegate {
             case didLogout
             case didWithdraw
+            case requestNotificationList
         }
     }
     
     @Dependency(\.openURL) private var openURL
     
     var body: some ReducerOf<Self> {
+        BindingReducer()
+        
         Scope(state: \.root, action: \.root) { MyPageFeature() }
         
         Reduce { (state: inout State, action: Action) -> Effect<Action> in
@@ -42,6 +49,9 @@ struct MyPageCoordinator {
             case .root(.profileTapped):
                 state.path.append(.accountPreference(.init()))
                 return .none
+
+            case .root(.notificationButtonTapped):
+                return .send(.delegate(.requestNotificationList))
                 
             case .path(.element(id: _, action: .accountPreference(.editProfileButtonTapped))):
                 guard case let .signedIn(user) = state.userSessionStatus else { return .none }
@@ -53,6 +63,13 @@ struct MyPageCoordinator {
                 
             case .path(.element(id: _, action: .accountPreference(.didWithdraw))):
                 return .send(.delegate(.didWithdraw))
+
+            case let .path(.element(
+                id: _,
+                action: .deviceAuthorizationPreference(.delegate(.showToast(item)))
+            )):
+                state.toastItem = item
+                return .none
                 
             default:
                 return .none

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Coordinator/MyPageCoordinatorView.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Coordinator/MyPageCoordinatorView.swift
@@ -31,5 +31,6 @@ struct MyPageCoordinatorView: View {
 
             }
         }
+        .nekiToast(item: $store.toastItem)
     }
 }

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/DeviceAuthorizationPreferenceFeature.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/DeviceAuthorizationPreferenceFeature.swift
@@ -10,23 +10,31 @@ import ComposableArchitecture
 import AVFoundation
 import CoreLocation
 import Photos
-// TODO: 알림 관련 임포팅 필요
-// import Firebase
+import UserNotifications
 
 @Reducer
 struct DeviceAuthorizationPreferenceFeature {
     @ObservableState
     struct State: Equatable {
+        @Shared(.appStorage(AppStorageKey.userSessionStatus)) var userSessionStatus: UserSessionStatus = .signedOut
+
         var cameraAuthorizationStatus: AVAuthorizationStatus = .notDetermined
         var locationAuthorizationStatus: CLAuthorizationStatus = .notDetermined
         var photosAuthorizationStatus: PHAuthorizationStatus = .notDetermined
+        var notificationAuthorizationStatus: UNAuthorizationStatus = .notDetermined
+        var isMarketingNotificationEnabled: Bool = false
+        var isUpdatingMarketingNotification: Bool = false
         
         var isCameraAuthorized: Bool { cameraAuthorizationStatus == .authorized }
         var isLocationAuthorized: Bool { locationAuthorizationStatus == .authorizedAlways || locationAuthorizationStatus == .authorizedWhenInUse }
         var isPhotosAuthorized: Bool { photosAuthorizationStatus == .authorized || photosAuthorizationStatus == .limited }
-        
-        var isAlertPresented: Bool = false
-        var alertItem: AlertItem?
+        var isNotificationAuthorized: Bool {
+            switch notificationAuthorizationStatus {
+            case .authorized, .provisional, .ephemeral: true
+            case .notDetermined, .denied: false
+            @unknown default: false
+            }
+        }
     }
     
     enum Action: BindableAction {
@@ -36,43 +44,32 @@ struct DeviceAuthorizationPreferenceFeature {
         case cameraCellTapped
         case locationCellTapped
         case photosCellTapped
+        case notificationsCellTapped
         
         // Internal Actions
         case updateCameraStatus(AVAuthorizationStatus)
         case updateLocationStatus(CLAuthorizationStatus)
         case updatePhotosStatus(PHAuthorizationStatus)
+        case updateNotificationStatus(UNAuthorizationStatus)
+        case marketingNotificationUpdateResponse(Bool, Result<Void, Error>)
+        case pushNotificationSynchronizationResponse(Result<UNAuthorizationStatus, Error>)
         case openAppSettings
-        case alertDismissed
+
+        // Delegate Actions
+        case delegate(Delegate)
+        enum Delegate {
+            case showToast(NekiToastItem)
+        }
         
         // Binding Actions
         case binding(BindingAction<State>)
     }
     
-    enum AlertItem {
-        case notification, photos, location, camera
-        
-        var title: String {
-            switch self {
-            case .notification: return "알림 권한"
-            case .photos: return "갤러리 권한"
-            case .location: return "위치 권한"
-            case .camera: return "카메라 권한"
-            }
-        }
-        
-        var description: String {
-            switch self {
-            case .notification: return "사진 저장 완료 오류 안내를 알려드리기 위해 알림 권한이 필요해요."
-            case .photos: return "사진을 불러와 네키에 저장 및 관리하기 위해 갤러리 접근 권한이 필요해요."
-            case .location: return "주변 포토부스를 찾기 위해 위치 사용 권한이 필요해요"
-            case .camera: return "QR 인식을 위해 카메라 접근이 필요해요."
-            }
-        }
-    }
-    
     @Dependency(\.dismiss) private var dismiss
     @Dependency(\.qrScannerClient) private var qrScannerClient
     @Dependency(\.mapClient) private var mapClient
+    @Dependency(\.pushNotificationClient) private var pushNotificationClient
+    @Dependency(\.authClient) private var authClient
     @Dependency(\.openURL) private var openURL
     
     var body: some ReducerOf<Self> {
@@ -81,6 +78,9 @@ struct DeviceAuthorizationPreferenceFeature {
         Reduce { (state: inout State, action: Action) -> Effect<Action> in
             switch action {
             case .onAppear:
+                if case let .signedIn(user) = state.userSessionStatus {
+                    state.isMarketingNotificationEnabled = user.marketingTermAgreed
+                }
                 return .merge(
                     .run { send in
                         let status = qrScannerClient.checkAuthorizationStatus()
@@ -94,6 +94,10 @@ struct DeviceAuthorizationPreferenceFeature {
                     .run { send in
                         let status = PHPhotoLibrary.authorizationStatus(for: .addOnly)
                         await send(.updatePhotosStatus(status))
+                    },
+                    .run { send in
+                        let status = try await pushNotificationClient.checkAuthorizationStatus()
+                        await send(.updateNotificationStatus(status))
                     }
                 )
                 
@@ -110,9 +114,7 @@ struct DeviceAuthorizationPreferenceFeature {
                     }
                     
                 case .denied, .restricted:
-                    state.alertItem = .camera
-                    state.isAlertPresented = true
-                    return .none
+                    return .send(.openAppSettings)
                     
                 case .authorized:
                     return .send(.openAppSettings)
@@ -129,9 +131,7 @@ struct DeviceAuthorizationPreferenceFeature {
                     }
                     
                 case .denied, .restricted:
-                    state.alertItem = .location
-                    state.isAlertPresented = true
-                    return .none
+                    return .send(.openAppSettings)
                     
                 case .authorizedAlways, .authorizedWhenInUse:
                     return .send(.openAppSettings)
@@ -149,9 +149,7 @@ struct DeviceAuthorizationPreferenceFeature {
                     }
                     
                 case .denied, .restricted:
-                    state.alertItem = .photos
-                    state.isAlertPresented = true
-                    return .none
+                    return .send(.openAppSettings)
                     
                 case .authorized, .limited:
                     return .send(.openAppSettings)
@@ -159,19 +157,74 @@ struct DeviceAuthorizationPreferenceFeature {
                 @unknown default:
                     return .none
                 }
+
+            case .notificationsCellTapped:
+                switch state.notificationAuthorizationStatus {
+                case .notDetermined:
+                    return .run { send in
+                        _ = try await pushNotificationClient.requestAuthorization()
+                        await send(.pushNotificationSynchronizationResponse(
+                            Result { try await pushNotificationClient.synchronizeDeviceToken() }
+                        ))
+                    }
+
+                case .denied:
+                    return .send(.openAppSettings)
+
+                case .authorized, .provisional, .ephemeral:
+                    return .send(.openAppSettings)
+
+                @unknown default:
+                    return .none
+                }
+
+            case .binding(\.isMarketingNotificationEnabled):
+                guard state.isUpdatingMarketingNotification == false else { return .none }
+
+                state.isUpdatingMarketingNotification = true
+                let requestedValue = state.isMarketingNotificationEnabled
+                return .run { send in
+                    await send(.marketingNotificationUpdateResponse(
+                        requestedValue,
+                        Result { try await authClient.updateMarketingConsent(requestedValue) }
+                    ))
+                }
+
+            case let .marketingNotificationUpdateResponse(requestedValue, .success):
+                state.isUpdatingMarketingNotification = false
+                state.$userSessionStatus.withLock {
+                    guard case let .signedIn(currentUser) = $0 else { return }
+                    var user = currentUser
+                    user.marketingTermAgreed = requestedValue
+                    $0 = .signedIn(user)
+                }
+                let message = requestedValue
+                    ? "마케팅 알림 수신에 동의했어요."
+                    : "마케팅 알림 수신을 거부했어요.\n마이페이지에서 언제든지 변경할 수 있어요."
+                return .send(.delegate(.showToast(
+                    NekiToastItem(message, style: .success)
+                )))
+
+            case let .marketingNotificationUpdateResponse(requestedValue, .failure):
+                state.isUpdatingMarketingNotification = false
+                state.isMarketingNotificationEnabled = !requestedValue
+                return .none
+
+            case let .pushNotificationSynchronizationResponse(.success(status)):
+                state.notificationAuthorizationStatus = status
+                return .none
+
+            case .pushNotificationSynchronizationResponse(.failure):
+                return .run { send in
+                    let status = try await pushNotificationClient.checkAuthorizationStatus()
+                    await send(.updateNotificationStatus(status))
+                }
                 
             case .openAppSettings:
-                state.alertItem = nil
-                state.isAlertPresented = false
-                return .run { send in
+                return .run { _ in
                     guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
                     await openURL(url)
                 }
-                
-            case .alertDismissed:
-                state.alertItem = nil
-                state.isAlertPresented = false
-                return .none
                 
             case let .updateCameraStatus(status):
                 state.cameraAuthorizationStatus = status
@@ -183,6 +236,10 @@ struct DeviceAuthorizationPreferenceFeature {
                 
             case let .updateLocationStatus(status):
                 state.locationAuthorizationStatus = status
+                return .none
+
+            case let .updateNotificationStatus(status):
+                state.notificationAuthorizationStatus = status
                 return .none
                 
             default:

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/DeviceAuthorizationPreferenceFeature.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/DeviceAuthorizationPreferenceFeature.swift
@@ -198,6 +198,10 @@ struct DeviceAuthorizationPreferenceFeature {
                     user.marketingTermAgreed = requestedValue
                     $0 = .signedIn(user)
                 }
+                if case let .signedIn(user) = state.userSessionStatus {
+                    let key = AppStorageKey.marketingConsentAlertPresentationCount(userID: user.id)
+                    UserDefaults.standard.set(2, forKey: key)
+                }
                 let message = requestedValue
                     ? "마케팅 알림 수신에 동의했어요."
                     : "마케팅 알림 수신을 거부했어요.\n마이페이지에서 언제든지 변경할 수 있어요."

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/MyPageFeature.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/MyPageFeature.swift
@@ -25,6 +25,7 @@ struct MyPageFeature {
         case onAppear
         case cellTapped(SectionCellItem)
         case profileTapped
+        case notificationButtonTapped
     }
     
     @Dependency(\.appVersionClient) private var appVersionClient

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/DeviceAuthorizationPreferenceView.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/DeviceAuthorizationPreferenceView.swift
@@ -13,30 +13,30 @@ struct DeviceAuthorizationPreferenceView: View {
     
     var body: some View {
         VStack {
-            Section {
-                VStack(spacing: 24) {
-                    cell(for: .camera, isAuthorized: store.isCameraAuthorized) {
-                        store.send(.cameraCellTapped)
+            VStack(spacing: 32) {
+                settingsSection(title: "권한 설정") {
+                    VStack(spacing: 24) {
+                        cell(for: .camera, isAuthorized: store.isCameraAuthorized) {
+                            store.send(.cameraCellTapped)
+                        }
+                        
+                        cell(for: .location, isAuthorized: store.isLocationAuthorized) {
+                            store.send(.locationCellTapped)
+                        }
+                        
+                        cell(for: .photos, isAuthorized: store.isPhotosAuthorized) {
+                            store.send(.photosCellTapped)
+                        }
+                        
+                        cell(for: .notifications, isAuthorized: store.isNotificationAuthorized) {
+                            store.send(.notificationsCellTapped)
+                        }
                     }
-                    
-                    cell(for: .location, isAuthorized: store.isLocationAuthorized) {
-                        store.send(.locationCellTapped)
-                    }
-                    
-                    cell(for: .photos, isAuthorized: store.isPhotosAuthorized) {
-                        store.send(.photosCellTapped)
-                    }
-                    
-                    // TODO: 알림 기능부터 구현 필요
-//                    cell(for: .notifications, isAuthorized: true) {
-//                        <#code#>
-//                    }
                 }
-            } header: {
-                Text("권한 설정")
-                    .nekiFont(.body14Medium)
-                    .foregroundStyle(.gray400)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                settingsSection(title: "알람 설정") {
+                    marketingNotificationToggle
+                }
             }
             .padding(.horizontal)
             .padding(.top)
@@ -46,19 +46,8 @@ struct DeviceAuthorizationPreferenceView: View {
         .nekiToolbar {
             NekiToolBar.back { store.send(.dismissButtonTapped) }
         } center: {
-            NekiToolBar.textCenter("기기 권한")
+            NekiToolBar.textCenter("기기 권한 및 알림")
         }
-        .nekiAlert(
-            isPresented: $store.isAlertPresented,
-            style: .cancelable,
-            title: store.alertItem?.title ?? "권한 안내",
-            subtitle: store.alertItem?.description ?? "원활한 서비스 제공을 위해 권한을 허용해주세요.",
-            confirmText: "허용",
-            cancelText: "취소",
-            hasIcon: true,
-            onConfirm: { store.send(.openAppSettings) },
-            onCancel: { store.send(.alertDismissed) }
-        )
         .onAppear { store.send(.onAppear) }
     }
 }
@@ -67,6 +56,35 @@ struct DeviceAuthorizationPreferenceView: View {
 // MARK: - DeviceAuthorizationPreferenceView + Subviews
 
 private extension DeviceAuthorizationPreferenceView {
+    func settingsSection<Content: View>(
+        title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(title)
+                .nekiFont(.body14Medium)
+                .foregroundStyle(.gray400)
+
+            content()
+        }
+    }
+
+    var marketingNotificationToggle: some View {
+        Toggle(isOn: $store.isMarketingNotificationEnabled) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(AuthorizationType.marketingNotifications.cellTitle)
+                    .nekiFont(.title18Medium)
+                    .foregroundStyle(.gray900)
+
+                Text(AuthorizationType.marketingNotifications.cellSubtitle)
+                    .nekiFont(.body14Medium)
+                    .foregroundStyle(.gray400)
+            }
+        }
+        .toggleStyle(.nekiSwitch)
+        .disabled(store.isUpdatingMarketingNotification)
+    }
+
     func cell(for type: AuthorizationType, isAuthorized: Bool, _ onTap: @escaping () -> Void) -> some View {
         HStack {
             VStack(alignment: .leading, spacing: 4) {
@@ -100,7 +118,7 @@ private extension DeviceAuthorizationPreferenceView {
 
 private extension DeviceAuthorizationPreferenceView {
     enum AuthorizationType {
-        case camera, location, photos, notifications
+        case camera, location, photos, notifications, marketingNotifications
         
         var cellTitle: String {
             switch self {
@@ -108,6 +126,7 @@ private extension DeviceAuthorizationPreferenceView {
             case .location: return "위치"
             case .photos: return "저장소"
             case .notifications: return "알림"
+            case .marketingNotifications: return "혜택·소식 알림"
             }
         }
         
@@ -117,6 +136,7 @@ private extension DeviceAuthorizationPreferenceView {
             case .location: return "주변 포토부스 탐색에 필요해요."
             case .photos: return "사진 저장 및 업로드에 필요해요."
             case .notifications: return "저장 사진 및 추억 리마인드에 필요해요."
+            case .marketingNotifications: return "이벤트, 혜택, 신규 기능 소식 등을 알려드려요."
             }
         }
     }

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/MyPageView.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/MyPageView.swift
@@ -34,8 +34,9 @@ struct MyPageView: View {
         .nekiToolbar(
             left: { NekiToolBar.textLeft("마이페이지") },
             right: {
-                // TODO: 알림 기능 보류
-                // NekiToolBar.icon(.iconBellFill)
+                NekiToolBar.icon(.iconBellFill) {
+                    store.send(.notificationButtonTapped)
+                }
             }
         )
         .task { await store.send(.onAppear).finish() }

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Coordinator/PoseCoordinator.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Coordinator/PoseCoordinator.swift
@@ -29,6 +29,7 @@ struct PoseCoordinator {
         enum Delegate {
             case logout
             case requestQRScan
+            case requestNotificationList
         }
     }
     
@@ -51,6 +52,9 @@ struct PoseCoordinator {
                 
             case .root(.delegate(.qrScanButtonTapped)):
                 return .send(.delegate(.requestQRScan))
+
+            case .root(.delegate(.requestNotificationList)):
+                return .send(.delegate(.requestNotificationList))
                 
                 // MARK: - Data Synchronization (Coordinator's Main Job)
             case let .path(.element(_, action: .detail(.delegate(.poseUpdated(pose))))):

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Feature/PoseFeature.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Feature/PoseFeature.swift
@@ -62,6 +62,7 @@ struct PoseFeature {
         case onTapBookmark(Pose)
         case onRefresh
         case qrScanButtonTapped
+        case notificationButtonTapped
         
         // Internal Actions (Async Results & Data Updates)
         case fetchListResponse(isScrapResult: Bool, Result<(poses: [Pose], hasNext: Bool), Error>)
@@ -74,6 +75,7 @@ struct PoseFeature {
             case didTapImage(Pose)
             case didTapStartRandomPose(PeopleCountOption)
             case qrScanButtonTapped
+            case requestNotificationList
         }
         
         // Binding Action
@@ -159,6 +161,9 @@ struct PoseFeature {
                 
             case .qrScanButtonTapped:
                 return .send(.delegate(.qrScanButtonTapped))
+
+            case .notificationButtonTapped:
+                return .send(.delegate(.requestNotificationList))
                 
             case let .onTapBookmark(pose):
                 var updatedPose = pose

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/PoseView.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/PoseView.swift
@@ -47,12 +47,11 @@ struct PoseView: View {
                     Image(.iconQrCode)
                 }
                 
-                // 알림
-//                Button {
-//                    
-//                } label: {
-//                    Image(.iconBellFill)
-//                }
+                Button {
+                    store.send(.notificationButtonTapped)
+                } label: {
+                    Image(.iconBellFill)
+                }
             } }
         )
         .sheet(item: $store.sheetItem) { item in

--- a/Neki-iOS/Neki-iOS-Debug.entitlements
+++ b/Neki-iOS/Neki-iOS-Debug.entitlements
@@ -6,6 +6,8 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:neki.suitestudy.com</string>

--- a/Neki-iOS/Neki-iOS-Debug.entitlements
+++ b/Neki-iOS/Neki-iOS-Debug.entitlements
@@ -2,12 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>
 	</array>
-	<key>aps-environment</key>
-	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:neki.suitestudy.com</string>

--- a/Neki-iOS/Neki-iOS-Release.entitlements
+++ b/Neki-iOS/Neki-iOS-Release.entitlements
@@ -2,12 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>production</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>
 	</array>
-	<key>aps-environment</key>
-	<string>production</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:neki.suitestudy.com</string>

--- a/Neki-iOS/Neki-iOS-Release.entitlements
+++ b/Neki-iOS/Neki-iOS-Release.entitlements
@@ -6,6 +6,8 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<key>aps-environment</key>
+	<string>production</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:neki.suitestudy.com</string>

--- a/Neki-iOS/Shared/DesignSystem/Sources/Component/Button/Style/NekiSwitchToggleStyle.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Component/Button/Style/NekiSwitchToggleStyle.swift
@@ -1,0 +1,48 @@
+//
+//  NekiSwitchToggleStyle.swift
+//  Neki-iOS
+//
+//  Created by Codex on 6/14/26.
+//
+
+import SwiftUI
+
+public struct NekiSwitchToggleStyle: ToggleStyle {
+    @Environment(\.isEnabled) private var isEnabled
+
+    public init() {}
+
+    public func makeBody(configuration: Configuration) -> some View {
+        Button {
+            configuration.isOn.toggle()
+        } label: {
+            HStack {
+                configuration.label
+
+                Spacer()
+
+                Capsule()
+                    .fill(configuration.isOn ? .primary300 : .gray100)
+                    .frame(width: 52, height: 28)
+                    .overlay {
+                        Circle()
+                            .fill(.white)
+                            .frame(width: 24, height: 24)
+                            .shadow(color: .black.opacity(0.12), radius: 1, y: 1)
+                            .offset(x: configuration.isOn ? 12 : -12)
+                    }
+            }
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .opacity(isEnabled ? 1 : 0.5)
+        .animation(.easeInOut(duration: 0.2), value: configuration.isOn)
+    }
+}
+
+
+// MARK: - NekiSwitchToggleStyle + Accessor
+
+public extension ToggleStyle where Self == NekiSwitchToggleStyle {
+    static var nekiSwitch: NekiSwitchToggleStyle { NekiSwitchToggleStyle() }
+}

--- a/Neki-iOS/Shared/DesignSystem/Sources/Component/Modal/NekiAlertModal.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Component/Modal/NekiAlertModal.swift
@@ -13,6 +13,11 @@ public enum NekiAlertStyle {
     case primarySecondary
 }
 
+public enum NekiAlertContentStyle {
+    case standard
+    case marketingConsent(description: Text)
+}
+
 public struct NekiAlertModal<Content: View, Actions: View>: View {
     let content: Content
     let actions: Actions

--- a/Neki-iOS/Shared/DesignSystem/Sources/Component/NekiToast/NekiToast.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Component/NekiToast/NekiToast.swift
@@ -62,9 +62,9 @@ struct NekiToastView: View {
             Text(item.message)
                 .nekiFont(.body16Medium)
                 .foregroundStyle(.white)
-                .lineLimit(2)
-            
-            Spacer()
+                .lineLimit(nil)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
             
             if let buttonTitle = item.buttonTitle, let action = item.action {
                 Button {
@@ -81,7 +81,7 @@ struct NekiToastView: View {
                 }
             }
         }
-        .frame(width: 303, height: 26)
+        .frame(width: 303)
         .padding(16)
         .background(.gray800)
         .clipShape(RoundedRectangle(cornerRadius: 12))

--- a/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiAlertModifier.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiAlertModifier.swift
@@ -26,6 +26,7 @@ struct NekiAlertModifier: ViewModifier {
     // 액션 클로저
     let onConfirm: (() -> Void)?
     let onCancel: (() -> Void)?
+    let onDismiss: (() -> Void)?
     let onSecondary: (() -> Void)?
     
     func body(content: Content) -> some View {
@@ -39,7 +40,10 @@ struct NekiAlertModifier: ViewModifier {
                     .zIndex(1)
                     .transition(.opacity)
                     .onTapGesture {
-                        if let onCancel = onCancel {
+                        guard isProcessing == false else { return }
+                        if let onDismiss {
+                            onDismiss()
+                        } else if let onCancel {
                             onCancel()
                         } else {
                             isPresented.toggle()
@@ -187,6 +191,7 @@ public extension View {
         hasIcon: Bool = true,
         onConfirm: (() -> Void)? = nil,
         onCancel: (() -> Void)? = nil,
+        onDismiss: (() -> Void)? = nil,
         onSecondary: (() -> Void)? = nil
     ) -> some View {
         self.modifier(NekiAlertModifier(
@@ -202,6 +207,7 @@ public extension View {
             hasIcon: hasIcon,
             onConfirm: onConfirm,
             onCancel: onCancel,
+            onDismiss: onDismiss,
             onSecondary: onSecondary
         ))
     }

--- a/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiAlertModifier.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiAlertModifier.swift
@@ -11,6 +11,7 @@ struct NekiAlertModifier: ViewModifier {
     @Binding var isPresented: Bool
     
     let style: NekiAlertStyle
+    let contentStyle: NekiAlertContentStyle
     let title: String
     let subtitle: String
     
@@ -46,17 +47,7 @@ struct NekiAlertModifier: ViewModifier {
                     }
                 
                 NekiAlertModal(hasIcon: hasIcon) {
-                    VStack(spacing: 4) {
-                        Text(title)
-                            .nekiFont(.title18Bold)
-                            .foregroundStyle(.gray900)
-                            .multilineTextAlignment(.center)
-                        
-                        Text(subtitle)
-                            .nekiFont(.body14Regular)
-                            .foregroundStyle(.gray500)
-                            .multilineTextAlignment(.center)
-                    }
+                    alertContent
                 } actions: {
                     buttonStack
                 }
@@ -66,6 +57,58 @@ struct NekiAlertModifier: ViewModifier {
             }
         }
         .animation(.easeInOut(duration: 0.2), value: isPresented)
+    }
+
+    @ViewBuilder
+    private var alertContent: some View {
+        switch contentStyle {
+        case .standard:
+            VStack(spacing: 4) {
+                titleText
+                    .nekiFont(.title18Bold)
+
+                subtitleText
+            }
+
+        case let .marketingConsent(description):
+            VStack(spacing: 2) {
+                titleText
+                    .nekiFont(.title24SemiBold)
+
+                subtitleText
+                    .padding(.top, 4)
+
+                description
+                    .nekiFont(.caption12Regular)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity)
+                    .padding(16)
+                    .background {
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(.gray50)
+                    }
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 12)
+                            .strokeBorder(.gray100, lineWidth: 1)
+                    }
+                    .padding(.top, 20)
+            }
+        }
+    }
+
+    private var titleText: some View {
+        Text(title)
+            .foregroundStyle(.gray900)
+            .multilineTextAlignment(.center)
+    }
+
+    private var subtitleText: some View {
+        Text(subtitle)
+            .nekiFont(.body14Regular)
+            .foregroundStyle(.gray500)
+            .multilineTextAlignment(.center)
     }
     
     // MARK: - Button Logic
@@ -134,6 +177,7 @@ public extension View {
     func nekiAlert(
         isPresented: Binding<Bool>,
         style: NekiAlertStyle = .plain,
+        contentStyle: NekiAlertContentStyle = .standard,
         title: String,
         subtitle: String,
         confirmText: String = "확인",
@@ -148,6 +192,7 @@ public extension View {
         self.modifier(NekiAlertModifier(
             isPresented: isPresented,
             style: style,
+            contentStyle: contentStyle,
             title: title,
             subtitle: subtitle,
             confirmText: confirmText,


### PR DESCRIPTION
## 🌴 작업한 브랜치
`feat/#241-fcm-notification`

## ✅ 작업한 내용

- FCM 기반 푸시 알림 환경을 구성했습니다.
  - APNs 토큰을 Firebase Messaging에 전달하도록 연결
  - FCM 토큰을 서버의 알림 등록/수정 API로 동기화
  - 앱 런치 및 권한 상태 변경 시점에 알림 권한 상태를 서버에 반영

- 마케팅 정보 푸시 수신 동의 플로우를 구현했습니다.
  - 마케팅 수신 동의용 `NekiAlert` 구성
  - 회원가입 이후 비동의 사용자 대상 마케팅 동의 팝업 노출
  - 마이페이지 기기 권한 화면에서 마케팅 알림 수신 여부 변경
  - 동의/거부 성공 시 Toast 노출

- 기기 권한 및 알림 설정 화면을 정리했습니다.
  - 네비게이션 타이틀을 `기기 권한 및 알림`으로 변경
  - 권한 설정 / 알람 설정 섹션 구성
  - `혜택·소식 알림` 토글 추가
  - 디자인 시스템에 신규 토글 스타일 추가

- 업데이트 후 기존 사용자 대상 약관 재동의 플로우를 추가했습니다.
  - 서버의 `agreedTerms` 값을 변경하지 않는 전제에서 로컬 정책 버전 기반으로 약관 화면 진입 처리
  - 약관 완료 후 사용자별 로컬 정책 버전 저장

- 알림 수신 이벤트 처리 구조를 분리했습니다.
  - `UNUserNotificationCenterDelegate` 역할을 별도 객체로 분리
  - 알림 foreground 수신 및 클릭 이벤트를 앱 계층으로 전달
  - 알림 클릭 시 GA 이벤트 기록
  - 이번 스프린트 범위에서 알림 클릭 후 화면 이동은 제외

- 알림 목록 화면 진입점을 임시 연결했습니다.
  - API 및 디자인 가이드 확정 전까지 빈 상태 화면으로 연결

## ❗️PR Point

- 알림 클릭 후 앱 내부 화면 이동은 이번 스프린트 범위에서 제외했습니다.
  - 추후 서버 페이로드의 `link` 스펙과 앱 내부 라우팅 대상이 확정되면 별도 작업으로 진행해야 합니다.

- 알림 목록 화면은 API와 디자인 가이드가 아직 확정되지 않아 임시 빈 상태 화면으로만 연결했습니다.

- `push_notification_click` GA는 현재 확정 가능한 payload key만 optional parameter로 기록합니다.
  - `notification_type`
  - `notification_tone`

- 실기기에서 Firebase Console 테스트 발송으로 알림 수신은 확인했습니다.
  - QA 단계에서 권한 상태별 케이스, 업데이트 기존 사용자 케이스, 마케팅 수신 동의/거부 케이스를 추가 확인해야 합니다.

## 📸 스크린샷
생략합니다.

## 📟 관련 이슈
- Resolved: #241