### PR TITLE
[Refactor] 포즈 상세정보 API 연결

### DIFF
--- a/Neki-iOS/Features/Pose/Sources/Data/Sources/DTOs/PoseDTO.swift
+++ b/Neki-iOS/Features/Pose/Sources/Data/Sources/DTOs/PoseDTO.swift
@@ -13,6 +13,8 @@ struct PoseDTO: Decodable {
     let imageURLString: String
     let isScrapped: Bool?
     let contentType: String
+    let width: Int?
+    let height: Int?
     let createdAt: Date
     
     enum CodingKeys: String, CodingKey {
@@ -21,6 +23,8 @@ struct PoseDTO: Decodable {
         case imageURLString = "imageUrl"
         case isScrapped = "scrap"
         case contentType
+        case width
+        case height
         case createdAt
     }
     
@@ -38,6 +42,15 @@ struct PoseDTO: Decodable {
         let imageURL = URL(string: imageURLString)
         let imageContentType = ImageContentType(contentType) ?? .jpeg
         
-        return Pose(id: id, peopleCountOption: peopleCountOption, imageURL: imageURL, isScrapped: isScrapped ?? false, contentType: imageContentType, createdAt: createdAt)
+        return Pose(
+            id: id,
+            peopleCountOption: peopleCountOption,
+            imageURL: imageURL,
+            isScrapped: isScrapped ?? false,
+            contentType: imageContentType,
+            width: width,
+            height: height,
+            createdAt: createdAt
+        )
     }
 }

--- a/Neki-iOS/Features/Pose/Sources/Domain/Sources/Clients/PoseClient.swift
+++ b/Neki-iOS/Features/Pose/Sources/Domain/Sources/Clients/PoseClient.swift
@@ -12,6 +12,7 @@ import ComposableArchitecture
 public struct PoseClient {
     public var fetchPoseList: @Sendable (_ page: Int, _ pageSize: Int, _ refresh: Bool) async throws -> (poses: [Pose], hasNext: Bool)
     public var fetchScrappedPoseList: @Sendable (_ page: Int, _ pageSize: Int, _ refresh: Bool) async throws -> (poses: [Pose], hasNext: Bool)
+    public var fetchPoseDetail: @Sendable (_ id: PoseID) async throws -> Pose
     public var scrapPose: @Sendable (_ poseID: Int) async throws -> Void
     public var initializeRandomPose: @Sendable (_ peopleCount: PeopleCountOption) async throws -> Pose
     public var startRandomPoseSuggestion: @Sendable (_ direction: RandomPosePagingDirection) async throws -> Pose
@@ -29,6 +30,8 @@ extension PoseClient: DependencyKey {
             try await poseRepository.fetchPoseList(page: page, pageSize: pageSize, refresh: refresh)
         } fetchScrappedPoseList: { page, pageSize, refresh in
             try await poseRepository.fetchScrappedPoseList(page: page, pageSize: pageSize, refresh: refresh)
+        } fetchPoseDetail: { id in
+            try await poseRepository.fetchPoseDetail(id: id)
         } scrapPose: { poseID in
             try await poseRepository.scrapPose(poseID: poseID)
         } initializeRandomPose: { peopleCount in

--- a/Neki-iOS/Features/Pose/Sources/Domain/Sources/Entities/Pose.swift
+++ b/Neki-iOS/Features/Pose/Sources/Domain/Sources/Entities/Pose.swift
@@ -13,5 +13,7 @@ public struct Pose: Identifiable, Sendable, Equatable {
     public let imageURL: URL?
     public var isScrapped: Bool
     public let contentType: ImageContentType
+    public let width: Int?
+    public let height: Int?
     public let createdAt: Date
 }

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Coordinator/PoseCoordinator.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Coordinator/PoseCoordinator.swift
@@ -66,7 +66,7 @@ struct PoseCoordinator {
             case let .routeToDetail(pose):
                 state.path.append(.detail(PoseDetailFeature.State(
                     poses: state.root.filteredPoses,
-                    selectedID: pose.id
+                    selectedPose: pose
                 )))
                 return .none
                 

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Feature/PoseDetailFeature.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/Feature/PoseDetailFeature.swift
@@ -17,15 +17,44 @@ struct PoseDetailFeature {
         var selectedID: PoseID
         var currentPose: Pose? { poses[id: selectedID] }
         var isScrapped: Bool { currentPose?.isScrapped ?? false }
+
+        init(
+            poses: IdentifiedArrayOf<Pose>,
+            selectedID: PoseID
+        ) {
+            self.poses = poses
+            self.selectedID = selectedID
+        }
+
+        init(
+            poses: IdentifiedArrayOf<Pose>,
+            selectedPose: Pose
+        ) {
+            self.poses = poses
+            self.selectedID = selectedPose.id
+            updatePose(selectedPose)
+        }
+
+        mutating func updatePose(_ pose: Pose) {
+            if poses[id: pose.id] == nil {
+                poses.append(pose)
+            } else {
+                poses[id: pose.id] = pose
+            }
+        }
     }
     
     enum Action {
+        // Lifecycle Actions
+        case onAppear
+
         // User Actions
         case onTapScrap
         case pageChanged(PoseID)
         case didTapBackButton
         
         // Internal Actions
+        case poseDetailResponse(PoseID, Result<Pose, Error>)
         case scrapResponse(Pose, Result<Void, Error>)
         
         // Delegate Actions
@@ -36,6 +65,7 @@ struct PoseDetailFeature {
     }
     
     private enum CancelID: Hashable {
+        case detail
         case scrap(PoseID)
     }
     
@@ -46,6 +76,10 @@ struct PoseDetailFeature {
     var body: some ReducerOf<Self> {
         Reduce { (state: inout State, action: Action) -> Effect<Action> in
             switch action {
+                // MARK: - Lifecycle Actions
+            case .onAppear:
+                return fetchPoseDetail(id: state.selectedID)
+
                 // MARK: - View Actions
             case .onTapScrap:
                 guard var pose = state.currentPose else { return .none }
@@ -63,12 +97,22 @@ struct PoseDetailFeature {
                 
             case let .pageChanged(newID):
                 state.selectedID = newID
-                return .none
+                return fetchPoseDetail(id: newID)
                 
             case .didTapBackButton:
                 return .run { _ in await dismiss() }
                 
                 // MARK: - Internal Actions
+            case let .poseDetailResponse(requestID, .success(pose)):
+                guard state.selectedID == requestID || state.poses[id: pose.id] != nil else { return .none }
+                state.updatePose(pose)
+                return .send(.delegate(.poseUpdated(pose)))
+
+            case let .poseDetailResponse(requestID, .failure(error)):
+                if error is CancellationError { return .none }
+                Logger.presentation.error("Error occured while fetching pose detail: ID-\(requestID) / Error: \(error)")
+                return .none
+
             case .scrapResponse(_, .success):
                 return .run { _ in analytics.logEvent(PoseAnalyticsEvent.poseBookmark) }
                 
@@ -87,5 +131,16 @@ struct PoseDetailFeature {
                 return .none
             }
         }
+    }
+}
+
+private extension PoseDetailFeature {
+    func fetchPoseDetail(id: PoseID) -> Effect<Action> {
+        .run { send in
+            await send(.poseDetailResponse(id, Result {
+                try await poseClient.fetchPoseDetail(id)
+            }))
+        }
+        .cancellable(id: CancelID.detail, cancelInFlight: true)
     }
 }

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/FeedImageView.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/FeedImageView.swift
@@ -15,6 +15,15 @@ struct FeedImageView: View {
     
     let item: Pose
     let onTapBookmark: (() -> Void)?
+    private var imageAspectRatio: CGFloat? {
+        guard let width = item.width,
+              let height = item.height,
+              width > 0,
+              height > 0
+        else { return nil }
+
+        return CGFloat(width) / CGFloat(height)
+    }
     
     let gradientColor: LinearGradient = LinearGradient(
         colors: [
@@ -38,7 +47,7 @@ struct FeedImageView: View {
                     Logger.presentation.error("실패한 이미지 id: \(item.id)")
                 }
                 .cancelOnDisappear(true)
-                .aspectRatio(contentMode: .fit)
+                .aspectRatio(imageAspectRatio, contentMode: .fit)
         }
         .overlay { Color.black.opacity(0.04) }
         .overlay { gradientColor.opacity(0.2) }

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/PoseDetailView.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/PoseDetailView.swift
@@ -52,5 +52,6 @@ struct PoseDetailView: View {
             center: { NekiToolBar.textCenter("포즈 상세") }
         )
         .background(.white)
+        .task { await store.send(.onAppear).finish() }
     }
 }

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/PoseView.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/PoseView.swift
@@ -84,7 +84,16 @@ private extension PoseView {
         ScrollView {
             MasonryGridView(
                 items: Array(store.filteredPoses),
-                columns: 2
+                columns: 2,
+                estimatedHeight: { item in
+                    guard let width = item.width,
+                          let height = item.height,
+                          width > 0,
+                          height > 0
+                    else { return nil }
+
+                    return CGFloat(height) / CGFloat(width)
+                }
             ) { item in
                 FeedImageView(item: item, onTapBookmark: { store.send(.onTapBookmark(item)) })
                     .onTapGesture {

--- a/Neki-iOS/Shared/DesignSystem/Sources/Component/View/MasonryGridView.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Component/View/MasonryGridView.swift
@@ -15,6 +15,7 @@ public struct MasonryGridView<Item: Identifiable, ItemView: View>: View {
     let columns: Int
     let horizontalSpacing: CGFloat
     let verticalSpacing: CGFloat
+    let estimatedHeight: ((Item) -> CGFloat?)?
     let content: (Item) -> ItemView
     let columnItems: [[Item]]
     
@@ -25,18 +26,37 @@ public struct MasonryGridView<Item: Identifiable, ItemView: View>: View {
         columns: Int = 2,
         horizontalSpacing: CGFloat = 12,
         verticalSpacing: CGFloat = 12,
+        estimatedHeight: ((Item) -> CGFloat?)? = nil,
         @ViewBuilder content: @escaping (Item) -> ItemView
     ) {
         self.items = items
         self.columns = max(1, columns)
         self.horizontalSpacing = horizontalSpacing
         self.verticalSpacing = verticalSpacing
+        self.estimatedHeight = estimatedHeight
         self.content = content
-        
-        var result = Array(repeating: [Item](), count: self.columns)
-        for (index, item) in items.enumerated() {
-            result[index % self.columns].append(item)
+
+        guard let estimatedHeight else {
+            var result = Array(repeating: [Item](), count: self.columns)
+            for (index, item) in items.enumerated() {
+                result[index % self.columns].append(item)
+            }
+            self.columnItems = result
+            return
         }
+
+        var result = Array(repeating: [Item](), count: self.columns)
+        var columnHeights = Array(repeating: CGFloat.zero, count: self.columns)
+
+        for item in items {
+            let columnIndex = columnHeights
+                .enumerated()
+                .min(by: { $0.element < $1.element })?
+                .offset ?? .zero
+            result[columnIndex].append(item)
+            columnHeights[columnIndex] += (estimatedHeight(item) ?? 1) + verticalSpacing
+        }
+
         self.columnItems = result
     }
     


### PR DESCRIPTION
## 🌴 작업한 브랜치
`codex/pose-detail-api-cache`

## ✅ 작업한 내용

- 포즈 상세정보 API를 상세 화면 진입 흐름에 연결했습니다.
  - 포즈사진 셀을 통해 상세 화면에 진입하면 선택된 포즈 ID 기준으로 상세 API를 호출합니다.
  - 상세 화면에서 페이지를 넘겨 다른 포즈를 선택할 때도 해당 포즈의 상세 API를 호출합니다.
  - 상세 API 성공 시 상세 화면의 포즈 데이터를 최신 응답값으로 갱신합니다.
  - 갱신된 포즈 데이터는 상위 포즈 목록 상태에도 반영됩니다.

- 랜덤포즈 추천 화면에서 상세 화면으로 진입하는 케이스를 보완했습니다.
  - 랜덤포즈는 기존 포즈 목록에 포함되지 않을 수 있으므로, 상세 화면 초기 데이터셋에 선택된 랜덤포즈를 포함하도록 처리했습니다.

- 포즈 상세 응답의 이미지 메타데이터를 보존하도록 확장했습니다.
  - `width`
  - `height`
  - 기존 `contentType`, `createdAt`, `scrap` 정보와 함께 도메인 엔티티에서 활용할 수 있도록 반영했습니다.

- 이미지 로딩 전 Masonry Layout 안정성을 개선했습니다.
  - `Pose.width` / `Pose.height` 값이 있으면 `FeedImageView`에서 로딩 전부터 이미지 비율을 적용합니다.
  - `MasonryGridView`에 optional `estimatedHeight` 클로저를 추가했습니다.
  - Pose 화면에서는 이미지 비율 기반 예상 높이를 사용해 컬럼 높이가 더 자연스럽게 분배되도록 했습니다.
  - 기존 Archive 화면 등 다른 호출부는 기본 동작을 유지합니다.

## ❗️PR Point

- 기존에 `PoseRepository.fetchPoseDetail(id:)`와 `PoseEndpoint.fetchPoseDetail`은 존재했지만, `PoseClient`와 상세 화면 흐름에서는 사용되지 않고 있었습니다.
  - 이번 작업에서 Client 경계를 열고 상세 화면 진입/페이지 변경 시점에 연결했습니다.

- 상세 API 실패 시에는 기존 목록 또는 랜덤포즈 데이터 기반 화면을 유지합니다.
  - 실패로 인해 상세 화면을 닫거나 사용자 상태를 임의로 변경하지 않습니다.

- `MasonryGridView`의 `estimatedHeight`는 optional로 설계했습니다.
  - 이미지 크기 정보를 가진 화면에서는 자연스러운 Masonry 분배를 사용할 수 있습니다.
  - 크기 정보가 없는 기존 화면은 기존 index 기반 분배를 그대로 사용합니다.

- 랜덤포즈 상세 진입 후 상세 API 응답은 상세 화면과 root 목록 캐시에 반영됩니다.
  - 다만 뒤에 남아 있는 랜덤포즈 화면의 `currentPose`까지 즉시 역동기화하는 처리는 이번 작업 범위에 포함하지 않았습니다.

## 📸 스크린샷
생략.

## 📟 관련 이슈
x