### PR TITLE
Chore/#247 randompose routing

### DIFF
--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/DeviceAuthorizationPreferenceFeature.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/Feature/DeviceAuthorizationPreferenceFeature.swift
@@ -23,6 +23,7 @@ struct DeviceAuthorizationPreferenceFeature {
         var photosAuthorizationStatus: PHAuthorizationStatus = .notDetermined
         var notificationAuthorizationStatus: UNAuthorizationStatus = .notDetermined
         var isMarketingNotificationEnabled: Bool = false
+        var confirmedMarketingNotificationEnabled: Bool = false
         var isUpdatingMarketingNotification: Bool = false
         
         var isCameraAuthorized: Bool { cameraAuthorizationStatus == .authorized }
@@ -51,6 +52,7 @@ struct DeviceAuthorizationPreferenceFeature {
         case updateLocationStatus(CLAuthorizationStatus)
         case updatePhotosStatus(PHAuthorizationStatus)
         case updateNotificationStatus(UNAuthorizationStatus)
+        case commitMarketingNotificationUpdate(Bool)
         case marketingNotificationUpdateResponse(Bool, Result<Void, Error>)
         case pushNotificationSynchronizationResponse(Result<UNAuthorizationStatus, Error>)
         case openAppSettings
@@ -63,6 +65,11 @@ struct DeviceAuthorizationPreferenceFeature {
         
         // Binding Actions
         case binding(BindingAction<State>)
+    }
+
+    private enum CancelID: Hashable {
+        case marketingNotificationUpdateDebounce
+        case marketingNotificationUpdateRequest
     }
     
     @Dependency(\.dismiss) private var dismiss
@@ -81,6 +88,7 @@ struct DeviceAuthorizationPreferenceFeature {
             case .onAppear:
                 if case let .signedIn(user) = state.userSessionStatus {
                     state.isMarketingNotificationEnabled = user.marketingTermAgreed
+                    state.confirmedMarketingNotificationEnabled = user.marketingTermAgreed
                 }
                 return .merge(
                     .run { send in
@@ -180,19 +188,30 @@ struct DeviceAuthorizationPreferenceFeature {
                 }
 
             case .binding(\.isMarketingNotificationEnabled):
-                guard state.isUpdatingMarketingNotification == false else { return .none }
-
                 state.isUpdatingMarketingNotification = true
                 let requestedValue = state.isMarketingNotificationEnabled
+                return .merge(
+                    .cancel(id: CancelID.marketingNotificationUpdateRequest),
+                    .send(.commitMarketingNotificationUpdate(requestedValue))
+                    .debounce(id: CancelID.marketingNotificationUpdateDebounce, for: .milliseconds(500), scheduler: DispatchQueue.main)
+                )
+
+            case let .commitMarketingNotificationUpdate(requestedValue):
+                guard requestedValue != state.confirmedMarketingNotificationEnabled else {
+                    state.isUpdatingMarketingNotification = false
+                    return .none
+                }
                 return .run { send in
                     await send(.marketingNotificationUpdateResponse(
                         requestedValue,
                         Result { try await authClient.updateMarketingConsent(requestedValue) }
                     ))
                 }
+                .cancellable(id: CancelID.marketingNotificationUpdateRequest, cancelInFlight: true)
 
             case let .marketingNotificationUpdateResponse(requestedValue, .success):
                 state.isUpdatingMarketingNotification = false
+                state.confirmedMarketingNotificationEnabled = requestedValue
                 state.$userSessionStatus.withLock {
                     guard case let .signedIn(currentUser) = $0 else { return }
                     var user = currentUser
@@ -220,9 +239,10 @@ struct DeviceAuthorizationPreferenceFeature {
                     NekiToastItem(message, style: .success)
                 )))
 
-            case let .marketingNotificationUpdateResponse(requestedValue, .failure):
+            case let .marketingNotificationUpdateResponse(_, .failure(error)):
+                if error is CancellationError { return .none }
                 state.isUpdatingMarketingNotification = false
-                state.isMarketingNotificationEnabled = !requestedValue
+                state.isMarketingNotificationEnabled = state.confirmedMarketingNotificationEnabled
                 return .none
 
             case let .pushNotificationSynchronizationResponse(.success(status)):

--- a/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/DeviceAuthorizationPreferenceView.swift
+++ b/Neki-iOS/Features/MyPage/Sources/Presentation/Sources/View/DeviceAuthorizationPreferenceView.swift
@@ -82,7 +82,6 @@ private extension DeviceAuthorizationPreferenceView {
             }
         }
         .toggleStyle(.nekiSwitch)
-        .disabled(store.isUpdatingMarketingNotification)
     }
 
     func cell(for type: AuthorizationType, isAuthorized: Bool, _ onTap: @escaping () -> Void) -> some View {

--- a/Neki-iOS/Features/Pose/Sources/Data/Sources/DefaultPoseRepository.swift
+++ b/Neki-iOS/Features/Pose/Sources/Data/Sources/DefaultPoseRepository.swift
@@ -156,18 +156,19 @@ private extension DefaultPoseRepository {
             }
         } catch {
             Logger.data.error("Random Pose Fetch Failed or Duplicated: \(error)")
-            guard cache.isEmpty == false else { throw error }
+            let cachedPoses = cache
+            guard cachedPoses.isEmpty == false else { throw error }
             
             let countMatchedIDs = cachedPoseIDsByPeopleCount[peopleCount] ?? []
             let validCachedPoses = countMatchedIDs.lazy
                 .filter { excludedIDs.contains($0) == false }
-                .compactMap { cache[$0] }
+                .compactMap { cachedPoses[$0] }
             
             if let randomFallbackPose = validCachedPoses.randomElement() {
                 return randomFallbackPose
             } else {
                 guard let fallbackID = countMatchedIDs.randomElement(),
-                      let fallback = cache[fallbackID]
+                      let fallback = cachedPoses[fallbackID]
                 else { throw error }
                 return fallback
             }

--- a/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/RandomPoseCarouselView.swift
+++ b/Neki-iOS/Features/Pose/Sources/Presentation/Sources/View/RandomPoseCarouselView.swift
@@ -101,6 +101,7 @@ private extension RandomPoseCarouselView {
             
             Spacer()
             
+            /* 26.06.17 랜덤포즈 페이지에서 상세보기 화면으로 이동할 수 없도록 하자는 기획의도 반영
             Button {
                 guard let pose = store.currentPose else { return }
                 store.send(.onTapDetail(pose))
@@ -112,6 +113,7 @@ private extension RandomPoseCarouselView {
                             .fill(.primary400)
                     }
             }
+             */
             
             Button {
                 store.send(.onTapScrap)

--- a/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiToastModifier.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiToastModifier.swift
@@ -9,18 +9,31 @@ import SwiftUI
 
 struct NekiToastModifier: ViewModifier {
     @Binding var item: NekiToastItem?
+    @State private var presentedItem: NekiToastItem?
+    @State private var presentationTask: Task<Void, Never>?
     
     func body(content: Content) -> some View {
         content
             .overlay(alignment: .bottom) {
-                if let currentItem = item {
+                if let currentItem = presentedItem {
                     nekiToastView(currentItem)
                 }
+            }
+            .onChange(of: item) { newItem in
+                presentLatestToast(newItem)
+            }
+            .onAppear {
+                presentLatestToast(item)
+            }
+            .onDisappear {
+                presentationTask?.cancel()
+                presentationTask = nil
+                presentedItem = nil
             }
     }
     
     private func nekiToastView(_ item: NekiToastItem) -> some View {
-        NekiToastView(item: item) { withAnimation { self.item = nil } }
+        NekiToastView(item: item) { dismiss(itemID: item.id) }
             .padding(.horizontal, 20)
             .padding(.bottom, 26)
             .id(item.id)
@@ -29,9 +42,35 @@ struct NekiToastModifier: ViewModifier {
             .task(id: item.id) {
                 do {
                     try await Task.sleep(for: .seconds(item.duration))
-                } catch { }
-                withAnimation { self.item = nil }
+                } catch { return }
+                dismiss(itemID: item.id)
             }
+    }
+
+    private func presentLatestToast(_ newItem: NekiToastItem?) {
+        presentationTask?.cancel()
+
+        guard let newItem else {
+            withAnimation { presentedItem = nil }
+            presentationTask = nil
+            return
+        }
+
+        presentationTask = Task { @MainActor in
+            withAnimation { presentedItem = nil }
+            await Task.yield()
+            guard Task.isCancelled == false else { return }
+            withAnimation { presentedItem = newItem }
+            if item?.id == newItem.id { presentationTask = nil }
+        }
+    }
+
+    private func dismiss(itemID: NekiToastItem.ID) {
+        guard presentedItem?.id == itemID else { return }
+        withAnimation {
+            presentedItem = nil
+            if item?.id == itemID { item = nil }
+        }
     }
 }
 


### PR DESCRIPTION
## 🌴 작업한 브랜치
`chore/#247-randompose-routing`



## ✅ 작업한 내용
기획의도 변경으로 인해 랜덤포즈 추천 단계에서 포즈 상세화면으로 이동할 수 있는 플로우를 차단했습니다.


## ❗️PR Point
생략.


## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|스크린샷|
|:--:|:--:|
|랜덤포즈화면|<img src = "https://github.com/user-attachments/assets/5ba2cc9a-3745-4a72-8ed2-699d9aea4f1d" width ="350">|



## 📟 관련 이슈
- Resolved: #247 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 마케팅 알림 동의 토글이 서버 동기화 중에도 언제든 조작 가능하도록 개선되었습니다.
  * 알림 팝업 메시지의 순차 표시 로직이 개선되어 더욱 안정적입니다.

* **제거된 기능**
  * 포즈 캐러셀의 상세보기 버튼이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->