### PR TITLE
[Fix] #249 - UNNotification Delegate 메인스레드 격리

### DIFF
--- a/Neki-iOS/Core/Sources/Notification/Sources/Presentation/Sources/Coordinator/PushNotificationDelegate.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Presentation/Sources/Coordinator/PushNotificationDelegate.swift
@@ -8,6 +8,7 @@
 import Foundation
 import UserNotifications
 
+@MainActor
 final class PushNotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
     private let eventBroker: PushNotificationEventBroker
 

--- a/Neki-iOS/Core/Sources/Notification/Sources/Presentation/Sources/Feature/PushNotificationEventFeature.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Presentation/Sources/Feature/PushNotificationEventFeature.swift
@@ -44,9 +44,7 @@ struct PushNotificationEventFeature {
             case let .eventReceived(.responseReceived(payload)):
                 Logger.data.debug("푸시 알림 클릭 이벤트 수신: \(payload.redactedLogDescription)")
                 return .run { _ in
-                    await MainActor.run {
-                        analyticsClient.logEvent(PushNotificationAnalyticsEvent.notificationClick(payload: payload))
-                    }
+                    analyticsClient.logEvent(PushNotificationAnalyticsEvent.notificationClick(payload: payload))
                 }
             }
         }

--- a/Neki-iOS/Core/Sources/Notification/Sources/Presentation/Sources/Feature/PushNotificationEventFeature.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Presentation/Sources/Feature/PushNotificationEventFeature.swift
@@ -44,7 +44,9 @@ struct PushNotificationEventFeature {
             case let .eventReceived(.responseReceived(payload)):
                 Logger.data.debug("푸시 알림 클릭 이벤트 수신: \(payload.redactedLogDescription)")
                 return .run { _ in
-                    analyticsClient.logEvent(PushNotificationAnalyticsEvent.notificationClick(payload: payload))
+                    await MainActor.run {
+                        analyticsClient.logEvent(PushNotificationAnalyticsEvent.notificationClick(payload: payload))
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 🌴 작업한 브랜치
`fix/#249-notification-crash`

## ✅ 작업한 내용

- 푸시 알림 클릭 시 앱이 종료되는 크래시를 수정했습니다.
- `UNUserNotificationCenterDelegate` 구현체인 `PushNotificationDelegate`를 `@MainActor`로 격리했습니다.
- 알림 클릭 이벤트 수신 후 GA 클릭 이벤트를 기록하는 지점을 `MainActor.run`으로 감싸 main thread에서 처리되도록 보장했습니다.
- 기존 Analytics 전역 구조는 변경하지 않고, 푸시 알림 클릭 처리 경로에만 수정 범위를 제한했습니다.

## ❗️PR Point

- 크래시 로그:
```text
NSInternalInconsistencyException
reason: 'Call must be made on main thread'
```

- 알림 클릭 후 `PushNotificationEventFeature` 까지 이벤트가 전달된 뒤 앱이 종료되는 문제 발생했습니다.
- 최초에는 Analytics 사양에 따라 원인이 그곳에 있다고 판단했지만 일반 화면에서 발생하는 GA 이벤트는 정상동작 중이었기 때문에 기각했습니다.
- 푸시 알림 클릭 직후 흐름인 delegate/event 처리 경로의 main thread 보장 문제로 판단하고 메인액터로 격리했습니다.
- 실기기에서 알림 터치 시 더 이상 앱이 종료되지 않음을 확인했습니다.

- Resolved: #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 푸시 알림 처리 시 메인 스레드 실행 안정성을 개선했습니다.

* **Refactor**
  * 푸시 알림 이벤트 분석 로깅의 스레드 안전성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->