### PR TITLE
[Feat] #252 - 로그아웃 API 연결

### DIFF
--- a/Neki-iOS/Core/Sources/Auth/Sources/Data/Sources/AuthEndpoint.swift
+++ b/Neki-iOS/Core/Sources/Auth/Sources/Data/Sources/AuthEndpoint.swift
@@ -11,6 +11,7 @@ import os
 enum AuthEndpoint {
     case reissueToken
     case login(dto: SocialLoginDTO.Request, provider: ProviderType)
+    case logout
     case fetchTerms
     case agreeWithTerms(dto: AgreeTermsDTO.Request)
     
@@ -28,7 +29,7 @@ extension AuthEndpoint: Endpoint {
         switch self {
         case .reissueToken: return .reissue
         case .login, .fetchTerms: return .none
-        case .agreeWithTerms, .withdraw, .editNickname, .editProfileImage, .fetchUserInfo: return .bearer
+        case .logout, .agreeWithTerms, .withdraw, .editNickname, .editProfileImage, .fetchUserInfo: return .bearer
         }
     }
     
@@ -46,6 +47,7 @@ extension AuthEndpoint: Endpoint {
         switch self {
         case .reissueToken: return "auth/refresh"
         case let .login(_, provider): return "auth/\(provider.name)/login"
+        case .logout: return "users/logout"
         case .fetchTerms: return "terms"
         case .agreeWithTerms: return "terms/agreements"
         case .withdraw: return "users/me"
@@ -57,7 +59,7 @@ extension AuthEndpoint: Endpoint {
     
     var method: HTTPMethodType {
         switch self {
-        case .reissueToken, .login, .agreeWithTerms: return .post
+        case .reissueToken, .login, .logout, .agreeWithTerms: return .post
         case .withdraw: return .delete
         case .editNickname, .editProfileImage: return .patch
         case .fetchUserInfo, .fetchTerms: return .get
@@ -66,7 +68,7 @@ extension AuthEndpoint: Endpoint {
     
     var body: (any Encodable)? {
         switch self {
-        case .reissueToken, .fetchUserInfo, .fetchTerms, .withdraw: return nil
+        case .reissueToken, .logout, .fetchUserInfo, .fetchTerms, .withdraw: return nil
         case let .login(dto, _): return dto
         case let .agreeWithTerms(dto): return dto
         case let .editNickname(dto): return dto

--- a/Neki-iOS/Core/Sources/Auth/Sources/Data/Sources/Implementations/DefaultAuthRepository.swift
+++ b/Neki-iOS/Core/Sources/Auth/Sources/Data/Sources/Implementations/DefaultAuthRepository.swift
@@ -78,10 +78,16 @@ public struct DefaultAuthRepository: AuthRepository {
     }
     
     public func logout() async throws(AuthRepositoryError) {
+        let endpoint = AuthEndpoint.logout
         do {
+            let _: BaseResponseDTO<EmptyData> = try await networkProvider.request(endpoint: endpoint)
             try tokenStorage.delete()
-        } catch {
+        } catch let error as NetworkError {
+            throw .networkError(error)
+        } catch is TokenStorageError {
             throw .userNotFound
+        } catch {
+            throw .unknown
         }
     }
     


### PR DESCRIPTION
## 🌴 작업한 브랜치
feat/#252-logout-api



## ✅ 작업한 내용
`AuthEndpoint` 에 로그아웃 엔드포인트를 정의하고 Repository Layer 내 로컬 액세스/리프레시토큰 제거 로직에 리모트 FCM 토큰 제거 API를 추가해 로그아웃 트랜잭션을 유지했습니다.


## ❗️PR Point
간단한 변경이므로 생략합니다.


## 📸 스크린샷
생략.


## 📟 관련 이슈
- Resolved: #252


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 로그아웃 기능이 추가되었습니다. 사용자가 앱에서 로그아웃할 때 서버와 통신하여 안전하게 처리됩니다.

* **버그 수정**
  * 로그아웃 과정의 오류 처리 로직이 개선되어 네트워크 오류, 토큰 저장소 오류 등을 명확하게 구분하여 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->