### PR TITLE
[Feat] 알림목록 페이지 추가 및 알림권한 확보 플로우 1, 2차, 접근 플로우 확정

### DIFF
--- a/Neki-iOS/Core/Sources/Network/Sources/Foundation/String+ISO8601Date.swift
+++ b/Neki-iOS/Core/Sources/Network/Sources/Foundation/String+ISO8601Date.swift
@@ -1,0 +1,59 @@
+//
+//  String+ISO8601Date.swift
+//  Neki-iOS
+//
+//  Created by Codex on 6/22/26.
+//
+
+import Foundation
+
+extension String {
+    func toISO8601DateOrNil() -> Date? {
+        if let date = ISO8601DateFormatters.fractionalWithTimeZone.date(from: self) {
+            return date
+        }
+
+        if let date = ISO8601DateFormatters.fractionalWithoutTimeZone.date(from: self) {
+            return date
+        }
+
+        if let date = ISO8601DateFormatters.defaultWithTimeZone.date(from: self) {
+            return date
+        }
+
+        return ISO8601DateFormatters.defaultWithoutTimeZone.date(from: self)
+    }
+}
+
+private enum ISO8601DateFormatters {
+    static let fractionalWithTimeZone: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    static let fractionalWithoutTimeZone: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [
+            .withYear, .withMonth, .withDay,
+            .withTime, .withDashSeparatorInDate, .withColonSeparatorInTime,
+            .withFractionalSeconds
+        ]
+        return formatter
+    }()
+
+    static let defaultWithTimeZone: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    static let defaultWithoutTimeZone: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [
+            .withYear, .withMonth, .withDay,
+            .withTime, .withDashSeparatorInDate, .withColonSeparatorInTime
+        ]
+        return formatter
+    }()
+}

--- a/Neki-iOS/Core/Sources/Notification/Sources/Data/Sources/DTOs/FetchRecentPushNotificationsDTO.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Data/Sources/DTOs/FetchRecentPushNotificationsDTO.swift
@@ -1,0 +1,12 @@
+//
+//  FetchRecentPushNotificationsDTO.swift
+//  Neki-iOS
+//
+//  Created by Codex on 6/22/26.
+//
+
+import Foundation
+
+enum FetchRecentPushNotificationsDTO {
+    typealias Response = [PushNotificationDTO]
+}

--- a/Neki-iOS/Core/Sources/Notification/Sources/Data/Sources/DTOs/PushNotificationDTO.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Data/Sources/DTOs/PushNotificationDTO.swift
@@ -1,0 +1,28 @@
+//
+//  PushNotificationDTO.swift
+//  Neki-iOS
+//
+//  Created by SwainYun on 6/22/26.
+//
+
+import Foundation
+
+struct PushNotificationDTO: Codable {
+    let id: Int
+    let type: String
+    let title: String
+    let body: String
+    let link: String?
+    let createdAt: String
+
+    func toEntity() -> PushNotificationListItem {
+        PushNotificationListItem(
+            id: id,
+            type: type,
+            title: title,
+            body: body,
+            receivedAt: createdAt.toISO8601DateOrNil(),
+            link: link
+        )
+    }
+}

--- a/Neki-iOS/Core/Sources/Notification/Sources/Data/Sources/Implementations/DefaultPushNotificationRepository.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Data/Sources/Implementations/DefaultPushNotificationRepository.swift
@@ -27,8 +27,10 @@ final actor DefaultPushNotificationRepository: PushNotificationRepository {
     }
 
     func fetchNotificationList() async throws -> [PushNotificationListItem] {
-        // TODO: Replace this stub with the real notification list API when the server contract is finalized.
-        []
+        let endpoint = PushNotificationEndpoint.fetchRecentNotifications
+        let responseDTO: BaseResponseDTO<FetchRecentPushNotificationsDTO.Response> = try await networkProvider.request(endpoint: endpoint)
+        guard let data = responseDTO.data else { throw NetworkError.responseDecodingError }
+        return data.map { $0.toEntity() }
     }
 
     func fetchFCMToken() async throws -> PushNotificationToken {

--- a/Neki-iOS/Core/Sources/Notification/Sources/Data/Sources/PushNotificationEndpoint.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Data/Sources/PushNotificationEndpoint.swift
@@ -10,6 +10,7 @@ import os
 
 enum PushNotificationEndpoint {
     case setDeviceToken(dto: FCMDeviceTokenDTO.Request)
+    case fetchRecentNotifications
 }
 
 
@@ -18,7 +19,7 @@ enum PushNotificationEndpoint {
 extension PushNotificationEndpoint: Endpoint {
     var authorizationType: AuthorizationType {
         switch self {
-        case .setDeviceToken: return .bearer
+        case .setDeviceToken, .fetchRecentNotifications: return .bearer
         }
     }
     
@@ -27,18 +28,21 @@ extension PushNotificationEndpoint: Endpoint {
     var path: String {
         switch self {
         case .setDeviceToken: "notifications"
+        case .fetchRecentNotifications: "notifications/recent"
         }
     }
     
     var method: HTTPMethodType {
         switch self {
         case .setDeviceToken: return .patch
+        case .fetchRecentNotifications: return .get
         }
     }
     
     var body: (any Encodable)? {
         switch self {
         case let .setDeviceToken(dto): return dto
+        case .fetchRecentNotifications: return nil
         }
     }
 }

--- a/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Entities/PushNotificationListItem.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Entities/PushNotificationListItem.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 public struct PushNotificationListItem: Identifiable, Equatable, Sendable {
-    public let id: String
+    public let id: Int
+    public let type: String
     public let title: String
     public let body: String
     public let receivedAt: Date?
@@ -16,7 +17,8 @@ public struct PushNotificationListItem: Identifiable, Equatable, Sendable {
     public let isRead: Bool
 
     public init(
-        id: String,
+        id: Int,
+        type: String,
         title: String,
         body: String,
         receivedAt: Date? = nil,
@@ -24,6 +26,7 @@ public struct PushNotificationListItem: Identifiable, Equatable, Sendable {
         isRead: Bool = false
     ) {
         self.id = id
+        self.type = type
         self.title = title
         self.body = body
         self.receivedAt = receivedAt

--- a/Neki-iOS/Features/Map/Sources/Data/Sources/DTOs/UpdatePhotoBoothBrandOrderDTO.swift
+++ b/Neki-iOS/Features/Map/Sources/Data/Sources/DTOs/UpdatePhotoBoothBrandOrderDTO.swift
@@ -1,0 +1,18 @@
+//
+//  UpdatePhotoBoothBrandOrderDTO.swift
+//  Neki-iOS
+//
+//  Created by Codex on 6/22/26.
+//
+
+import Foundation
+
+enum UpdatePhotoBoothBrandOrderDTO {
+    struct Request: Encodable {
+        let brandIDs: [Int]
+
+        enum CodingKeys: String, CodingKey {
+            case brandIDs = "brandIds"
+        }
+    }
+}

--- a/Neki-iOS/Features/Map/Sources/Data/Sources/DefaultPhotoBoothRepository.swift
+++ b/Neki-iOS/Features/Map/Sources/Data/Sources/DefaultPhotoBoothRepository.swift
@@ -11,12 +11,6 @@ import Dependencies
 import DependenciesMacros
 import os
 
-private enum PhotoBoothBrandOrderServerStub {
-    // 서버 브랜드 순서 저장 API 준비 전 실기기 검증용입니다.
-    // 서버 API 연동 시 이 플래그와 updateBrandOrder의 stub 분기를 제거합니다.
-    static let isEnabled = true
-}
-
 private enum TileSystem {
     static let defaultZoomLevel: Int = 15
     
@@ -77,30 +71,37 @@ public final actor DefaultPhotoBoothRepository {
     private var nextFavoriteOrder: Int = .zero
     private var brandMap: [BrandID: PhotoBoothBrand]?
     private var brandOrderIDs: [PhotoBoothBrand.ID] = []
-    private var brandFetchTask: Task<[BrandID: PhotoBoothBrand], Error>?
+    private var brandFetchTask: Task<([BrandID: PhotoBoothBrand], [PhotoBoothBrand.ID]), Error>?
     
     public init() {}
     
     private func ensureBrandsLoaded() async throws -> [BrandID: PhotoBoothBrand] {
         if let existingMap = brandMap { return existingMap }
         
-        if let existingTask = brandFetchTask { return try await existingTask.value }
+        if let existingTask = brandFetchTask {
+            let (map, orderIDs) = try await existingTask.value
+            if map.isEmpty == false { brandMap = map }
+            brandOrderIDs = orderIDs
+            return map
+        }
         
-        let task = Task<[BrandID: PhotoBoothBrand], Error> {
+        let task = Task<([BrandID: PhotoBoothBrand], [PhotoBoothBrand.ID]), Error> {
             let endpoint = MapEndpoint.fetchBrands
             let responseDTO: BaseResponseDTO<FetchPhotoBrandsDTO.Response> = try await networkProvider.request(endpoint: endpoint)
-            guard let brandList = responseDTO.data else { return [:] }
-            return brandList.reduce(into: [BrandID: PhotoBoothBrand]()) { dict, dto in
-                let brandEntity = dto.toEntity()
-                dict[brandEntity.name] = brandEntity
-            }
+            guard let brandList = responseDTO.data else { return ([:], []) }
+            let brandEntities = brandList.map { $0.toEntity() }
+            return (
+                Dictionary(uniqueKeysWithValues: brandEntities.map { ($0.name, $0) }),
+                brandEntities.map(\.id)
+            )
         }
         
         brandFetchTask = task
         
         do {
-            let map = try await task.value
+            let (map, orderIDs) = try await task.value
             if map.isEmpty == false { brandMap = map }
+            brandOrderIDs = orderIDs
             brandFetchTask = nil
             return map
         } catch {
@@ -229,14 +230,12 @@ extension DefaultPhotoBoothRepository: PhotoBoothRepository {
     }
 
     func updateBrandOrder(_ brands: [PhotoBoothBrand]) async throws -> [PhotoBoothBrand] {
-        if PhotoBoothBrandOrderServerStub.isEnabled {
-            brandOrderIDs = brands.map(\.id)
-            return try await loadBrands()
-        }
-
-        // TODO: 서버 API 스펙 확정 후 실제 브랜드 순서 저장 endpoint 호출로 교체합니다.
-        brandOrderIDs = brands.map(\.id)
-        return try await loadBrands()
+        let orderedIDs = brands.map(\.id)
+        let dto = UpdatePhotoBoothBrandOrderDTO.Request(brandIDs: orderedIDs)
+        let endpoint = MapEndpoint.updateBrandOrder(dto: dto)
+        let _: BaseResponseDTO<EmptyData> = try await networkProvider.request(endpoint: endpoint)
+        brandOrderIDs = orderedIDs
+        return brands
     }
 }
 

--- a/Neki-iOS/Features/Map/Sources/Data/Sources/MapEndpoint.swift
+++ b/Neki-iOS/Features/Map/Sources/Data/Sources/MapEndpoint.swift
@@ -13,6 +13,7 @@ enum MapEndpoint {
     case updateFavorite(id: Int, dto: TogglePhotoBoothFavoriteDTO)
     case fetchFavorites
     case fetchBrands
+    case updateBrandOrder(dto: UpdatePhotoBoothBrandOrderDTO.Request)
 }
 
 
@@ -23,7 +24,7 @@ extension MapEndpoint: Endpoint {
     
     var contentType: HTTPContentType {
         switch self {
-        case .polygon, .point, .updateFavorite, .fetchFavorites, .fetchBrands: return .json
+        case .polygon, .point, .updateFavorite, .fetchFavorites, .fetchBrands, .updateBrandOrder: return .json
         }
     }
     
@@ -34,6 +35,7 @@ extension MapEndpoint: Endpoint {
         case let .updateFavorite(id, _): return "/photo-booths/\(id)/favorite"
         case .fetchFavorites: return "/photo-booths/favorite"
         case .fetchBrands: return "/photo-booths/brand"
+        case .updateBrandOrder: return "/photo-booths/brand/order"
         }
     }
     
@@ -42,6 +44,7 @@ extension MapEndpoint: Endpoint {
         case .polygon, .point: return .post
         case .updateFavorite: return .patch
         case .fetchFavorites, .fetchBrands: return .get
+        case .updateBrandOrder: return .put
         }
     }
     
@@ -51,6 +54,7 @@ extension MapEndpoint: Endpoint {
         case let .point(dto): return dto
         case let .updateFavorite(_, dto): return dto
         case .fetchFavorites, .fetchBrands: return nil
+        case let .updateBrandOrder(dto): return dto
         }
     }
 }


### PR DESCRIPTION
## 🌴 작업한 브랜치

`feat/#251-notification-list`

## ✅ 작업한 내용

- 최근 알림 목록 조회 API를 연결했습니다.
- `GET notifications/recent` 응답 스펙에 맞춰 알림 DTO와 엔티티를 정리했습니다.
- 최근 알림 목록 화면에서 Repository stub 대신 실제 API를 호출하도록 변경했습니다.
- 알림 응답의 `createdAt` 파싱을 위해 재사용 가능한 ISO8601 문자열 파서 확장을 Core 영역에 추가했습니다.
- 브랜드 필터칩 순서 저장 API를 연결했습니다.
- `PUT photo-booths/brand/order` 요청 스펙에 맞춰 브랜드 ID 순서 저장 DTO와 endpoint를 추가했습니다.
- 브랜드 정렬 저장 stub을 제거하고 실제 API 호출로 교체했습니다.
- 브랜드 정렬 저장 성공 후 불필요한 브랜드 목록 재조회 없이, 사용자가 저장한 순서를 즉시 반영하도록 개선했습니다.

## ❗️PR Point

- 최근 알림 조회 API는 로그인 사용자의 최근 알림을 최대 30건 최신순으로 내려주는 서버 스펙을 기준으로 연결했습니다.
- 알림 목록 응답의 `data`가 누락된 경우는 정상적인 빈 목록이 아니라 응답 형식 오류로 보고 실패 처리합니다.
- 브랜드 정렬 저장 성공 후 서버 재조회는 수행하지 않습니다. 네트워크 요청 성공을 저장 완료로 간주하고, 클라이언트가 이미 가진 정렬 결과를 그대로 반영합니다.

## 📸 스크린샷
생략.

## 📟 관련 이슈

- Resolved: #251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 푸시 알림 목록 조회 기능 구현
  * 사진 부스 브랜드 순서 업데이트 기능 추가

* **Bug Fixes**
  * 푸시 알림 엔티티의 ID 타입 및 속성 정규화

* **Refactor**
  * 내부 ISO8601 날짜 파싱 기능 추가
  * 브랜드 데이터 로딩 및 캐싱 로직 재구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->