### PR TITLE
[Chore] 지도 GA 이벤트 연결

### DIFF
--- a/Neki-iOS/Core/Sources/Analytics/Sources/Domain/Sources/Entities/AnalyticsEventName.swift
+++ b/Neki-iOS/Core/Sources/Analytics/Sources/Domain/Sources/Entities/AnalyticsEventName.swift
@@ -30,6 +30,13 @@ public enum AnalyticsEventName: String {
     case mapBrandFilterToggle = "map_brand_filter_toggle"
     case boothSelect = "booth_select"
     case boothFavorite = "booth_favorite"
+    case boothFavoriteAdd = "booth_favorite_add"
+    case boothFavoriteRemove = "booth_favorite_remove"
+    case favoriteBoothFilterToggle = "favorite_booth_filter_toggle"
+    case favoriteBoothView = "favorite_booth_view"
+    case brandFilterManageView = "brand_filter_manage_view"
+    case brandFavoriteAdd = "brand_favorite_add"
+    case brandFavoriteRemove = "brand_favorite_remove"
     case mapRouteClick = "map_route_click"
     
     // 포즈

--- a/Neki-iOS/Core/Sources/Analytics/Sources/Domain/Sources/Entities/AnalyticsParameterKey.swift
+++ b/Neki-iOS/Core/Sources/Analytics/Sources/Domain/Sources/Entities/AnalyticsParameterKey.swift
@@ -27,6 +27,10 @@ public enum AnalyticsParameterKey: String {
     case action = "action"
     case selectedCount = "selected_count"
     case brandName = "brand_name"
+    case boothName = "booth_name"
+    case favoriteBoothCount = "favorite_booth_count"
+    case pinnedBrandCount = "pinned_brand_count"
+    case totalBrandCount = "total_brand_count"
     case entryPoint = "entry_point"
     case mapType = "map_type"
     

--- a/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/MapAnalyticsEvent.swift
+++ b/Neki-iOS/Features/Map/Sources/Domain/Sources/Entities/MapAnalyticsEvent.swift
@@ -12,6 +12,13 @@ enum MapAnalyticsEvent {
     case mapBrandFilterToggle(action: MapFilterAction, selectedCount: Int, brandName: String)
     case boothSelect(brandName: String, entryPoint: MapEntryPoint)
     case boothFavorite(action: MapFilterAction, brandName: String)
+    case boothFavoriteAdd(boothName: String, brandName: String)
+    case boothFavoriteRemove(boothName: String, brandName: String)
+    case favoriteBoothFilterToggle(action: MapFilterAction, favoriteBoothCount: Int)
+    case favoriteBoothView(favoriteBoothCount: Int)
+    case brandFilterManageView(pinnedBrandCount: Int, totalBrandCount: Int)
+    case brandFavoriteAdd(brandName: String)
+    case brandFavoriteRemove(brandName: String)
     case mapRouteClick(mapType: DirectionAppType)
 }
 
@@ -25,6 +32,13 @@ extension MapAnalyticsEvent: AnalyticsEvent {
         case .mapBrandFilterToggle: return .mapBrandFilterToggle
         case .boothSelect: return .boothSelect
         case .boothFavorite: return .boothFavorite
+        case .boothFavoriteAdd: return .boothFavoriteAdd
+        case .boothFavoriteRemove: return .boothFavoriteRemove
+        case .favoriteBoothFilterToggle: return .favoriteBoothFilterToggle
+        case .favoriteBoothView: return .favoriteBoothView
+        case .brandFilterManageView: return .brandFilterManageView
+        case .brandFavoriteAdd: return .brandFavoriteAdd
+        case .brandFavoriteRemove: return .brandFavoriteRemove
         case .mapRouteClick: return .mapRouteClick
         }
     }
@@ -39,6 +53,20 @@ extension MapAnalyticsEvent: AnalyticsEvent {
             return [.brandName: brandName, .entryPoint: entryPoint.rawValue]
         case let .boothFavorite(action, brandName):
             return [.action: action.rawValue, .brandName: brandName]
+        case let .boothFavoriteAdd(boothName, brandName):
+            return [.boothName: boothName, .brandName: brandName]
+        case let .boothFavoriteRemove(boothName, brandName):
+            return [.boothName: boothName, .brandName: brandName]
+        case let .favoriteBoothFilterToggle(action, favoriteBoothCount):
+            return [.action: action.rawValue, .favoriteBoothCount: favoriteBoothCount]
+        case let .favoriteBoothView(favoriteBoothCount):
+            return [.favoriteBoothCount: favoriteBoothCount]
+        case let .brandFilterManageView(pinnedBrandCount, totalBrandCount):
+            return [.pinnedBrandCount: pinnedBrandCount, .totalBrandCount: totalBrandCount]
+        case let .brandFavoriteAdd(brandName):
+            return [.brandName: brandName]
+        case let .brandFavoriteRemove(brandName):
+            return [.brandName: brandName]
         case let .mapRouteClick(mapType):
             return [.mapType: mapType.rawValue]
         }

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
@@ -378,8 +378,9 @@ public struct MapFeature {
                 let requestedValue = photoBooth.isFavorite == false
                 updatePhotoBoothFavoriteState(&state, id: photoBooth.id, isFavorite: requestedValue)
 
-                let action: MapFilterAction = requestedValue ? .select : .deselect
-                let event = MapAnalyticsEvent.boothFavorite(action: action, brandName: photoBooth.brand.name)
+                let event: MapAnalyticsEvent = requestedValue
+                    ? .boothFavoriteAdd(boothName: photoBooth.name, brandName: photoBooth.brand.name)
+                    : .boothFavoriteRemove(boothName: photoBooth.name, brandName: photoBooth.brand.name)
                 let stateEffect: Effect<Action> = .send(.startBackgroundCalculation)
                 let analyticsEffect: Effect<Action> = .run { _ in analytics.logEvent(event: event) }
                 let requestEffect: Effect<Action> = .run { [id = photoBooth.id, requestedValue] send in
@@ -440,10 +441,12 @@ public struct MapFeature {
 
             case let .favoritePhotoBoothsResponse(.success(photoBooths)):
                 let favoriteBooths = IdentifiedArray(uniqueElements: photoBooths)
+                let favoriteBoothCount = favoriteBooths.count
                 return .merge(
                     .send(.photoBoothListAction(.setFavoriteBooths(favoriteBooths))),
-                    .send(.photoBoothListAction(.setFavoriteBoothCount(favoriteBooths.count))),
-                    .send(.startBackgroundCalculation)
+                    .send(.photoBoothListAction(.setFavoriteBoothCount(favoriteBoothCount))),
+                    .send(.startBackgroundCalculation),
+                    .run { _ in analytics.logEvent(event: MapAnalyticsEvent.favoriteBoothView(favoriteBoothCount: favoriteBoothCount)) }
                 )
                 
             case let .favoritePhotoBoothsResponse(.failure(error)):
@@ -503,7 +506,13 @@ public struct MapFeature {
                 
             case .didTapFavoriteMarkerFilterButton:
                 state.isFavoriteMarkerFilterEnabled.toggle()
-                return .send(.startBackgroundCalculation)
+                let action: MapFilterAction = state.isFavoriteMarkerFilterEnabled ? .select : .deselect
+                let favoriteBoothCount = state.photoBoothListState.favoriteBoothCount
+                let event = MapAnalyticsEvent.favoriteBoothFilterToggle(action: action, favoriteBoothCount: favoriteBoothCount)
+                return .merge(
+                    .send(.startBackgroundCalculation),
+                    .run { _ in analytics.logEvent(event: event) }
+                )
                 
             case let .didSelectDirectionApp(appType):
                 guard let photoBooth = state.directionSheetPhotoBooth else { return .none }
@@ -537,7 +546,12 @@ public struct MapFeature {
                 return .send(.didTapFavorite(photoBooth))
 
             case .photoBoothListAction(.delegate(.didTapBrandReorderButton)):
-                return .send(.delegate(.routeToBrandReorder(state.photoBoothListState.brands)))
+                let totalBrandCount = state.photoBoothListState.brands.count
+                let event = MapAnalyticsEvent.brandFilterManageView(pinnedBrandCount: .zero, totalBrandCount: totalBrandCount)
+                return .merge(
+                    .send(.delegate(.routeToBrandReorder(state.photoBoothListState.brands))),
+                    .run { _ in analytics.logEvent(event: event) }
+                )
 
             case let .photoBoothListAction(.didTapBooth(photoBooth)):
                 state.isUserTrackingMode = false

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
@@ -547,7 +547,8 @@ public struct MapFeature {
 
             case .photoBoothListAction(.delegate(.didTapBrandReorderButton)):
                 let totalBrandCount = state.photoBoothListState.brands.count
-                let event = MapAnalyticsEvent.brandFilterManageView(pinnedBrandCount: .zero, totalBrandCount: totalBrandCount)
+                let selectedBrandCount = state.photoBoothListState.filteredBrands.count
+                let event = MapAnalyticsEvent.brandFilterManageView(pinnedBrandCount: selectedBrandCount, totalBrandCount: totalBrandCount)
                 return .merge(
                     .send(.delegate(.routeToBrandReorder(state.photoBoothListState.brands))),
                     .run { _ in analytics.logEvent(event: event) }


### PR DESCRIPTION
## 🌴 작업한 브랜치
`feat/#251-notification-list`



## ✅ 작업한 내용
지도 고도화 작업 관련 GA 이벤트를 추가하고 수집 로직을 적용했습니다.


## ❗️PR Point
단순 수정이므로 생략합니다.


## 📟 관련 이슈
- Resolved: #251 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 즐겨찾기 추가/제거, 즐겨찾기 필터 토글, 즐겨찾기 부스 목록 진입, 브랜드 관리 화면 진입 및 재정렬 요청에 대해 더 세분화된 분석 이벤트와 파라미터(즐겨찾기 부스 수, 고정/전체 브랜드 수 등) 수집을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->