### PR TITLE
[Feat] 즐겨찾기 포토부스 지도 표시 유지 정책 개선

### DIFF
--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
@@ -540,7 +540,7 @@ public struct MapFeature {
                         isFavoriteMarkerFilterEnabled: isFavoriteMarkerFilterEnabled
                     )
                     visibleListBooths = activeFilters.isEmpty ? listBooths : listBooths.filter { activeFilters.contains($0.brand) }
-                    visibleFavoriteBooths = activeFilters.isEmpty ? favoriteBooths : favoriteBooths.filter { activeFilters.contains($0.brand) }
+                    visibleFavoriteBooths = favoriteBooths.filter { $0.isFavorite && (activeFilters.isEmpty || activeFilters.contains($0.brand)) }
                     await send(.didFinishBackgroundCalculation(map: visibleMapBooths, list: visibleListBooths, favoriteList: visibleFavoriteBooths))
                 }
                 .cancellable(id: CancelID.calculation, cancelInFlight: true)

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
@@ -63,6 +63,8 @@ public struct MapFeature {
         var selectedBooth: PhotoBooth?
         var directionSheetPhotoBooth: PhotoBooth?
         var isFavoriteMarkerFilterEnabled: Bool = false
+        var favoriteFetchGeneration: Int = .zero
+        var pendingFavoriteUpdates: [PhotoBooth.ID: Bool] = [:]
         
         // Child State
         var photoBoothListState = PhotoBoothListFeature.State()
@@ -115,7 +117,7 @@ public struct MapFeature {
         case fetchNearbyPhotoBooths(GeographicCoordinate)
         case nearbyPhotoBoothResponse(Result<[PhotoBooth], Error>)
         case fetchFavoritePhotoBooths(shouldLogViewEvent: Bool)
-        case favoritePhotoBoothsResponse(Result<[PhotoBooth], Error>, shouldLogViewEvent: Bool)
+        case favoritePhotoBoothsResponse(Result<[PhotoBooth], Error>, shouldLogViewEvent: Bool, generation: Int)
         case refreshVisibleMapPhotoBooths
         case didUpdateVisibleMapPhotoBooths(IdentifiedArrayOf<PhotoBooth>)
         case startBackgroundCalculation
@@ -146,6 +148,7 @@ public struct MapFeature {
         case sdkAuthorizationStream
         case calculation
         case mapMarkerViewportCalculation
+        case favoriteFetch
         case favorite(PhotoBooth.ID)
     }
     
@@ -366,7 +369,7 @@ public struct MapFeature {
                 
             case let .processNewChunk(chunk, isFirstBatch):
                 let mapBooths = IdentifiedArray(uniqueElements: chunk)
-                let favoriteBooths = isFirstBatch ? state.photoBoothListState.favoriteBooths : IdentifiedArrayOf<PhotoBooth>()
+                let favoriteBooths = state.photoBoothListState.favoriteBooths
                 let activeFilters = state.photoBoothListState.filteredBrands
                 let currentBounds = state.currentBounds
                 let isFavoriteMarkerFilterEnabled = state.isFavoriteMarkerFilterEnabled
@@ -401,6 +404,8 @@ public struct MapFeature {
                 
             case let .didTapFavorite(photoBooth):
                 let requestedValue = photoBooth.isFavorite == false
+                state.favoriteFetchGeneration += 1
+                state.pendingFavoriteUpdates[photoBooth.id] = requestedValue
                 updatePhotoBoothFavoriteState(&state, id: photoBooth.id, isFavorite: requestedValue)
 
                 let event: MapAnalyticsEvent = requestedValue
@@ -408,6 +413,7 @@ public struct MapFeature {
                     : .boothFavoriteRemove(boothName: photoBooth.name, brandName: photoBooth.brand.name)
                 let stateEffect: Effect<Action> = .send(.startBackgroundCalculation)
                 let analyticsEffect: Effect<Action> = .run { _ in analytics.logEvent(event: event) }
+                let cancelFavoriteFetchEffect: Effect<Action> = .cancel(id: CancelID.favoriteFetch)
                 let requestEffect: Effect<Action> = .run { [id = photoBooth.id, requestedValue] send in
                     await send(.updatePhotoBoothFavoriteResponse(
                         id: id,
@@ -418,23 +424,26 @@ public struct MapFeature {
                 .cancellable(id: CancelID.favorite(photoBooth.id), cancelInFlight: true)
                 
                 guard requestedValue else {
-                    return .merge(stateEffect, analyticsEffect, requestEffect)
+                    return .merge(stateEffect, analyticsEffect, cancelFavoriteFetchEffect, requestEffect)
                 }
                 
                 return .merge(
                     stateEffect,
                     analyticsEffect,
+                    cancelFavoriteFetchEffect,
                     requestEffect,
                     .send(.delegate(.showToast(NekiToastItem("저장한 포토부스에 추가됐어요!", style: .success))))
                 )
 
             case let .updatePhotoBoothFavoriteResponse(id, requestedValue, .success):
+                state.pendingFavoriteUpdates[id] = nil
                 updatePhotoBoothFavoriteState(&state, id: id, isFavorite: requestedValue)
                 return .send(.startBackgroundCalculation)
 
             case let .updatePhotoBoothFavoriteResponse(id, requestedValue, .failure(error)):
                 if error is CancellationError { return .none }
                 Logger.presentation.error("PhotoBooth favorite update error: \(error)")
+                state.pendingFavoriteUpdates[id] = nil
                 updatePhotoBoothFavoriteState(&state, id: id, isFavorite: requestedValue == false)
                 return .send(.startBackgroundCalculation)
 
@@ -460,15 +469,20 @@ public struct MapFeature {
                 return .none
 
             case let .fetchFavoritePhotoBooths(shouldLogViewEvent):
+                state.favoriteFetchGeneration += 1
+                let generation = state.favoriteFetchGeneration
                 return .run { send in
                     await send(.favoritePhotoBoothsResponse(
                         Result { try await photoBoothClient.fetchFavoritePhotoBooths() },
-                        shouldLogViewEvent: shouldLogViewEvent
+                        shouldLogViewEvent: shouldLogViewEvent,
+                        generation: generation
                     ))
                 }
+                .cancellable(id: CancelID.favoriteFetch, cancelInFlight: true)
 
-            case let .favoritePhotoBoothsResponse(.success(photoBooths), shouldLogViewEvent):
-                let favoriteBooths = IdentifiedArray(uniqueElements: photoBooths)
+            case let .favoritePhotoBoothsResponse(.success(photoBooths), shouldLogViewEvent, generation):
+                guard generation == state.favoriteFetchGeneration else { return .none }
+                let favoriteBooths = mergedFavoriteBooths(from: photoBooths, state: state)
                 let favoriteBoothCount = favoriteBooths.count
                 let viewEventEffect: Effect<Action> = shouldLogViewEvent
                     ? .run { _ in analytics.logEvent(event: MapAnalyticsEvent.favoriteBoothView(favoriteBoothCount: favoriteBoothCount)) }
@@ -480,7 +494,8 @@ public struct MapFeature {
                     viewEventEffect
                 )
                 
-            case let .favoritePhotoBoothsResponse(.failure(error), _):
+            case let .favoritePhotoBoothsResponse(.failure(error), _, generation):
+                guard generation == state.favoriteFetchGeneration else { return .none }
                 Logger.presentation.error("Favorite PhotoBooths fetch error: \(error)")
                 return .none
 
@@ -628,6 +643,40 @@ public struct MapFeature {
 // MARK: - MapFeature + Effect Handlers
 
 private extension MapFeature {
+    func mergedFavoriteBooths(from fetchedPhotoBooths: [PhotoBooth], state: State) -> IdentifiedArrayOf<PhotoBooth> {
+        var favoriteBooths = IdentifiedArrayOf<PhotoBooth>()
+
+        for photoBooth in fetchedPhotoBooths {
+            guard state.pendingFavoriteUpdates[photoBooth.id] != false else { continue }
+            var favoriteBooth = photoBooth
+            favoriteBooth.isFavorite = true
+            favoriteBooths.append(favoriteBooth)
+        }
+
+        for (id, isFavorite) in state.pendingFavoriteUpdates {
+            guard isFavorite else {
+                favoriteBooths.remove(id: id)
+                continue
+            }
+            guard var photoBooth = localPhotoBooth(id: id, state: state) else { continue }
+            photoBooth.isFavorite = true
+            if favoriteBooths[id: id] != nil { favoriteBooths[id: id] = photoBooth }
+            else { favoriteBooths.insert(photoBooth, at: .zero) }
+        }
+
+        return favoriteBooths
+    }
+
+    func localPhotoBooth(id: PhotoBooth.ID, state: State) -> PhotoBooth? {
+        if let photoBooth = state.selectedBooth, photoBooth.id == id { return photoBooth }
+        if let photoBooth = state.photoBooths[id: id] { return photoBooth }
+        if let photoBooth = state.visiblePhotoBooths[id: id] { return photoBooth }
+        if let photoBooth = state.photoBoothListState.photoBooths[id: id] { return photoBooth }
+        if let photoBooth = state.photoBoothListState.visibleBooths[id: id] { return photoBooth }
+        if let photoBooth = state.photoBoothListState.favoriteBooths[id: id] { return photoBooth }
+        return state.photoBoothListState.visibleFavoriteBooths[id: id]
+    }
+
     static func visibleMapPhotoBooths(
         mapBooths: IdentifiedArrayOf<PhotoBooth>,
         favoriteBooths: IdentifiedArrayOf<PhotoBooth>,

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
@@ -97,6 +97,7 @@ public struct MapFeature {
         // Map Logic Actions
         case mapLoaded(GeographicBoundingBox)
         case cameraMotionStarted
+        case cameraMotionChanged(GeographicBoundingBox)
         case cameraMotionEnded(GeographicBoundingBox)
         case updateSearchButtonVisibility(isVisible: Bool)
         
@@ -113,8 +114,10 @@ public struct MapFeature {
         // Sheet
         case fetchNearbyPhotoBooths(GeographicCoordinate)
         case nearbyPhotoBoothResponse(Result<[PhotoBooth], Error>)
-        case fetchFavoritePhotoBooths
-        case favoritePhotoBoothsResponse(Result<[PhotoBooth], Error>)
+        case fetchFavoritePhotoBooths(shouldLogViewEvent: Bool)
+        case favoritePhotoBoothsResponse(Result<[PhotoBooth], Error>, shouldLogViewEvent: Bool)
+        case refreshVisibleMapPhotoBooths
+        case didUpdateVisibleMapPhotoBooths(IdentifiedArrayOf<PhotoBooth>)
         case startBackgroundCalculation
         case processNewChunk([PhotoBooth], isFirstBatch: Bool)
         case appendProcessedChunk(map: [PhotoBooth], isFirstBatch: Bool)
@@ -142,6 +145,7 @@ public struct MapFeature {
         case locationAuthorizationStream
         case sdkAuthorizationStream
         case calculation
+        case mapMarkerViewportCalculation
         case favorite(PhotoBooth.ID)
     }
     
@@ -160,10 +164,9 @@ public struct MapFeature {
                 
                 // MARK: - Life Cycle & Streams
             case .onAppear:
-                let favoriteFetchEffect: Effect<Action> = state.photoBoothListState.selectedTab == .favorite ? .send(.fetchFavoritePhotoBooths) : .none
                 return .merge(
                     .send(.loadBrands),
-                    favoriteFetchEffect,
+                    .send(.fetchFavoritePhotoBooths(shouldLogViewEvent: false)),
                     .run { send in
                         for await status in await mapClient.locationAuthorizationStatus() {
                             await send(.updateLocationAuthorization(status))
@@ -231,7 +234,10 @@ public struct MapFeature {
             case let .mapLoaded(bounds):
                 state.currentBounds = bounds
                 state.cameraPosition = bounds.center
-                return .send(.attemptInitialSearch)
+                return .merge(
+                    .send(.attemptInitialSearch),
+                    .send(.startBackgroundCalculation)
+                )
                 
             case .didTapCurrentLocationButton:
                 resetToMapMode(&state, for: .first)
@@ -279,11 +285,18 @@ public struct MapFeature {
                 
             case .cameraMotionStarted:
                 return .send(.updateSearchButtonVisibility(isVisible: true))
+
+            case let .cameraMotionChanged(bounds):
+                state.currentBounds = bounds
+                return .send(.refreshVisibleMapPhotoBooths)
                 
             case let .cameraMotionEnded(bounds):
                 state.currentBounds = bounds
                 state.cameraPosition = bounds.center
-                return .send(.attemptInitialSearch)
+                return .merge(
+                    .send(.attemptInitialSearch),
+                    .send(.startBackgroundCalculation)
+                )
                 
             case let .updateSearchButtonVisibility(isVisible):
                 state.isSearchHereButtonVisible = isVisible
@@ -352,18 +365,30 @@ public struct MapFeature {
                 return .send(.processNewChunk(chunk, isFirstBatch: isFirstBatch))
                 
             case let .processNewChunk(chunk, isFirstBatch):
+                let mapBooths = IdentifiedArray(uniqueElements: chunk)
+                let favoriteBooths = isFirstBatch ? state.photoBoothListState.favoriteBooths : IdentifiedArrayOf<PhotoBooth>()
                 let activeFilters = state.photoBoothListState.filteredBrands
+                let currentBounds = state.currentBounds
+                let isFavoriteMarkerFilterEnabled = state.isFavoriteMarkerFilterEnabled
                 return .run { send in
-                    let filteredChunk: [PhotoBooth]
-                    filteredChunk = activeFilters.isEmpty ? chunk : chunk.filter { activeFilters.contains($0.brand) }
-                    await send(.appendProcessedChunk(map: filteredChunk, isFirstBatch: isFirstBatch))
+                    let visibleMapBooths = Self.visibleMapPhotoBooths(
+                        mapBooths: mapBooths,
+                        favoriteBooths: favoriteBooths,
+                        activeFilters: activeFilters,
+                        currentBounds: currentBounds,
+                        isFavoriteMarkerFilterEnabled: isFavoriteMarkerFilterEnabled
+                    )
+                    await send(.appendProcessedChunk(map: Array(visibleMapBooths), isFirstBatch: isFirstBatch))
                 }
                 
             case let .appendProcessedChunk(map, isFirstBatch):
                 if isFirstBatch {
                     state.visiblePhotoBooths = IdentifiedArray(uniqueElements: map)
                 } else {
-                    state.visiblePhotoBooths.append(contentsOf: map)
+                    map.forEach { photoBooth in
+                        if state.visiblePhotoBooths[id: photoBooth.id] != nil { state.visiblePhotoBooths[id: photoBooth.id] = photoBooth }
+                        else { state.visiblePhotoBooths.append(photoBooth) }
+                    }
                 }
                 return .none
                 
@@ -434,23 +459,51 @@ public struct MapFeature {
                 Logger.presentation.error("Nearby PhotoBooths fetch error: \(error)")
                 return .none
 
-            case .fetchFavoritePhotoBooths:
+            case let .fetchFavoritePhotoBooths(shouldLogViewEvent):
                 return .run { send in
-                    await send(.favoritePhotoBoothsResponse(Result { try await photoBoothClient.fetchFavoritePhotoBooths() }))
+                    await send(.favoritePhotoBoothsResponse(
+                        Result { try await photoBoothClient.fetchFavoritePhotoBooths() },
+                        shouldLogViewEvent: shouldLogViewEvent
+                    ))
                 }
 
-            case let .favoritePhotoBoothsResponse(.success(photoBooths)):
+            case let .favoritePhotoBoothsResponse(.success(photoBooths), shouldLogViewEvent):
                 let favoriteBooths = IdentifiedArray(uniqueElements: photoBooths)
                 let favoriteBoothCount = favoriteBooths.count
+                let viewEventEffect: Effect<Action> = shouldLogViewEvent
+                    ? .run { _ in analytics.logEvent(event: MapAnalyticsEvent.favoriteBoothView(favoriteBoothCount: favoriteBoothCount)) }
+                    : .none
                 return .merge(
                     .send(.photoBoothListAction(.setFavoriteBooths(favoriteBooths))),
                     .send(.photoBoothListAction(.setFavoriteBoothCount(favoriteBoothCount))),
                     .send(.startBackgroundCalculation),
-                    .run { _ in analytics.logEvent(event: MapAnalyticsEvent.favoriteBoothView(favoriteBoothCount: favoriteBoothCount)) }
+                    viewEventEffect
                 )
                 
-            case let .favoritePhotoBoothsResponse(.failure(error)):
+            case let .favoritePhotoBoothsResponse(.failure(error), _):
                 Logger.presentation.error("Favorite PhotoBooths fetch error: \(error)")
+                return .none
+
+            case .refreshVisibleMapPhotoBooths:
+                let mapBooths = state.photoBooths
+                let favoriteBooths = state.photoBoothListState.favoriteBooths
+                let activeFilters = state.photoBoothListState.filteredBrands
+                let currentBounds = state.currentBounds
+                let isFavoriteMarkerFilterEnabled = state.isFavoriteMarkerFilterEnabled
+                return .run { send in
+                    let visibleMapBooths = Self.visibleMapPhotoBooths(
+                        mapBooths: mapBooths,
+                        favoriteBooths: favoriteBooths,
+                        activeFilters: activeFilters,
+                        currentBounds: currentBounds,
+                        isFavoriteMarkerFilterEnabled: isFavoriteMarkerFilterEnabled
+                    )
+                    await send(.didUpdateVisibleMapPhotoBooths(visibleMapBooths))
+                }
+                .cancellable(id: CancelID.mapMarkerViewportCalculation, cancelInFlight: true)
+
+            case let .didUpdateVisibleMapPhotoBooths(photoBooths):
+                state.visiblePhotoBooths = photoBooths
                 return .none
 
             case .startBackgroundCalculation:
@@ -459,14 +512,18 @@ public struct MapFeature {
                 let favoriteBooths = state.photoBoothListState.favoriteBooths
                 let activeFilters = state.photoBoothListState.filteredBrands
                 let isFavoriteMarkerFilterEnabled = state.isFavoriteMarkerFilterEnabled
+                let currentBounds = state.currentBounds
                 return .run { send in
                     let visibleMapBooths: IdentifiedArrayOf<PhotoBooth>
                     let visibleListBooths: IdentifiedArrayOf<PhotoBooth>
                     let visibleFavoriteBooths: IdentifiedArrayOf<PhotoBooth>
-                    visibleMapBooths = mapBooths.filter {
-                        (activeFilters.isEmpty || activeFilters.contains($0.brand)) &&
-                        (isFavoriteMarkerFilterEnabled == false || $0.isFavorite)
-                    }
+                    visibleMapBooths = Self.visibleMapPhotoBooths(
+                        mapBooths: mapBooths,
+                        favoriteBooths: favoriteBooths,
+                        activeFilters: activeFilters,
+                        currentBounds: currentBounds,
+                        isFavoriteMarkerFilterEnabled: isFavoriteMarkerFilterEnabled
+                    )
                     visibleListBooths = activeFilters.isEmpty ? listBooths : listBooths.filter { activeFilters.contains($0.brand) }
                     visibleFavoriteBooths = activeFilters.isEmpty ? favoriteBooths : favoriteBooths.filter { activeFilters.contains($0.brand) }
                     await send(.didFinishBackgroundCalculation(map: visibleMapBooths, list: visibleListBooths, favoriteList: visibleFavoriteBooths))
@@ -537,7 +594,7 @@ public struct MapFeature {
                 case .favorite:
                     state.photoBoothListState.filteredBrands.removeAll()
                     return .merge(
-                        .send(.fetchFavoritePhotoBooths),
+                        .send(.fetchFavoritePhotoBooths(shouldLogViewEvent: true)),
                         .send(.startBackgroundCalculation)
                     )
                 }
@@ -571,6 +628,35 @@ public struct MapFeature {
 // MARK: - MapFeature + Effect Handlers
 
 private extension MapFeature {
+    static func visibleMapPhotoBooths(
+        mapBooths: IdentifiedArrayOf<PhotoBooth>,
+        favoriteBooths: IdentifiedArrayOf<PhotoBooth>,
+        activeFilters: Set<PhotoBoothBrand>,
+        currentBounds: GeographicBoundingBox?,
+        isFavoriteMarkerFilterEnabled: Bool
+    ) -> IdentifiedArrayOf<PhotoBooth> {
+        var visibleBooths = IdentifiedArrayOf<PhotoBooth>()
+
+        if isFavoriteMarkerFilterEnabled == false {
+            for photoBooth in mapBooths {
+                guard activeFilters.isEmpty || activeFilters.contains(photoBooth.brand) else { continue }
+                visibleBooths.append(photoBooth)
+            }
+        }
+
+        guard let currentBounds else { return visibleBooths }
+
+        for photoBooth in favoriteBooths {
+            guard photoBooth.isFavorite else { continue }
+            guard currentBounds.contains(photoBooth.coordinate) else { continue }
+            guard activeFilters.isEmpty || activeFilters.contains(photoBooth.brand) else { continue }
+            if visibleBooths[id: photoBooth.id] != nil { visibleBooths[id: photoBooth.id] = photoBooth }
+            else { visibleBooths.append(photoBooth) }
+        }
+
+        return visibleBooths
+    }
+
     func resetToMapMode(_ state: inout State, for stage: SheetStage) {
         state.selectedBooth = nil
         state.detent = stage.detent

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/Feature/MapFeature.swift
@@ -668,13 +668,14 @@ private extension MapFeature {
     }
 
     func localPhotoBooth(id: PhotoBooth.ID, state: State) -> PhotoBooth? {
-        if let photoBooth = state.selectedBooth, photoBooth.id == id { return photoBooth }
-        if let photoBooth = state.photoBooths[id: id] { return photoBooth }
-        if let photoBooth = state.visiblePhotoBooths[id: id] { return photoBooth }
-        if let photoBooth = state.photoBoothListState.photoBooths[id: id] { return photoBooth }
-        if let photoBooth = state.photoBoothListState.visibleBooths[id: id] { return photoBooth }
-        if let photoBooth = state.photoBoothListState.favoriteBooths[id: id] { return photoBooth }
-        return state.photoBoothListState.visibleFavoriteBooths[id: id]
+        let selectedBooth = state.selectedBooth?.id == id ? state.selectedBooth : nil
+        return selectedBooth ??
+            state.photoBooths[id: id] ??
+            state.visiblePhotoBooths[id: id] ??
+            state.photoBoothListState.photoBooths[id: id] ??
+            state.photoBoothListState.visibleBooths[id: id] ??
+            state.photoBoothListState.favoriteBooths[id: id] ??
+            state.photoBoothListState.visibleFavoriteBooths[id: id]
     }
 
     static func visibleMapPhotoBooths(

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NaverMapView.swift
@@ -10,6 +10,7 @@ import ComposableArchitecture
 import NMapsMap
 import Kingfisher
 import os
+import QuartzCore
 
 fileprivate enum Constants {
     // Map Settings
@@ -34,6 +35,7 @@ fileprivate enum Constants {
     static let clusterCaptionTextSize: CGFloat = 14.0
     static let captionColorHex: UInt = 0x202227
     static let brandClusteringThreshold: Double = 15.0
+    static let favoriteMarkerViewportUpdateInterval: TimeInterval = 0.15
 }
 
 struct NaverMapRepresentable: UIViewRepresentable {
@@ -149,6 +151,7 @@ extension NaverMapRepresentable {
         var isMapLoaded: Bool = false
         
         let parent: NaverMapRepresentable
+        private var lastFavoriteMarkerViewportUpdateTime: TimeInterval = .zero
         
         private var markerImageTasks: [BoothID: Task<Void, Never>] = [:]
         private var overlayImageCache: NSCache<NSString, NMFOverlayImage> = {
@@ -502,6 +505,13 @@ extension NaverMapRepresentable.Coordinator: NMFMapViewCameraDelegate {
             parent.store.send(.didDetectMapInteraction)
         }
         parent.store.send(.cameraMotionStarted)
+    }
+
+    func mapView(_ mapView: NMFMapView, cameraIsChangingByReason reason: Int) {
+        let currentTime = CACurrentMediaTime()
+        guard currentTime - lastFavoriteMarkerViewportUpdateTime >= Constants.favoriteMarkerViewportUpdateInterval else { return }
+        lastFavoriteMarkerViewportUpdateTime = currentTime
+        parent.store.send(.cameraMotionChanged(mapView.contentBounds.toDomain()))
     }
     
     func mapViewCameraIdle(_ mapView: NMFMapView) {

--- a/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NearPhotoBoothListSheet.swift
+++ b/Neki-iOS/Features/Map/Sources/Presentation/Sources/View/NearPhotoBoothListSheet.swift
@@ -162,26 +162,6 @@ private extension NearPhotoBoothListSheet {
                     }
                 }
             }
-        } header: {
-            HStack {
-                HStack(spacing: 2) {
-                    Text("가까운").foregroundStyle(.primary400) +
-                    Text(" ") +
-                    Text("포토") +
-                    Text(" ") +
-                    Text("부스")
-                    
-                    Image(.iconPinClip)
-                }
-                
-                Spacer()
-                
-                Image(.iconExclamationMarkGray)
-                    .onTapGesture { store.send(.toggleTooltip) }
-                    .nekiTooltip(isPresented: $store.isTooltipPresented, "가까운 네컷 사진 브랜드는\n1Km 기준으로 표시돼요.")
-            }
-            .nekiFont(.title18Bold)
-            .padding(.horizontal, 20)
         }
         .frame(maxHeight: .infinity)
     }


### PR DESCRIPTION
## 🌴 작업한 브랜치

`feat/#258-favorite-booth-rendering`

## ✅ 작업한 내용

- 지도 진입 시 저장한 포토부스 목록을 미리 조회하도록 변경했습니다.
- 저장한 포토부스 탭 진입 여부와 무관하게 즐겨찾기 포토부스 데이터가 지도 표시 후보 계산에 사용되도록 했습니다.
- 지역 재검색 결과와 즐겨찾기 포토부스 목록을 분리해 관리하고, 지도 표시 후보 계산 시 병합하도록 개선했습니다.
- 현재 지도 bounds 안에 포함된 즐겨찾기 포토부스만 마커 후보에 포함하여 네이버지도 SDK 렌더링 부담을 제한했습니다.
- 카메라 이동 중에도 즐겨찾기 마커 후보를 갱신하도록 개선했습니다.
- 카메라 이동 중 갱신은 150ms 단위로 제한하여 과도한 TCA 액션 전송과 마커 재계산을 방지했습니다.
- 이동 중에는 지도 마커 후보만 갱신하고, 리스트/시트 상태 재계산은 기존 전체 계산 흐름에 유지했습니다.
- 일반 검색 결과와 즐겨찾기 목록에 동일 포토부스가 함께 존재할 경우 ID 기준으로 중복 제거하고 즐겨찾기 상태가 반영된 데이터를 우선하도록 했습니다.
- 가까운 포토부스 탭에서 더 이상 디자인 가이드에 포함되지 않는 헤더 UI를 제거했습니다.
  - “가까운 포토 부스” 문구
  - 클립 아이콘
  - 툴팁 버튼

## ❗️PR Point

- 모든 즐겨찾기 포토부스를 SDK 마커로 상시 유지하지 않고, 현재 지도 영역에 포함된 즐겨찾기만 `visiblePhotoBooths`에 병합합니다.
- 기존 `NaverMapView`의 마커 추가/제거 및 클러스터링 구조는 유지했습니다.
- 지도 이동 중 즐겨찾기 마커 반영을 위해 카메라 이동 중 delegate를 사용했습니다.
- 네트워크 재검색은 이동 중에 수행하지 않으며, 캐시된 즐겨찾기 목록과 현재 bounds만 사용합니다.
- 카메라 이동 중 갱신은 150ms 단위로 제한했지만, 이 제한을 풀고 MapFeature에 항상 유지한다면 플리커링 현상 없이 부드럽게 마커가 나타납니다. 단, 이 경우에는 심한 성능저하가 발생할 수 있으므로 즐겨찾기할 수 있는 포토부스의 개수를 제한하는 것이 좋다고 판단됩니다.

## 📸 스크린샷

생략.

## 📟 관련 이슈

- Resolved: #258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 지도 카메라 이동 중 화면 범위(bounds) 변화를 즉시 반영해 보이는 포토부스가 더 빠르게 갱신됩니다.
* **Bug Fixes**
  * 즐겨찾기(즐겨찾기) 로딩이 최신 요청만 반영되도록 안정화했으며, 낙관적 UI와 실패 시 되돌림까지 개선했습니다.
  * 즐겨찾기 마커의 뷰포트 갱신은 이동 중 최소 주기로 제한해 부드러운 성능을 돕습니다.
  * 화면 표시 결과가 bounds 및 즐겨찾기 토글에 맞게 정확히 구성됩니다.
* **UI Changes**
  * 가까운 포토부스 목록의 헤더 안내 영역을 제거해 구성을 간소화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->