### PR TITLE
[Chore] deprecated 문법 정리 및 자잘한 수정

### DIFF
--- a/Neki-iOS.xcodeproj/project.pbxproj
+++ b/Neki-iOS.xcodeproj/project.pbxproj
@@ -430,7 +430,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.OneTen.Neki-dev.Share-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -469,7 +469,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.OneTen.Neki-iOS.Share-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Utilities/PushNotificationEventBroker.swift
+++ b/Neki-iOS/Core/Sources/Notification/Sources/Domain/Sources/Utilities/PushNotificationEventBroker.swift
@@ -17,7 +17,7 @@ public actor PushNotificationEventBroker {
         let id = UUID()
 
         return AsyncStream { continuation in
-            Task { await self.addContinuation(continuation, id: id) }
+            Task { self.addContinuation(continuation, id: id) }
 
             continuation.onTermination = { [weak self] _ in
                 Task { await self?.removeContinuation(id: id) }

--- a/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiToastModifier.swift
+++ b/Neki-iOS/Shared/DesignSystem/Sources/Modifier/NekiToastModifier.swift
@@ -19,7 +19,7 @@ struct NekiToastModifier: ViewModifier {
                     nekiToastView(currentItem)
                 }
             }
-            .onChange(of: item) { newItem in
+            .onChange(of: item) { _, newItem in
                 presentLatestToast(newItem)
             }
             .onAppear {


### PR DESCRIPTION
## 🌴 작업한 브랜치
`chore/#260-syntax-renew`



## ✅ 작업한 내용
deprecated된 문법(특히 onChange iOS 17.0 +)을 사용한 부분을 확인하고 노란색 경고메세지를 해소했습니다.
코드 리팩토링 과정에서 더이상 비동기 클로저가 아니게 됐음에도 불구하고 호출부에 `await` 키워드를 선언한 부분을 발견해 정정했습니다.
그 외 자잘한 수정을 담았습니다.


## ❗️PR Point
생략합니다.


## 📸 스크린샷
생략합니다.


## 📟 관련 이슈
- Resolved: #260


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 쉐어 확장 기능의 버전이 1.3.0으로 업데이트되었습니다.

* **Bug Fixes**
  * 토스트 표시가 변경될 때 최신 상태가 더 안정적으로 반영되도록 개선했습니다.
  * 푸시 알림 이벤트 처리의 비동기 동작을 정리해 더 일관되게 동작하도록 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->